### PR TITLE
fix(kubo): run repo GC hourly per daemon instead of on a StorageMax watermark

### DIFF
--- a/src/runtime/node/community/local-community/cleanup.ts
+++ b/src/runtime/node/community/local-community/cleanup.ts
@@ -123,14 +123,19 @@ export async function repinCommentUpdateIfNeeded(community: LocalCommunity) {
     community._dbHandler.forceUpdateOnAllComments(); // pkc-js will recalculate and publish all comment updates
 }
 
-// GC once the repo is within this fraction of Datastore.StorageMax. Kubo's own --enable-gc makes the
-// same decision from Datastore.StorageGCWatermark (default 90), so we mirror it instead of inventing
-// a second policy — a node that later switches to the daemon flag behaves identically.
-const GC_HIGH_WATERMARK = 0.9;
-
-// Floor between two GC runs on one daemon. Once a repo is above the watermark it tends to STAY above
-// it (GC only reclaims unpinned blocks), so without a floor every sync of every community would
-// trigger a fresh GC.
+// Floor between two GC runs on one daemon, and the whole of the GC policy: once an hour we sweep,
+// unconditionally.
+//
+// repo.gc over the RPC is not conditional. Kubo consults Datastore.StorageGCWatermark only from the
+// daemon's own `--enable-gc` loop; /api/v0/repo/gc always runs a full sweep. pkc-js never spawns the
+// daemon (the operator hands us a kubo RPC URL that may not even be local), so we cannot delegate to
+// that loop and the schedule has to live here.
+//
+// The floor is what makes it a schedule. This runs at the end of every community sync on a default
+// 20s publishInterval, and the in-flight promise below only merges callers that actually overlap —
+// the moment a run settles the next sync tick is free to start another. Without the floor a node
+// hosting dozens of communities GCs back to back forever, and since kubo 0.43.0 GC and in-flight MFS
+// writes hold each other off, so that steady state would stall every postUpdates write on the node.
 const MIN_MS_BETWEEN_GC = 60 * 60 * 1000;
 
 // repo.gc and repo.stat are whole-daemon operations, but cleanUpIpfsRepoIfDue runs once per community
@@ -162,6 +167,28 @@ export async function cleanUpIpfsRepoIfDue(community: LocalCommunity, force = fa
     return gcRun;
 }
 
+type KuboRpcClient = ReturnType<LocalCommunity["_clientsManager"]["getDefaultKuboRpcClient"]>;
+
+// size-only: a default repo/stat also counts every object, which walks the whole flatfs blockstore —
+// on the repos this feature exists for that is millions of files. Nothing branches on the result, it
+// only feeds the log line, so a failing daemon costs us the number and not the GC.
+async function _readRepoSizeSafely({
+    kuboRpc,
+    kuboUrl,
+    log
+}: {
+    kuboRpc: KuboRpcClient;
+    kuboUrl: string;
+    log: Logger;
+}): Promise<bigint | undefined> {
+    try {
+        return (await kuboRpc._client.repo.stat({ searchParams: new URLSearchParams({ "size-only": "true" }) })).repoSize;
+    } catch (e) {
+        log.trace("Failed to read repo size from the kubo node", kuboUrl, e);
+        return undefined;
+    }
+}
+
 async function _runRepoGcIfDue({
     community,
     kuboUrl,
@@ -175,46 +202,13 @@ async function _runRepoGcIfDue({
 }): Promise<void> {
     const kuboRpc = community._clientsManager.getDefaultKuboRpcClient();
 
-    let repoSizeBefore: bigint | undefined;
-
     if (!force) {
         const lastGcFinishedAt = lastGcFinishedAtByKuboUrl.get(kuboUrl);
         if (typeof lastGcFinishedAt === "number" && Date.now() - lastGcFinishedAt < MIN_MS_BETWEEN_GC) return;
-
-        let repoStat: Awaited<ReturnType<typeof kuboRpc._client.repo.stat>>;
-        try {
-            // size-only: the default repo/stat also counts every object, which walks the whole
-            // flatfs blockstore — on the repos this feature exists for that is millions of files.
-            repoStat = await kuboRpc._client.repo.stat({ searchParams: new URLSearchParams({ "size-only": "true" }) });
-        } catch (e) {
-            log.error("Skipping repo.gc: failed to read repo.stat from the kubo node", kuboUrl, e);
-            return;
-        }
-
-        repoSizeBefore = repoStat.repoSize;
-
-        // storageMax comes from Datastore.StorageMax. If the daemon reports no ceiling there is
-        // nothing to compare against, so fall back to GCing on the interval alone rather than
-        // never GCing at all.
-        if (repoStat.storageMax > 0n) {
-            const gcThreshold = (repoStat.storageMax * BigInt(Math.round(GC_HIGH_WATERMARK * 100))) / 100n;
-            if (repoStat.repoSize < gcThreshold) {
-                log.trace(
-                    "Skipping repo.gc on",
-                    kuboUrl,
-                    "- repo size",
-                    repoStat.repoSize,
-                    "is below the",
-                    `${GC_HIGH_WATERMARK * 100}%`,
-                    "watermark",
-                    gcThreshold,
-                    "of StorageMax",
-                    repoStat.storageMax
-                );
-                return;
-            }
-        }
     }
+
+    // Read purely for the before/after line at the end, so a failure here must not skip the sweep.
+    const repoSizeBefore = await _readRepoSizeSafely({ kuboRpc, kuboUrl, log });
 
     let gcCids = 0;
     try {
@@ -233,12 +227,7 @@ async function _runRepoGcIfDue({
 
     // How much a GC actually reclaims is the open question on pkc-js#225: the affected node had
     // >11k recursive pins, and GC never touches pinned data. Log it rather than assume.
-    let repoSizeAfter: bigint | undefined;
-    try {
-        repoSizeAfter = (await kuboRpc._client.repo.stat({ searchParams: new URLSearchParams({ "size-only": "true" }) })).repoSize;
-    } catch (e) {
-        log.trace("repo.gc finished but the follow-up repo.stat failed", e);
-    }
+    const repoSizeAfter = await _readRepoSizeSafely({ kuboRpc, kuboUrl, log });
 
     log(
         "GC cleaned",

--- a/src/runtime/node/community/local-community/cleanup.ts
+++ b/src/runtime/node/community/local-community/cleanup.ts
@@ -189,6 +189,28 @@ async function _readRepoSizeSafely({
     }
 }
 
+// Bytes arrive as bigint. Repo sizes are nowhere near Number.MAX_SAFE_INTEGER (9PB), so converting
+// once for the human-readable scaling is exact in every case we can actually hit.
+function _formatBytes(bytes: bigint): string {
+    const asNumber = Number(bytes);
+    const units = ["B", "KB", "MB", "GB", "TB"];
+    const magnitude = Math.abs(asNumber);
+    const unitIndex = magnitude < 1 ? 0 : Math.min(Math.floor(Math.log(magnitude) / Math.log(1024)), units.length - 1);
+    const scaled = asNumber / 1024 ** unitIndex;
+    return unitIndex === 0 ? `${asNumber}B` : `${scaled.toFixed(2)}${units[unitIndex]}`;
+}
+
+// Exported for tests. The repo can legitimately end a sweep BIGGER than it started: GC and the
+// community syncs writing new blocks run against the same daemon, and nothing pauses publishing for
+// the duration. Report that case as what it is instead of logging a negative reclaim.
+export function _describeReclaimedSpace({ before, after }: { before: bigint | undefined; after: bigint | undefined }): string {
+    if (typeof before !== "bigint" || typeof after !== "bigint") return "reclaimed an unknown amount, repo.stat was unavailable";
+
+    const sizes = `(${_formatBytes(before)} -> ${_formatBytes(after)})`;
+    if (after > before) return `reclaimed no space, the repo grew ${_formatBytes(after - before)} during the sweep ${sizes}`;
+    return `reclaimed ${_formatBytes(before - after)} ${sizes}`;
+}
+
 async function _runRepoGcIfDue({
     community,
     kuboUrl,
@@ -234,10 +256,8 @@ async function _runRepoGcIfDue({
         gcCids,
         "cids out of the IPFS node",
         kuboUrl,
-        "- repo size",
-        repoSizeBefore ?? "unknown",
-        "->",
-        repoSizeAfter ?? "unknown"
+        "and",
+        _describeReclaimedSpace({ before: repoSizeBefore, after: repoSizeAfter })
     );
 }
 

--- a/test/node/community/local-community/cleanup.test.ts
+++ b/test/node/community/local-community/cleanup.test.ts
@@ -195,17 +195,15 @@ describe("cleanup: repinCommentUpdateIfNeeded", () => {
 });
 
 describe("cleanup: cleanUpIpfsRepoIfDue", () => {
-    // Builds a fake community wired to one kubo URL. repoSize/storageMax drive the watermark check;
-    // repo.gc records its calls so a test can assert whether it ran.
+    // Builds a fake community wired to one kubo URL. repoSize only feeds the before/after log line —
+    // nothing branches on it — while repo.gc records its calls so a test can assert whether it ran.
     const makeCommunity = ({
         url = "http://localhost:15001/api/v0",
         repoSize = 1n,
-        storageMax = 100n,
         gcImpl
     }: {
         url?: string;
         repoSize?: bigint;
-        storageMax?: bigint;
         gcImpl?: () => AsyncGenerator<{ cid: string }>;
     } = {}) => {
         const stat = vi.fn(async (_options?: { searchParams?: URLSearchParams }) => ({
@@ -213,7 +211,7 @@ describe("cleanup: cleanUpIpfsRepoIfDue", () => {
             repoPath: "/repo",
             repoSize,
             version: "fs-repo@18",
-            storageMax
+            storageMax: 100n
         }));
         const gc = vi.fn(
             gcImpl ??
@@ -232,17 +230,11 @@ describe("cleanup: cleanUpIpfsRepoIfDue", () => {
 
     beforeEach(() => _resetRepoGcSchedulingState());
 
-    it("skips GC when the repo is below the StorageMax watermark", async () => {
-        const { community, stat, gc } = makeCommunity({ repoSize: 10n, storageMax: 100n });
-
-        await cleanUpIpfsRepoIfDue(community);
-
-        expect(stat).toHaveBeenCalledTimes(1);
-        expect(gc).not.toHaveBeenCalled();
-    });
-
-    it("runs GC once the repo reaches the watermark", async () => {
-        const { community, gc } = makeCommunity({ repoSize: 95n, storageMax: 100n });
+    // /api/v0/repo/gc has no watermark of its own — Datastore.StorageGCWatermark is only read by the
+    // daemon's `--enable-gc` loop, which pkc-js cannot turn on since it never spawns the daemon. The
+    // interval floor is therefore the entire policy, and repo size must not gate the sweep.
+    it("GCs on the interval alone, whatever the repo size", async () => {
+        const { community, gc } = makeCommunity({ repoSize: 1n });
 
         await cleanUpIpfsRepoIfDue(community);
 
@@ -252,27 +244,21 @@ describe("cleanup: cleanUpIpfsRepoIfDue", () => {
     it("asks the daemon for size-only stats, not a full object count", async () => {
         // A default repo/stat counts every object, which walks the whole flatfs blockstore — millions
         // of files on exactly the repos this feature exists for.
-        const { community, stat } = makeCommunity({ repoSize: 10n, storageMax: 100n });
+        const { community, stat } = makeCommunity();
 
         await cleanUpIpfsRepoIfDue(community);
 
-        const passedSearchParams = stat.mock.calls[0]?.[0]?.searchParams as URLSearchParams | undefined;
-        expect(passedSearchParams?.get("size-only")).to.equal("true");
+        for (const call of stat.mock.calls) {
+            const passedSearchParams = call?.[0]?.searchParams as URLSearchParams | undefined;
+            expect(passedSearchParams?.get("size-only")).to.equal("true");
+        }
     });
 
-    it("does not GC again within the interval floor, even while still over the watermark", async () => {
-        const { community, gc } = makeCommunity({ repoSize: 95n, storageMax: 100n });
+    it("does not GC again within the interval floor", async () => {
+        const { community, gc } = makeCommunity();
 
         await cleanUpIpfsRepoIfDue(community);
         await cleanUpIpfsRepoIfDue(community);
-        await cleanUpIpfsRepoIfDue(community);
-
-        expect(gc).toHaveBeenCalledTimes(1);
-    });
-
-    it("GCs on the interval alone when the daemon reports no StorageMax", async () => {
-        const { community, gc } = makeCommunity({ repoSize: 10n, storageMax: 0n });
-
         await cleanUpIpfsRepoIfDue(community);
 
         expect(gc).toHaveBeenCalledTimes(1);
@@ -284,8 +270,6 @@ describe("cleanup: cleanUpIpfsRepoIfDue", () => {
         let releaseGc: () => void = () => {};
         const gcStarted = new Promise<void>((resolve) => (releaseGc = resolve));
         const { community, gc } = makeCommunity({
-            repoSize: 95n,
-            storageMax: 100n,
             gcImpl: () =>
                 (async function* () {
                     await gcStarted;
@@ -301,8 +285,8 @@ describe("cleanup: cleanUpIpfsRepoIfDue", () => {
     });
 
     it("keys the interval floor per kubo url, so a second daemon still GCs", async () => {
-        const first = makeCommunity({ url: "http://localhost:15001/api/v0", repoSize: 95n, storageMax: 100n });
-        const second = makeCommunity({ url: "http://localhost:15004/api/v0", repoSize: 95n, storageMax: 100n });
+        const first = makeCommunity({ url: "http://localhost:15001/api/v0" });
+        const second = makeCommunity({ url: "http://localhost:15004/api/v0" });
 
         await cleanUpIpfsRepoIfDue(first.community);
         await cleanUpIpfsRepoIfDue(second.community);
@@ -311,24 +295,24 @@ describe("cleanup: cleanUpIpfsRepoIfDue", () => {
         expect(second.gc).toHaveBeenCalledTimes(1);
     });
 
-    it("force bypasses both the interval floor and the watermark", async () => {
-        const { community, stat, gc } = makeCommunity({ repoSize: 1n, storageMax: 100n });
+    it("force bypasses the interval floor", async () => {
+        const { community, gc } = makeCommunity();
 
         await cleanUpIpfsRepoIfDue(community, true);
         await cleanUpIpfsRepoIfDue(community, true);
 
         expect(gc).toHaveBeenCalledTimes(2);
-        // force skips the due-check entirely; the only stat calls are the post-GC size readings.
-        expect(stat).toHaveBeenCalledTimes(2);
     });
 
-    it("does not throw when repo.stat fails, and leaves GC unrun", async () => {
-        const { community, kuboRpcClient, gc } = makeCommunity({ repoSize: 95n, storageMax: 100n });
+    // repo.stat is only read to log how much the sweep reclaimed, so a daemon that cannot answer it
+    // must still get GCed. Gating on it would mean a node under memory pressure never reclaims.
+    it("still GCs when repo.stat fails, losing only the size readings", async () => {
+        const { community, kuboRpcClient, gc } = makeCommunity();
         kuboRpcClient._client.repo.stat = vi.fn().mockRejectedValue(new Error("fetch failed"));
 
         await cleanUpIpfsRepoIfDue(community);
 
-        expect(gc).not.toHaveBeenCalled();
+        expect(gc).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/test/node/community/local-community/cleanup.test.ts
+++ b/test/node/community/local-community/cleanup.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
+    _describeReclaimedSpace,
     _resetRepoGcSchedulingState,
     addAllCidsUnderPurgedCommentToBeRemoved,
     cleanUpIpfsRepoIfDue,
@@ -313,6 +314,42 @@ describe("cleanup: cleanUpIpfsRepoIfDue", () => {
         await cleanUpIpfsRepoIfDue(community);
 
         expect(gc).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("cleanup: _describeReclaimedSpace", () => {
+    // The cid count from repo.gc says how many blocks went; only these numbers say whether that
+    // mattered. On pkc-js#225 a repo that stays huge after a sweep is the signal that everything
+    // left is pinned, which no GC schedule can fix.
+    it("reports the reclaimed bytes and both sizes", () => {
+        const oneGb = 1024n ** 3n;
+        expect(_describeReclaimedSpace({ before: 12n * oneGb, after: 10n * oneGb })).to.equal("reclaimed 2.00GB (12.00GB -> 10.00GB)");
+    });
+
+    it("scales each unit and keeps raw bytes below 1KB", () => {
+        expect(_describeReclaimedSpace({ before: 900n, after: 400n })).to.equal("reclaimed 500B (900B -> 400B)");
+        expect(_describeReclaimedSpace({ before: 5n * 1024n * 1024n, after: 1n * 1024n * 1024n })).to.equal(
+            "reclaimed 4.00MB (5.00MB -> 1.00MB)"
+        );
+    });
+
+    it("reports a repo that grew during the sweep, rather than a negative reclaim", () => {
+        // GC and the community syncs writing new blocks share one daemon, and nothing pauses
+        // publishing for the length of a sweep, so after > before is a real outcome.
+        expect(_describeReclaimedSpace({ before: 10n * 1024n * 1024n, after: 12n * 1024n * 1024n })).to.equal(
+            "reclaimed no space, the repo grew 2.00MB during the sweep (10.00MB -> 12.00MB)"
+        );
+    });
+
+    it("says so when repo.stat gave us nothing, on either side", () => {
+        const unavailable = "reclaimed an unknown amount, repo.stat was unavailable";
+        expect(_describeReclaimedSpace({ before: undefined, after: 10n })).to.equal(unavailable);
+        expect(_describeReclaimedSpace({ before: 10n, after: undefined })).to.equal(unavailable);
+        expect(_describeReclaimedSpace({ before: undefined, after: undefined })).to.equal(unavailable);
+    });
+
+    it("does not treat a zero-byte reclaim as unknown", () => {
+        expect(_describeReclaimedSpace({ before: 0n, after: 0n })).to.equal("reclaimed 0B (0B -> 0B)");
     });
 });
 


### PR DESCRIPTION
Closes #258. Refs #225.

`cleanUpIpfsRepoIfDue` gated `repo.gc` on three things: a per-daemon in-flight mutex, a 1h interval floor, and a 90% `Datastore.StorageMax` watermark. This drops the watermark. The floor plus the mutex is the whole policy: **one full GC per hour per daemon, unconditionally.**

### Why the watermark goes

It was added in #252 to mirror `Datastore.StorageGCWatermark`, so a node that later switched to daemon-side GC would behave identically. It buys little:

- It only bites when `StorageMax` is meaningfully configured. The default 10GB is not a ceiling most operators have considered, and the #225 node reached ~190GB against exactly that default.
- `storageMax` of 0 already fell through to GCing on the interval alone, so the unconditional path is not a new mode. It is the one that now always applies.
- It made a failed `repo.stat` skip the sweep entirely, and a daemon that cannot answer `repo/stat` is the one that most needs reclaiming.

### Why the floor stays

`repo.gc` over the RPC is unconditional: kubo reads `StorageGCWatermark` only in the daemon's own `--enable-gc` loop, never in `/api/v0/repo/gc`. pkc-js never spawns the daemon, so there is nothing to delegate to and the schedule has to live client-side.

The mutex answers "how many at once", the floor answers "how often". They are not interchangeable. `cleanUpIpfsRepoIfDue` runs at the end of every community sync on a default 20s `publishInterval`, and the in-flight promise is cleared as soon as a run settles, so without the floor the next sync tick just starts another sweep. On a node hosting dozens of communities that converges to a ~100% GC duty cycle, and since kubo 0.43.0 GC and in-flight MFS writes hold each other off, that steady state would stall every `postUpdates` write on the node.

### Changes

**Scheduling** (`fix(kubo): run repo GC hourly per daemon...`)

- Remove `GC_HIGH_WATERMARK` and the `repo.stat`-driven skip.
- `MIN_MS_BETWEEN_GC` (1h, keyed by kubo RPC URL) and the per-URL in-flight mutex are unchanged.
- The `size-only=true` `repo.stat` reads move into `_readRepoSizeSafely` and now feed only the log line. A stat failure costs the number, not the sweep.
- `force` bypasses only the interval floor.

**Logging** (`feat(kubo): log bytes reclaimed by each repo GC...`)

Each run now logs both halves of what happened: how many cids went, and how much space that freed. The two are not interchangeable. `repo.gc` yields one entry per removed block so the count is exact, but block sizes here span a raw 256KB leaf down to a few hundred bytes of dag-pb link node, so a count cannot be converted into a size. The size is what #225 is actually about: a repo that stays huge after a sweep means everything left is pinned, which no GC schedule fixes.

`_describeReclaimedSpace` covers the case worth being careful about. GC and the community syncs writing new blocks share one daemon and nothing pauses publishing for the length of a sweep, so a repo can legitimately end bigger than it started. That reports as `reclaimed no space, the repo grew 2.00MB during the sweep (10.00MB -> 12.00MB)` rather than as a negative reclaim.

### Tests

`test/node/community/local-community/cleanup.test.ts`, 22 passing:

- Replaces the two watermark cases with "GCs on the interval alone, whatever the repo size", checked red against the previous watermark branch (rebuilt `dist/`, since the suite imports from there) before being kept green.
- Drops the now-redundant "GCs on the interval alone when the daemon reports no StorageMax".
- Flips "does not throw when repo.stat fails, and leaves GC unrun" to "still GCs when repo.stat fails, losing only the size readings".
- The size-only assertion now covers every `repo.stat` call rather than just the first.
- New `_describeReclaimedSpace` block: unit scaling, the repo-grew case, either-side-unavailable, and a zero-byte reclaim that must not read as unknown.

`npm run build`, `npx tsc --project test/tsconfig.json --noEmit`, and `garbage.collection.community.test.ts` all pass.

### Caveat on the numbers

kubo's flatfs tracks disk usage incrementally and can mark it approximate on large repos, so treat the logged sizes as directional rather than exact accounting. They are still enough to answer the pinned-vs-unpinned question, which is the reason for logging them.