### PR TITLE
fix(helia): detach peer:update listener when the provider stream throws

### DIFF
--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -378,16 +378,23 @@ export async function connectToPubsubPeers({
             };
             throw e;
         }
+    } finally {
+        // Provider stream ended (all router records merged, or the stream was aborted): sweep any
+        // retryable peers not already re-dialed via peer:update, and detach the listener. The
+        // retries run in the background like the initial dials — a successful retry fires
+        // peer:connected/subscription-change, which resolves the subscriber wait below without
+        // delaying it — and crucially they do NOT wait for the initial dials to settle (issue #215):
+        // most peer:update-triggered retries have already fired mid-stream, seconds before a slow
+        // relay-circuit dial would have released the old batch pass.
+        //
+        // This has to run in a finally: the catch above rethrows, and on that path the
+        // "peer:update" listener registered by createAddrMergeRetryScheduler was never detached.
+        // Every leaked onPeerUpdate closure retains runRetry's scope — including the logger it
+        // captured — for the lifetime of the page. onProviderStreamEnded is idempotent (it
+        // guards on listenerRemoved), so running it on every path is safe.
+        retryScheduler.onProviderStreamEnded();
     }
 
-    // Provider stream ended (all router records merged, or the stream was aborted): sweep any
-    // retryable peers not already re-dialed via peer:update, and detach the listener. The
-    // retries run in the background like the initial dials — a successful retry fires
-    // peer:connected/subscription-change, which resolves the subscriber wait below without
-    // delaying it — and crucially they do NOT wait for the initial dials to settle (issue #215):
-    // most peer:update-triggered retries have already fired mid-stream, seconds before a slow
-    // relay-circuit dial would have released the old batch pass.
-    retryScheduler.onProviderStreamEnded();
     inflightDialPromises.push(...retryScheduler.retryTasks);
 
     // Wait for the gossipsub subscription-change event — this is the signal that bitswap can


### PR DESCRIPTION
The `catch` in `connectToPubsubPeers` rethrows past `retryScheduler.onProviderStreamEnded()`, so on the throw path the `peer:update` listener registered by `createAddrMergeRetryScheduler` is never detached. Moving the call into a `finally` fixes it.

### Why it matters

Each leaked `onPeerUpdate` closure retains `runRetry`s enclosing scope — the peer records and the `Logger` for that call — for the lifetime of the page. This was found while tracking down unbounded memory growth in a browser tab left open on a site built on pkc-js. Firefox GC-heap analysis attributed **10,369 retained `pkc-logger` `Logger` objects** (62,211 `debug` function objects — 6 `debug` instances per `Logger`, 3 function objects each) to exactly this retaining path:

```
*ROOT: mCallback* Function addEventListener/<   [main-event/dist/src/index.js:91]
  --UNKNOWN SLOT 1--> LexicalEnvironment --enclosing_environment--> Call
  --listener--> Function onPeerUpdate           [pkc-js/src/helia/util.ts]
  --UNKNOWN SLOT 1--> LexicalEnvironment --enclosing_environment--> Call
  --runRetry--> Function runRetry               [pkc-js/src/helia/util.ts]
  ... --log--> Function log                     [pkc-logger/dist/src/index.js:20]
```

### Notes

- `onProviderStreamEnded()` is idempotent (it guards on `listenerRemoved`), so running it on every path is safe.
- The second scheduler further down the file already reaches its teardown on both paths and is unchanged.
- On the throw path this now also sweeps pending retryable peers before detaching. Those retries are fire-and-forget and record their own errors, and they are still aborted by `options.signal` on `helia.stop()`, so nothing outlives the node.
- Typechecked with `tsc --project config/tsconfig.json`. No test added: reproducing it needs a router that makes `findProviders` throw for a reason other than our own abort, which the existing warmup suite does not set up.

### Context

This is one of three listener-teardown bugs behind the same leak. The other two are upstream — `main-event` (`removeEventListener` never detaches, which silently no-ops every cleanup call in the libp2p/helia tree) and `@helia/utils` `abstract-session` (per-request `Queue` listeners never removed). This fix is correct regardless of those, and worth having on its own: cleanup should not depend on a library bug to be harmless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when connecting to pubsub peers by ensuring retry handling and cleanup occur even if provider discovery encounters an error.
  * Prevented stale event listeners or incomplete retry processing after failed connection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->