### PR TITLE
test(modqueue): run rejection blocks concurrently and raise the node-local CI timeout

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest, macos-latest]
-        timeout-minutes: 35
+        timeout-minutes: 40
         steps:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v4
@@ -60,9 +60,11 @@ jobs:
               run: node test/run-test-config.js --environment node --per-test-logs ${{ runner.temp }}/per-test-logs test/challenges
             - name: Run node tests (local config)
               id: run_node_tests_local
-              # Step timeout below the 35-min job cap: on a Kubo MFS hang this fails the STEP (not the job)
+              # Step timeout below the 40-min job cap: on a Kubo MFS hang this fails the STEP (not the job)
               # while the backgrounded Kubo daemons are still alive, so the goroutine-dump step below can reach them.
-              timeout-minutes: 28
+              # windows-latest runs the suite in ~28 min, so the cap needs real headroom above that; the
+              # remaining ~7 min of job budget covers setup, the goroutine dump and the artifact uploads.
+              timeout-minutes: 33
               run: DEBUG="pkc*" PKC_CONFIGS=local-kubo-rpc node test/run-test-config.js --parallel --environment node --log-prefix test_node_local --per-test-logs "${{ runner.temp }}/per-test-logs" test/node src/rpc/test/node src/rpc/test/node-and-browser
               shell: bash
             # Capture Kubo daemon goroutine dumps FIRST on failure/cancel, while the daemon is still alive.

--- a/test/node/community/modqueue/rejection.modqueue.community.test.ts
+++ b/test/node/community/modqueue/rejection.modqueue.community.test.ts
@@ -57,227 +57,384 @@ for (const commentMod of commentModProps) {
         // but if a reply is rejected, then it will be included in pages only if shouldCommentBePurged = false
         const shouldCommentBeInPostsOrRepliesPages = pendingCommentDepth === 0 ? false : !shouldCommentBePurged; // if it's a reply then it will be nested within another commment and will appear in community.post
 
-        describe.sequential(
+        const blockTitle =
             `Comment moderation rejection of pending comment with depth ` +
-                pendingCommentDepth +
-                " and commentModeration=" +
-                JSON.stringify(commentMod),
-            () => {
-                let pkc: PKCType;
-                let commentToBeRejected: Comment;
-                let modSigner: SignerType;
-                let community: LocalCommunity | RpcLocalCommunity;
+            pendingCommentDepth +
+            " and commentModeration=" +
+            JSON.stringify(commentMod);
 
-                beforeAll(async () => {
-                    pkc = await mockPKC();
-                    community = (await pkc.createCommunity()) as LocalCommunity | RpcLocalCommunity;
-                    community.setMaxListeners(100);
-                    modSigner = await pkc.createSigner();
-                    await community.edit({
-                        roles: {
-                            [modSigner.address]: { role: "moderator" }
-                        },
-                        settings: { challenges: [createPendingApprovalChallenge()] }
-                    });
+        const blockBody = () => {
+            let pkc: PKCType;
+            let commentToBeRejected: Comment;
+            let modSigner: SignerType;
+            let community: LocalCommunity | RpcLocalCommunity;
 
-                    await community.start();
-                    await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => Boolean(community.updatedAt) });
-
-                    const pending = await publishToModQueueWithDepth({
-                        community,
-                        pkc: pkc, // needs to be remote or otherwise it will add comment to local node which will ruin our test
-                        depth: pendingCommentDepth,
-                        modCommentProps: { signer: modSigner, content: " 12" + Math.random() },
-                        commentProps: pendingApprovalCommentProps
-                    });
-                    commentToBeRejected = pending.comment;
-
-                    await resolveWhenConditionIsTrue({
-                        toUpdate: community,
-                        predicate: async () => Boolean(community.modQueue.pageCids.pendingApproval)
-                    }); // wait until we publish a new mod queue with this new comment
-                    await commentToBeRejected.update();
+            beforeAll(async () => {
+                pkc = await mockPKC();
+                community = (await pkc.createCommunity()) as LocalCommunity | RpcLocalCommunity;
+                community.setMaxListeners(100);
+                modSigner = await pkc.createSigner();
+                await community.edit({
+                    roles: {
+                        [modSigner.address]: { role: "moderator" }
+                    },
+                    settings: { challenges: [createPendingApprovalChallenge()] }
                 });
 
-                afterAll(async () => {
-                    await community.delete();
-                    await pkc.destroy();
+                await community.start();
+                await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => Boolean(community.updatedAt) });
+
+                const pending = await publishToModQueueWithDepth({
+                    community,
+                    pkc: pkc, // needs to be remote or otherwise it will add comment to local node which will ruin our test
+                    depth: pendingCommentDepth,
+                    modCommentProps: { signer: modSigner, content: " 12" + Math.random() },
+                    commentProps: pendingApprovalCommentProps
+                });
+                commentToBeRejected = pending.comment;
+
+                await resolveWhenConditionIsTrue({
+                    toUpdate: community,
+                    predicate: async () => Boolean(community.modQueue.pageCids.pendingApproval)
+                }); // wait until we publish a new mod queue with this new comment
+                await commentToBeRejected.update();
+            });
+
+            afterAll(async () => {
+                await community.delete();
+                await pkc.destroy();
+            });
+
+            it.sequential(`Can reject comment with commentModeration=${JSON.stringify(commentMod)}`, async () => {
+                const commentModeration = await pkc.createCommentModeration({
+                    communityAddress: community.address,
+                    signer: modSigner,
+                    commentModeration: commentMod as unknown as Record<string, unknown>,
+                    commentCid: commentToBeRejected.cid!
                 });
 
-                it.sequential(`Can reject comment with commentModeration=${JSON.stringify(commentMod)}`, async () => {
-                    const commentModeration = await pkc.createCommentModeration({
-                        communityAddress: community.address,
-                        signer: modSigner,
-                        commentModeration: commentMod as unknown as Record<string, unknown>,
-                        commentCid: commentToBeRejected.cid!
-                    });
+                await publishWithExpectedResult({ publication: commentModeration, expectedChallengeSuccess: true });
+            });
 
-                    await publishWithExpectedResult({ publication: commentModeration, expectedChallengeSuccess: true });
+            it.sequential(`Rejecting a pending comment will purge it from modQueue`, async () => {
+                // The sync loop that clears modQueue.pageCids.pendingApproval may have snapshotted its
+                // comment-update batch before the rejection was stored, publishing a torn update where the
+                // rejected comment has no commentUpdates row yet: it still counts as lastCommentCid and is
+                // invisible to page generation until the next loop. The rejected comment is always the
+                // newest row, so as long as it lacks a commentUpdates row with approved=false (and isn't
+                // purged) it must equal lastCommentCid. Waiting for lastCommentCid to move off it therefore
+                // guarantees the rejection reached the comment's CommentUpdate before the tests below assert.
+                await resolveWhenConditionIsTrue({
+                    toUpdate: community,
+                    predicate: async () =>
+                        !community.modQueue.pageCids.pendingApproval && community.lastCommentCid !== commentToBeRejected.cid
                 });
+                expect(community.modQueue.pageCids.pendingApproval).to.be.undefined;
+            });
 
-                it.sequential(`Rejecting a pending comment will purge it from modQueue`, async () => {
-                    // The sync loop that clears modQueue.pageCids.pendingApproval may have snapshotted its
-                    // comment-update batch before the rejection was stored, publishing a torn update where the
-                    // rejected comment has no commentUpdates row yet: it still counts as lastCommentCid and is
-                    // invisible to page generation until the next loop. The rejected comment is always the
-                    // newest row, so as long as it lacks a commentUpdates row with approved=false (and isn't
-                    // purged) it must equal lastCommentCid. Waiting for lastCommentCid to move off it therefore
-                    // guarantees the rejection reached the comment's CommentUpdate before the tests below assert.
-                    await resolveWhenConditionIsTrue({
-                        toUpdate: community,
-                        predicate: async () =>
-                            !community.modQueue.pageCids.pendingApproval && community.lastCommentCid !== commentToBeRejected.cid
-                    });
-                    expect(community.modQueue.pageCids.pendingApproval).to.be.undefined;
-                });
-
-                if (!shouldCommentBePurged)
-                    itSkipIfRpc(
-                        `Rejecting a pending comment with ${JSON.stringify(commentMod)} will not remove it from database of community because it has more than {approved: false}`,
-                        async () => {
-                            // @ts-expect-error - accessing private _dbHandler
-                            const queryRes = (community._dbHandler as LocalCommunity["_dbHandler"]).queryComment(commentToBeRejected.cid!);
-                            expect(queryRes).to.be.exist;
-                        }
-                    );
-                if (shouldCommentBePurged) {
-                    itSkipIfRpc(`Rejecting a pending comment with only ${JSON.stringify(commentMod)} will purge it out of DB`, async () => {
+            if (!shouldCommentBePurged)
+                itSkipIfRpc(
+                    `Rejecting a pending comment with ${JSON.stringify(commentMod)} will not remove it from database of community because it has more than {approved: false}`,
+                    async () => {
                         // @ts-expect-error - accessing private _dbHandler
                         const queryRes = (community._dbHandler as LocalCommunity["_dbHandler"]).queryComment(commentToBeRejected.cid!);
-                        expect(queryRes).to.be.not.exist;
-                    });
-                }
+                        expect(queryRes).to.be.exist;
+                    }
+                );
+            if (shouldCommentBePurged) {
+                itSkipIfRpc(`Rejecting a pending comment with only ${JSON.stringify(commentMod)} will purge it out of DB`, async () => {
+                    // @ts-expect-error - accessing private _dbHandler
+                    const queryRes = (community._dbHandler as LocalCommunity["_dbHandler"]).queryComment(commentToBeRejected.cid!);
+                    expect(queryRes).to.be.not.exist;
+                });
+            }
 
-                if (pendingCommentDepth > 0) {
-                    it(`Rejected reply does not show up in parentComment.replyCount`, async () => {
-                        expect((await getCommentWithCommentUpdateProps({ cid: commentToBeRejected.parentCid!, pkc })).replyCount).to.equal(
-                            0
-                        );
-                    });
-
-                    it(`Rejected reply does not show up in parentComment.childCount`, async () => {
-                        expect((await getCommentWithCommentUpdateProps({ cid: commentToBeRejected.parentCid!, pkc })).childCount).to.equal(
-                            0
-                        );
-                    });
-
-                    it(`Rejected reply does not show up in parentComment.lastChildCid`, async () => {
-                        expect((await getCommentWithCommentUpdateProps({ cid: commentToBeRejected.parentCid!, pkc })).lastChildCid).to.be
-                            .undefined;
-                    });
-                    it(`Rejected reply does not show up in parentComment.lastReplyTimestamp`, async () => {
-                        expect((await getCommentWithCommentUpdateProps({ cid: commentToBeRejected.parentCid!, pkc })).lastReplyTimestamp).to
-                            .be.undefined;
-                    });
-                }
-
-                if (pendingCommentDepth === 0)
-                    it(`Rejected post does not show up in community.lastPostCid`, async () => {
-                        expect(community.lastPostCid).to.not.equal(commentToBeRejected.cid);
-                    });
-
-                it(`Rejected comment does not show up in community.lastCommentCid`, async () => {
-                    expect(community.lastCommentCid).to.not.equal(commentToBeRejected.cid);
+            if (pendingCommentDepth > 0) {
+                it(`Rejected reply does not show up in parentComment.replyCount`, async () => {
+                    expect((await getCommentWithCommentUpdateProps({ cid: commentToBeRejected.parentCid!, pkc })).replyCount).to.equal(0);
                 });
 
-                itSkipIfRpc(
-                    `A rejected comment with only ${JSON.stringify(commentMod)} will ${shouldCommentBeInPostsOrRepliesPages ? "" : "never"} show up in community.posts`,
-                    async () => {
-                        const preloadedSortName = "hot";
-                        const { generated, capturedChunks } = await capturePostsGeneration(
-                            community as LocalCommunity,
-                            preloadedSortName,
-                            1024 * 1024
-                        );
+                it(`Rejected reply does not show up in parentComment.childCount`, async () => {
+                    expect((await getCommentWithCommentUpdateProps({ cid: commentToBeRejected.parentCid!, pkc })).childCount).to.equal(0);
+                });
 
-                        const foundInGeneratedPages = cidExistsInChunks(capturedChunks, commentToBeRejected.cid!);
-                        if (shouldCommentBeInPostsOrRepliesPages) {
-                            expect(generated, "expected posts generation when rejected comment should be visible").to.exist;
-                            expect(foundInGeneratedPages, "rejected comment should be present in generated posts").to.be.true;
-                        } else {
-                            expect(foundInGeneratedPages, "rejected comment should be excluded from generated posts").to.be.false;
+                it(`Rejected reply does not show up in parentComment.lastChildCid`, async () => {
+                    expect((await getCommentWithCommentUpdateProps({ cid: commentToBeRejected.parentCid!, pkc })).lastChildCid).to.be
+                        .undefined;
+                });
+                it(`Rejected reply does not show up in parentComment.lastReplyTimestamp`, async () => {
+                    expect((await getCommentWithCommentUpdateProps({ cid: commentToBeRejected.parentCid!, pkc })).lastReplyTimestamp).to.be
+                        .undefined;
+                });
+            }
+
+            if (pendingCommentDepth === 0)
+                it(`Rejected post does not show up in community.lastPostCid`, async () => {
+                    expect(community.lastPostCid).to.not.equal(commentToBeRejected.cid);
+                });
+
+            it(`Rejected comment does not show up in community.lastCommentCid`, async () => {
+                expect(community.lastCommentCid).to.not.equal(commentToBeRejected.cid);
+            });
+
+            itSkipIfRpc(
+                `A rejected comment with only ${JSON.stringify(commentMod)} will ${shouldCommentBeInPostsOrRepliesPages ? "" : "never"} show up in community.posts`,
+                async () => {
+                    const preloadedSortName = "hot";
+                    const { generated, capturedChunks } = await capturePostsGeneration(
+                        community as LocalCommunity,
+                        preloadedSortName,
+                        1024 * 1024
+                    );
+
+                    const foundInGeneratedPages = cidExistsInChunks(capturedChunks, commentToBeRejected.cid!);
+                    if (shouldCommentBeInPostsOrRepliesPages) {
+                        expect(generated, "expected posts generation when rejected comment should be visible").to.exist;
+                        expect(foundInGeneratedPages, "rejected comment should be present in generated posts").to.be.true;
+                    } else {
+                        expect(foundInGeneratedPages, "rejected comment should be excluded from generated posts").to.be.false;
+                    }
+                }
+            );
+
+            if (pendingCommentDepth > 0)
+                itSkipIfRpc(`A rejected reply will ${shouldCommentBePurged ? "not" : ""} show up in parentComment.replies`, async () => {
+                    const expectedResult = !shouldCommentBePurged;
+                    const parentRow = (community as LocalCommunity)._dbHandler.queryComment(commentToBeRejected.parentCid!);
+                    expect(parentRow).to.exist;
+
+                    const { generated, capturedChunks } = await captureRepliesGeneration({
+                        community: community as LocalCommunity,
+                        parentCid: parentRow!.cid,
+                        parentDepth: parentRow!.depth,
+                        preloadedSortName: "best",
+                        preloadedPageSizeBytes: 1024 * 1024
+                    });
+
+                    const foundInReplies = cidExistsInChunks(capturedChunks, commentToBeRejected.cid!);
+                    expect(foundInReplies).to.equal(expectedResult);
+                    if (expectedResult) expect(generated, "expected replies generation to contain the rejected comment").to.exist;
+                });
+            if (pendingCommentDepth > 0)
+                itSkipIfRpc(`A rejected reply will ${shouldCommentBePurged ? "not" : ""} show up in flat pages of post`, async () => {
+                    const shouldCommentBeInFlatPages = !shouldCommentBePurged;
+                    // @ts-expect-error - accessing private _dbHandler
+                    const postRow = (community._dbHandler as LocalCommunity["_dbHandler"]).queryComment(commentToBeRejected.postCid!);
+                    expect(postRow).to.exist;
+
+                    for (const sortName of ["newFlat", "oldFlat"]) {
+                        const { generated, capturedChunks } = await captureRepliesGeneration({
+                            community: community as LocalCommunity,
+                            parentCid: postRow!.cid,
+                            parentDepth: postRow!.depth,
+                            preloadedSortName: sortName,
+                            preloadedPageSizeBytes: 1024 * 1024
+                        });
+
+                        const foundInFlatPages = cidExistsInChunks(capturedChunks, commentToBeRejected.cid!);
+                        expect(foundInFlatPages).to.equal(shouldCommentBeInFlatPages);
+                        if (shouldCommentBeInFlatPages)
+                            expect(generated, "expected flat pages generation to include the rejected comment").to.exist;
+                    }
+                });
+
+            it(`comments with approved: false should not be in pageCids.pendingApproval`, async () => {
+                expect(community.modQueue.pageCids.pendingApproval).to.be.undefined;
+            });
+            if (pendingCommentDepth === 0)
+                itSkipIfRpc(
+                    `Rejecting a pending post with ${JSON.stringify(commentMod)} will ${shouldCommentBePurged ? "not" : ""} keep it in community.postUpdates`,
+                    async () => {
+                        const localMfsPath = `/${community.address}/postUpdates/86400/${commentToBeRejected.cid}/update`;
+                        const kuboRpc = Object.values(pkc.clients.kuboRpcClients)[0]._client;
+
+                        try {
+                            const res = await kuboRpc.files.stat(localMfsPath); // this call needs to pass because file should exist
+
+                            if (!shouldCommentBePurged) expect(res.size).to.be.greaterThan(0);
+                            else expect.fail("call should not succeed");
+                        } catch (e) {
+                            if (shouldCommentBePurged) expect((e as Error).message).to.equal("file does not exist");
+                            else expect.fail("should not fail");
                         }
                     }
                 );
 
-                if (pendingCommentDepth > 0)
-                    itSkipIfRpc(
-                        `A rejected reply will ${shouldCommentBePurged ? "not" : ""} show up in parentComment.replies`,
+            remotePKCConfigs.forEach((remotePKCConfig) => {
+                const itSequentialIfRpc =
+                    remotePKCConfig.testConfigCode === "remote-pkc-rpc" ||
+                    remotePKCConfig.testConfigCode === "local-kubo-rpc" ||
+                    remotePKCConfig.testConfigCode === "remote-kubo-rpc"
+                        ? it.sequential
+                        : it;
+
+                if (shouldCommentBePurged) {
+                    itSequentialIfRpc(
+                        `Should not be able to update a rejected comment with ${JSON.stringify(commentMod)} and retrieve its CommentIpfs - PKC Config ${remotePKCConfig.name}`,
                         async () => {
-                            const expectedResult = !shouldCommentBePurged;
-                            const parentRow = (community as LocalCommunity)._dbHandler.queryComment(commentToBeRejected.parentCid!);
-                            expect(parentRow).to.exist;
-
-                            const { generated, capturedChunks } = await captureRepliesGeneration({
-                                community: community as LocalCommunity,
-                                parentCid: parentRow!.cid,
-                                parentDepth: parentRow!.depth,
-                                preloadedSortName: "best",
-                                preloadedPageSizeBytes: 1024 * 1024
-                            });
-
-                            const foundInReplies = cidExistsInChunks(capturedChunks, commentToBeRejected.cid!);
-                            expect(foundInReplies).to.equal(expectedResult);
-                            if (expectedResult) expect(generated, "expected replies generation to contain the rejected comment").to.exist;
-                        }
-                    );
-                if (pendingCommentDepth > 0)
-                    itSkipIfRpc(`A rejected reply will ${shouldCommentBePurged ? "not" : ""} show up in flat pages of post`, async () => {
-                        const shouldCommentBeInFlatPages = !shouldCommentBePurged;
-                        // @ts-expect-error - accessing private _dbHandler
-                        const postRow = (community._dbHandler as LocalCommunity["_dbHandler"]).queryComment(commentToBeRejected.postCid!);
-                        expect(postRow).to.exist;
-
-                        for (const sortName of ["newFlat", "oldFlat"]) {
-                            const { generated, capturedChunks } = await captureRepliesGeneration({
-                                community: community as LocalCommunity,
-                                parentCid: postRow!.cid,
-                                parentDepth: postRow!.depth,
-                                preloadedSortName: sortName,
-                                preloadedPageSizeBytes: 1024 * 1024
-                            });
-
-                            const foundInFlatPages = cidExistsInChunks(capturedChunks, commentToBeRejected.cid!);
-                            expect(foundInFlatPages).to.equal(shouldCommentBeInFlatPages);
-                            if (shouldCommentBeInFlatPages)
-                                expect(generated, "expected flat pages generation to include the rejected comment").to.exist;
-                        }
-                    });
-
-                it(`comments with approved: false should not be in pageCids.pendingApproval`, async () => {
-                    expect(community.modQueue.pageCids.pendingApproval).to.be.undefined;
-                });
-                if (pendingCommentDepth === 0)
-                    itSkipIfRpc(
-                        `Rejecting a pending post with ${JSON.stringify(commentMod)} will ${shouldCommentBePurged ? "not" : ""} keep it in community.postUpdates`,
-                        async () => {
-                            const localMfsPath = `/${community.address}/postUpdates/86400/${commentToBeRejected.cid}/update`;
-                            const kuboRpc = Object.values(pkc.clients.kuboRpcClients)[0]._client;
-
+                            const remotePKC = await remotePKCConfig.pkcInstancePromise();
+                            remotePKC._timeouts["comment-ipfs"] = 500; // speed up the test
                             try {
-                                const res = await kuboRpc.files.stat(localMfsPath); // this call needs to pass because file should exist
+                                const newComment = await remotePKC.createComment({
+                                    cid: commentToBeRejected.cid,
+                                    communityAddress: commentToBeRejected.communityAddress
+                                });
 
-                                if (!shouldCommentBePurged) expect(res.size).to.be.greaterThan(0);
-                                else expect.fail("call should not succeed");
-                            } catch (e) {
-                                if (shouldCommentBePurged) expect((e as Error).message).to.equal("file does not exist");
-                                else expect.fail("should not fail");
+                                const errors: Error[] = [];
+                                const failIfUpdated = () =>
+                                    newComment.raw.comment &&
+                                    expect.fail("Rejected comment unexpectedly emitted an update event with CommentIpfs");
+                                newComment.on("update", failIfUpdated);
+                                newComment.on("error", (err: Error) => errors.push(err));
+                                await newComment.update();
+
+                                await new Promise<void>((resolve) => {
+                                    let settled = false;
+                                    let timeoutId: NodeJS.Timeout;
+                                    const onError = () => {
+                                        if (settled) return;
+                                        settled = true;
+                                        clearTimeout(timeoutId);
+                                        newComment.removeListener("error", onError);
+                                        resolve();
+                                    };
+                                    timeoutId = setTimeout(() => {
+                                        if (settled) return;
+                                        settled = true;
+                                        newComment.removeListener("error", onError);
+                                        resolve();
+                                    }, 10_000);
+                                    newComment.on("error", onError);
+                                });
+
+                                newComment.removeListener("update", failIfUpdated);
+
+                                expect(newComment.raw.commentUpdate).to.be.undefined;
+                                expect(newComment.raw.comment).to.be.undefined;
+                                expect(newComment.signature).to.be.undefined;
+                                expect(newComment.updatedAt).to.be.undefined;
+                                errors.forEach((err) =>
+                                    expect((err as Error & { code: string }).code).to.be.oneOf([
+                                        "ERR_FETCH_CID_P2P_TIMEOUT",
+                                        "ERR_FAILED_TO_FETCH_COMMENT_IPFS_FROM_GATEWAYS"
+                                    ])
+                                );
+                                await newComment.stop();
+                            } finally {
+                                await remotePKC.destroy();
                             }
                         }
                     );
 
-                remotePKCConfigs.forEach((remotePKCConfig) => {
-                    const itSequentialIfRpc =
-                        remotePKCConfig.testConfigCode === "remote-pkc-rpc" ||
-                        remotePKCConfig.testConfigCode === "local-kubo-rpc" ||
-                        remotePKCConfig.testConfigCode === "remote-kubo-rpc"
-                            ? it.sequential
-                            : it;
+                    itSequentialIfRpc(
+                        `Should not be able to update a rejected comment with ${JSON.stringify(commentMod)} and retrieve its CommentUpdate - PKC Config ${remotePKCConfig.name}`,
+                        async () => {
+                            const remotePKC = await remotePKCConfig.pkcInstancePromise();
+                            remotePKC._timeouts["comment-update-ipfs"] = 1000;
+                            try {
+                                const newComment = await remotePKC.createComment(commentToBeRejected);
+                                expect(newComment.raw.comment).to.be.ok;
 
-                    if (shouldCommentBePurged) {
+                                const errors: Error[] = [];
+                                const failIfUpdated = () =>
+                                    newComment.raw.commentUpdate &&
+                                    expect.fail("Rejected comment unexpectedly emitted an update event with CommentUpdate");
+                                newComment.on("update", failIfUpdated);
+                                newComment.on("error", (err: Error) => errors.push(err));
+                                await newComment.update();
+
+                                await new Promise<void>((resolve) => {
+                                    let settled = false;
+                                    let timeoutId: NodeJS.Timeout;
+                                    const onError = () => {
+                                        if (settled) return;
+                                        settled = true;
+                                        clearTimeout(timeoutId);
+                                        newComment.removeListener("error", onError);
+                                        resolve();
+                                    };
+                                    timeoutId = setTimeout(() => {
+                                        if (settled) return;
+                                        settled = true;
+                                        newComment.removeListener("error", onError);
+                                        resolve();
+                                    }, 10_000);
+                                    newComment.on("error", onError);
+                                });
+
+                                newComment.removeListener("update", failIfUpdated);
+
+                                expect(newComment.raw.commentUpdate).to.be.undefined;
+                                expect(newComment.updatedAt).to.be.undefined;
+                                if (errors.length > 0)
+                                    expect((errors[0] as Error & { code: string }).code).to.be.oneOf([
+                                        "ERR_FAILED_TO_FETCH_COMMENT_UPDATE_FROM_ALL_POST_UPDATES_RANGES",
+                                        "ERR_FAILED_TO_FIND_REPLY_COMMENT_UPDATE_WITHIN_PARENT_COMMENT_PAGE_CIDS",
+                                        "ERR_COMMUNITY_HAS_NO_POST_UPDATES"
+                                    ]);
+                                await newComment.stop();
+                            } finally {
+                                await remotePKC.destroy();
+                            }
+                        }
+                    );
+                }
+
+                if (!shouldCommentBePurged) {
+                    // test scenearios:
+                    // have CommentIpfs but want to load commentUpdate
+                    // have neither CommentUpdate or CommentIpfs
+
+                    itSequentialIfRpc(
+                        `Can update a rejected comment with ${JSON.stringify(commentMod)} and retrieve its update as long as we have its CommentIpfs - PKC Config ${remotePKCConfig.name}`,
+                        async () => {
+                            const remotePKC = await remotePKCConfig.pkcInstancePromise();
+
+                            try {
+                                const newComment = await remotePKC.createComment(commentToBeRejected);
+                                expect(newComment.raw.comment).to.be.ok;
+
+                                await newComment.update();
+                                await resolveWhenConditionIsTrue({
+                                    toUpdate: newComment,
+                                    predicate: async () => Boolean(newComment.updatedAt)
+                                });
+
+                                for (const commentModKey of Object.keys(
+                                    commentMod
+                                ) as (keyof CreateCommentModerationOptions["commentModeration"])[]) {
+                                    expect((newComment as unknown as Record<string, unknown>)[commentModKey]).to.equal(
+                                        commentMod[commentModKey]
+                                    );
+                                    expect((newComment.raw.commentUpdate! as unknown as Record<string, unknown>)[commentModKey]).to.equal(
+                                        commentMod[commentModKey]
+                                    );
+                                }
+
+                                expect(newComment.updatedAt).to.be.a("number");
+                                expect(newComment.upvoteCount).to.equal(0);
+                                expect(newComment.replyCount).to.equal(0);
+                                expect(newComment.childCount).to.equal(0);
+                                expect(newComment.removed).to.be.true;
+
+                                expect(newComment.raw.commentUpdate!.updatedAt).to.be.a("number");
+                                expect(newComment.raw.commentUpdate!.upvoteCount).to.equal(0);
+                                expect(newComment.raw.commentUpdate!.replyCount).to.equal(0);
+                                expect(newComment.raw.commentUpdate!.childCount).to.equal(0);
+                                expect(newComment.raw.commentUpdate!.removed).to.be.true;
+
+                                await newComment.stop();
+                            } finally {
+                                await remotePKC.destroy();
+                            }
+                        }
+                    );
+
+                    if (shouldCommentBeInPostsOrRepliesPages) {
                         itSequentialIfRpc(
-                            `Should not be able to update a rejected comment with ${JSON.stringify(commentMod)} and retrieve its CommentIpfs - PKC Config ${remotePKCConfig.name}`,
+                            `Can update a rejected comment with ${JSON.stringify(commentMod)} and retrieve both CommentIpfs and CommentUpdate - PKC Config ${remotePKCConfig.name}`,
                             async () => {
+                                // times out in RPC
                                 const remotePKC = await remotePKCConfig.pkcInstancePromise();
                                 remotePKC._timeouts["comment-ipfs"] = 500; // speed up the test
                                 try {
@@ -285,120 +442,6 @@ for (const commentMod of commentModProps) {
                                         cid: commentToBeRejected.cid,
                                         communityAddress: commentToBeRejected.communityAddress
                                     });
-
-                                    const errors: Error[] = [];
-                                    const failIfUpdated = () =>
-                                        newComment.raw.comment &&
-                                        expect.fail("Rejected comment unexpectedly emitted an update event with CommentIpfs");
-                                    newComment.on("update", failIfUpdated);
-                                    newComment.on("error", (err: Error) => errors.push(err));
-                                    await newComment.update();
-
-                                    await new Promise<void>((resolve) => {
-                                        let settled = false;
-                                        let timeoutId: NodeJS.Timeout;
-                                        const onError = () => {
-                                            if (settled) return;
-                                            settled = true;
-                                            clearTimeout(timeoutId);
-                                            newComment.removeListener("error", onError);
-                                            resolve();
-                                        };
-                                        timeoutId = setTimeout(() => {
-                                            if (settled) return;
-                                            settled = true;
-                                            newComment.removeListener("error", onError);
-                                            resolve();
-                                        }, 10_000);
-                                        newComment.on("error", onError);
-                                    });
-
-                                    newComment.removeListener("update", failIfUpdated);
-
-                                    expect(newComment.raw.commentUpdate).to.be.undefined;
-                                    expect(newComment.raw.comment).to.be.undefined;
-                                    expect(newComment.signature).to.be.undefined;
-                                    expect(newComment.updatedAt).to.be.undefined;
-                                    errors.forEach((err) =>
-                                        expect((err as Error & { code: string }).code).to.be.oneOf([
-                                            "ERR_FETCH_CID_P2P_TIMEOUT",
-                                            "ERR_FAILED_TO_FETCH_COMMENT_IPFS_FROM_GATEWAYS"
-                                        ])
-                                    );
-                                    await newComment.stop();
-                                } finally {
-                                    await remotePKC.destroy();
-                                }
-                            }
-                        );
-
-                        itSequentialIfRpc(
-                            `Should not be able to update a rejected comment with ${JSON.stringify(commentMod)} and retrieve its CommentUpdate - PKC Config ${remotePKCConfig.name}`,
-                            async () => {
-                                const remotePKC = await remotePKCConfig.pkcInstancePromise();
-                                remotePKC._timeouts["comment-update-ipfs"] = 1000;
-                                try {
-                                    const newComment = await remotePKC.createComment(commentToBeRejected);
-                                    expect(newComment.raw.comment).to.be.ok;
-
-                                    const errors: Error[] = [];
-                                    const failIfUpdated = () =>
-                                        newComment.raw.commentUpdate &&
-                                        expect.fail("Rejected comment unexpectedly emitted an update event with CommentUpdate");
-                                    newComment.on("update", failIfUpdated);
-                                    newComment.on("error", (err: Error) => errors.push(err));
-                                    await newComment.update();
-
-                                    await new Promise<void>((resolve) => {
-                                        let settled = false;
-                                        let timeoutId: NodeJS.Timeout;
-                                        const onError = () => {
-                                            if (settled) return;
-                                            settled = true;
-                                            clearTimeout(timeoutId);
-                                            newComment.removeListener("error", onError);
-                                            resolve();
-                                        };
-                                        timeoutId = setTimeout(() => {
-                                            if (settled) return;
-                                            settled = true;
-                                            newComment.removeListener("error", onError);
-                                            resolve();
-                                        }, 10_000);
-                                        newComment.on("error", onError);
-                                    });
-
-                                    newComment.removeListener("update", failIfUpdated);
-
-                                    expect(newComment.raw.commentUpdate).to.be.undefined;
-                                    expect(newComment.updatedAt).to.be.undefined;
-                                    if (errors.length > 0)
-                                        expect((errors[0] as Error & { code: string }).code).to.be.oneOf([
-                                            "ERR_FAILED_TO_FETCH_COMMENT_UPDATE_FROM_ALL_POST_UPDATES_RANGES",
-                                            "ERR_FAILED_TO_FIND_REPLY_COMMENT_UPDATE_WITHIN_PARENT_COMMENT_PAGE_CIDS",
-                                            "ERR_COMMUNITY_HAS_NO_POST_UPDATES"
-                                        ]);
-                                    await newComment.stop();
-                                } finally {
-                                    await remotePKC.destroy();
-                                }
-                            }
-                        );
-                    }
-
-                    if (!shouldCommentBePurged) {
-                        // test scenearios:
-                        // have CommentIpfs but want to load commentUpdate
-                        // have neither CommentUpdate or CommentIpfs
-
-                        itSequentialIfRpc(
-                            `Can update a rejected comment with ${JSON.stringify(commentMod)} and retrieve its update as long as we have its CommentIpfs - PKC Config ${remotePKCConfig.name}`,
-                            async () => {
-                                const remotePKC = await remotePKCConfig.pkcInstancePromise();
-
-                                try {
-                                    const newComment = await remotePKC.createComment(commentToBeRejected);
-                                    expect(newComment.raw.comment).to.be.ok;
 
                                     await newComment.update();
                                     await resolveWhenConditionIsTrue({
@@ -428,6 +471,10 @@ for (const commentMod of commentModProps) {
                                     expect(newComment.raw.commentUpdate!.replyCount).to.equal(0);
                                     expect(newComment.raw.commentUpdate!.childCount).to.equal(0);
                                     expect(newComment.raw.commentUpdate!.removed).to.be.true;
+                                    expect(newComment.pendingApproval).to.be.false;
+
+                                    expect(newComment.raw.comment).to.be.ok;
+                                    expect(newComment.signature).to.be.ok;
 
                                     await newComment.stop();
                                 } finally {
@@ -435,74 +482,44 @@ for (const commentMod of commentModProps) {
                                 }
                             }
                         );
+                    }
 
-                        if (shouldCommentBeInPostsOrRepliesPages) {
-                            itSequentialIfRpc(
-                                `Can update a rejected comment with ${JSON.stringify(commentMod)} and retrieve both CommentIpfs and CommentUpdate - PKC Config ${remotePKCConfig.name}`,
-                                async () => {
-                                    // times out in RPC
-                                    const remotePKC = await remotePKCConfig.pkcInstancePromise();
-                                    remotePKC._timeouts["comment-ipfs"] = 500; // speed up the test
-                                    try {
-                                        const newComment = await remotePKC.createComment({
-                                            cid: commentToBeRejected.cid,
-                                            communityAddress: commentToBeRejected.communityAddress
-                                        });
+                    // if only {approved:false} then we're not getting an update
+                    itSequentialIfRpc(
+                        `A rejected comment will have pendingApproval=false after receiving an update with ${JSON.stringify(commentMod)} if it already had its CommentIpfs - PKC Config ${remotePKCConfig.name}`,
+                        async () => {
+                            const remotePKC = await remotePKCConfig.pkcInstancePromise();
+                            remotePKC._timeouts["comment-ipfs"] = 500; // it's gonna fail to load CID so this will make test run faster
 
-                                        await newComment.update();
-                                        await resolveWhenConditionIsTrue({
-                                            toUpdate: newComment,
-                                            predicate: async () => Boolean(newComment.updatedAt)
-                                        });
-
-                                        for (const commentModKey of Object.keys(
-                                            commentMod
-                                        ) as (keyof CreateCommentModerationOptions["commentModeration"])[]) {
-                                            expect((newComment as unknown as Record<string, unknown>)[commentModKey]).to.equal(
-                                                commentMod[commentModKey]
-                                            );
-                                            expect(
-                                                (newComment.raw.commentUpdate! as unknown as Record<string, unknown>)[commentModKey]
-                                            ).to.equal(commentMod[commentModKey]);
-                                        }
-
-                                        expect(newComment.updatedAt).to.be.a("number");
-                                        expect(newComment.upvoteCount).to.equal(0);
-                                        expect(newComment.replyCount).to.equal(0);
-                                        expect(newComment.childCount).to.equal(0);
-                                        expect(newComment.removed).to.be.true;
-
-                                        expect(newComment.raw.commentUpdate!.updatedAt).to.be.a("number");
-                                        expect(newComment.raw.commentUpdate!.upvoteCount).to.equal(0);
-                                        expect(newComment.raw.commentUpdate!.replyCount).to.equal(0);
-                                        expect(newComment.raw.commentUpdate!.childCount).to.equal(0);
-                                        expect(newComment.raw.commentUpdate!.removed).to.be.true;
-                                        expect(newComment.pendingApproval).to.be.false;
-
-                                        expect(newComment.raw.comment).to.be.ok;
-                                        expect(newComment.signature).to.be.ok;
-
-                                        await newComment.stop();
-                                    } finally {
-                                        await remotePKC.destroy();
-                                    }
-                                }
-                            );
+                            try {
+                                const remoteCommentToBeRejected = await remotePKC.createComment({
+                                    cid: commentToBeRejected.cid,
+                                    raw: { comment: commentToBeRejected.raw.comment }
+                                });
+                                expect(remoteCommentToBeRejected.raw.comment).to.be.ok;
+                                await remoteCommentToBeRejected.update();
+                                await resolveWhenConditionIsTrue({
+                                    toUpdate: remoteCommentToBeRejected,
+                                    predicate: async () => remoteCommentToBeRejected.pendingApproval === false
+                                });
+                                expect(remoteCommentToBeRejected.pendingApproval).to.be.false;
+                            } finally {
+                                await remotePKC.destroy();
+                            }
                         }
+                    );
 
-                        // if only {approved:false} then we're not getting an update
+                    if (shouldCommentBeInPostsOrRepliesPages)
                         itSequentialIfRpc(
-                            `A rejected comment will have pendingApproval=false after receiving an update with ${JSON.stringify(commentMod)} if it already had its CommentIpfs - PKC Config ${remotePKCConfig.name}`,
+                            `A rejected comment will have pendingApproval=false after receiving an update with ${JSON.stringify(commentMod)} without CommentIpfs - PKC Config ${remotePKCConfig.name}`,
                             async () => {
                                 const remotePKC = await remotePKCConfig.pkcInstancePromise();
-                                remotePKC._timeouts["comment-ipfs"] = 500; // it's gonna fail to load CID so this will make test run faster
-
                                 try {
+                                    remotePKC._timeouts["comment-ipfs"] = 500; // it's gonna fail to load CID so this will make test run faster
                                     const remoteCommentToBeRejected = await remotePKC.createComment({
                                         cid: commentToBeRejected.cid,
-                                        raw: { comment: commentToBeRejected.raw.comment }
+                                        communityAddress: commentToBeRejected.communityAddress
                                     });
-                                    expect(remoteCommentToBeRejected.raw.comment).to.be.ok;
                                     await remoteCommentToBeRejected.update();
                                     await resolveWhenConditionIsTrue({
                                         toUpdate: remoteCommentToBeRejected,
@@ -514,136 +531,119 @@ for (const commentMod of commentModProps) {
                                 }
                             }
                         );
+                }
+            });
 
-                        if (shouldCommentBeInPostsOrRepliesPages)
-                            itSequentialIfRpc(
-                                `A rejected comment will have pendingApproval=false after receiving an update with ${JSON.stringify(commentMod)} without CommentIpfs - PKC Config ${remotePKCConfig.name}`,
-                                async () => {
-                                    const remotePKC = await remotePKCConfig.pkcInstancePromise();
-                                    try {
-                                        remotePKC._timeouts["comment-ipfs"] = 500; // it's gonna fail to load CID so this will make test run faster
-                                        const remoteCommentToBeRejected = await remotePKC.createComment({
-                                            cid: commentToBeRejected.cid,
-                                            communityAddress: commentToBeRejected.communityAddress
-                                        });
-                                        await remoteCommentToBeRejected.update();
-                                        await resolveWhenConditionIsTrue({
-                                            toUpdate: remoteCommentToBeRejected,
-                                            predicate: async () => remoteCommentToBeRejected.pendingApproval === false
-                                        });
-                                        expect(remoteCommentToBeRejected.pendingApproval).to.be.false;
-                                    } finally {
-                                        await remotePKC.destroy();
-                                    }
-                                }
-                            );
-                    }
+            it(`Can't vote on rejected comment`, async () => {
+                const expectedMessage = commentMod.removed
+                    ? messages.ERR_COMMUNITY_PUBLICATION_PARENT_HAS_BEEN_REMOVED
+                    : shouldCommentBePurged
+                      ? messages.ERR_PUBLICATION_PARENT_DOES_NOT_EXIST_IN_COMMUNITY
+                      : messages.ERR_USER_PUBLISHED_UNDER_DISAPPROVED_COMMENT;
+                const vote = await generateMockVote(commentToBeRejected as CommentIpfsWithCidDefined, 1, pkc, modSigner); // need to publish under mod otherwise we're gonna get captcha challenge
+                await publishWithExpectedResult({
+                    publication: vote,
+                    expectedChallengeSuccess: false,
+                    expectedReason: expectedMessage
+                });
+            });
+
+            it(`Can't publish a reply under a rejected comment`, async () => {
+                const expectedMessage = commentMod.removed
+                    ? messages.ERR_COMMUNITY_PUBLICATION_PARENT_HAS_BEEN_REMOVED
+                    : shouldCommentBePurged
+                      ? messages.ERR_PUBLICATION_PARENT_DOES_NOT_EXIST_IN_COMMUNITY
+                      : messages.ERR_USER_PUBLISHED_UNDER_DISAPPROVED_COMMENT;
+                const reply = await generateMockComment(commentToBeRejected as CommentIpfsWithCidDefined, pkc, false);
+                await publishWithExpectedResult({
+                    publication: reply,
+                    expectedChallengeSuccess: false,
+                    expectedReason: expectedMessage
+                });
+            });
+
+            it(`Can't publish an edit under a rejected comment`, async () => {
+                const expectedMessage = commentMod.removed
+                    ? messages.ERR_COMMUNITY_PUBLICATION_PARENT_HAS_BEEN_REMOVED
+                    : shouldCommentBePurged
+                      ? messages.ERR_PUBLICATION_PARENT_DOES_NOT_EXIST_IN_COMMUNITY
+                      : messages.ERR_USER_PUBLISHED_UNDER_DISAPPROVED_COMMENT;
+                const edit = await pkc.createCommentEdit({
+                    communityAddress: commentToBeRejected.communityAddress,
+                    commentCid: commentToBeRejected.cid!,
+                    reason: "random reason should fail",
+                    content: "text to edit on pending comment",
+                    signer: commentToBeRejected.signer
+                });
+                await publishWithExpectedResult({
+                    publication: edit,
+                    expectedChallengeSuccess: false,
+                    expectedReason: expectedMessage
+                });
+            });
+
+            itSkipIfRpc(`A rejected comment is not pinned to IPFS node`, async () => {
+                const kuboRpc = Object.values(pkc.clients.kuboRpcClients)[0]._client;
+
+                // Collect all pinned CIDs
+                for await (const pin of kuboRpc.pin.ls()) {
+                    expect(pin.cid.toString()).to.not.equal(commentToBeRejected.cid); // pending comment should not be pinned in kubo
+                }
+            });
+
+            itSkipIfRpc(`Should not be able to fetch rejected comment with only its CID since it's not provided anymore`, async () => {
+                const originalTimeout = JSON.parse(JSON.stringify(pkc._timeouts["generic-ipfs"]));
+                pkc._timeouts["generic-ipfs"] = 1000;
+                try {
+                    await pkc.fetchCid({ cid: commentToBeRejected.cid! });
+                    expect.fail("should fail");
+                } catch (e) {
+                    expect((e as Error & { code: string }).code).to.equal("ERR_FETCH_CID_P2P_TIMEOUT");
+                } finally {
+                    pkc._timeouts["generic-ipfs"] = originalTimeout;
+                }
+            });
+
+            it(`Sub should reject CommentModeration if a mod published disapproval for a comment that already got disapproved`, async () => {
+                const expectedMessage = shouldCommentBePurged
+                    ? messages.ERR_PUBLICATION_PARENT_DOES_NOT_EXIST_IN_COMMUNITY
+                    : messages.ERR_MOD_ATTEMPTING_TO_APPROVE_OR_DISAPPROVE_COMMENT_THAT_IS_NOT_PENDING;
+                const commentModerationDisapproval = await pkc.createCommentModeration({
+                    communityAddress: community.address,
+                    signer: modSigner,
+                    commentModeration: { approved: false },
+                    commentCid: commentToBeRejected.cid!
                 });
 
-                it(`Can't vote on rejected comment`, async () => {
-                    const expectedMessage = commentMod.removed
-                        ? messages.ERR_COMMUNITY_PUBLICATION_PARENT_HAS_BEEN_REMOVED
-                        : shouldCommentBePurged
-                          ? messages.ERR_PUBLICATION_PARENT_DOES_NOT_EXIST_IN_COMMUNITY
-                          : messages.ERR_USER_PUBLISHED_UNDER_DISAPPROVED_COMMENT;
-                    const vote = await generateMockVote(commentToBeRejected as CommentIpfsWithCidDefined, 1, pkc, modSigner); // need to publish under mod otherwise we're gonna get captcha challenge
-                    await publishWithExpectedResult({
-                        publication: vote,
-                        expectedChallengeSuccess: false,
-                        expectedReason: expectedMessage
-                    });
+                await publishWithExpectedResult({
+                    publication: commentModerationDisapproval,
+                    expectedChallengeSuccess: false,
+                    expectedReason: expectedMessage
                 });
+            });
 
-                it(`Can't publish a reply under a rejected comment`, async () => {
-                    const expectedMessage = commentMod.removed
-                        ? messages.ERR_COMMUNITY_PUBLICATION_PARENT_HAS_BEEN_REMOVED
-                        : shouldCommentBePurged
-                          ? messages.ERR_PUBLICATION_PARENT_DOES_NOT_EXIST_IN_COMMUNITY
-                          : messages.ERR_USER_PUBLISHED_UNDER_DISAPPROVED_COMMENT;
-                    const reply = await generateMockComment(commentToBeRejected as CommentIpfsWithCidDefined, pkc, false);
-                    await publishWithExpectedResult({
-                        publication: reply,
-                        expectedChallengeSuccess: false,
-                        expectedReason: expectedMessage
-                    });
-                });
+            itSkipIfRpc.sequential(`A rejected comment is not pinned to IPFS node after restarting the sub`, async () => {
+                await community.stop();
 
-                it(`Can't publish an edit under a rejected comment`, async () => {
-                    const expectedMessage = commentMod.removed
-                        ? messages.ERR_COMMUNITY_PUBLICATION_PARENT_HAS_BEEN_REMOVED
-                        : shouldCommentBePurged
-                          ? messages.ERR_PUBLICATION_PARENT_DOES_NOT_EXIST_IN_COMMUNITY
-                          : messages.ERR_USER_PUBLISHED_UNDER_DISAPPROVED_COMMENT;
-                    const edit = await pkc.createCommentEdit({
-                        communityAddress: commentToBeRejected.communityAddress,
-                        commentCid: commentToBeRejected.cid!,
-                        reason: "random reason should fail",
-                        content: "text to edit on pending comment",
-                        signer: commentToBeRejected.signer
-                    });
-                    await publishWithExpectedResult({
-                        publication: edit,
-                        expectedChallengeSuccess: false,
-                        expectedReason: expectedMessage
-                    });
-                });
+                const updatePromise = new Promise((resolve) => community.once("update", resolve));
+                await community.start();
+                await updatePromise;
 
-                itSkipIfRpc(`A rejected comment is not pinned to IPFS node`, async () => {
-                    const kuboRpc = Object.values(pkc.clients.kuboRpcClients)[0]._client;
+                const kuboRpc = Object.values(pkc.clients.kuboRpcClients)[0]._client;
 
-                    // Collect all pinned CIDs
-                    for await (const pin of kuboRpc.pin.ls()) {
-                        expect(pin.cid.toString()).to.not.equal(commentToBeRejected.cid); // pending comment should not be pinned in kubo
-                    }
-                });
+                // Collect all pinned CIDs
+                for await (const pin of kuboRpc.pin.ls()) {
+                    expect(pin.cid.toString()).to.not.equal(commentToBeRejected.cid); // pending comment should not be pinned in kubo
+                }
+            });
+        };
 
-                itSkipIfRpc(`Should not be able to fetch rejected comment with only its CID since it's not provided anymore`, async () => {
-                    const originalTimeout = JSON.parse(JSON.stringify(pkc._timeouts["generic-ipfs"]));
-                    pkc._timeouts["generic-ipfs"] = 1000;
-                    try {
-                        await pkc.fetchCid({ cid: commentToBeRejected.cid! });
-                        expect.fail("should fail");
-                    } catch (e) {
-                        expect((e as Error & { code: string }).code).to.equal("ERR_FETCH_CID_P2P_TIMEOUT");
-                    } finally {
-                        pkc._timeouts["generic-ipfs"] = originalTimeout;
-                    }
-                });
-
-                it(`Sub should reject CommentModeration if a mod published disapproval for a comment that already got disapproved`, async () => {
-                    const expectedMessage = shouldCommentBePurged
-                        ? messages.ERR_PUBLICATION_PARENT_DOES_NOT_EXIST_IN_COMMUNITY
-                        : messages.ERR_MOD_ATTEMPTING_TO_APPROVE_OR_DISAPPROVE_COMMENT_THAT_IS_NOT_PENDING;
-                    const commentModerationDisapproval = await pkc.createCommentModeration({
-                        communityAddress: community.address,
-                        signer: modSigner,
-                        commentModeration: { approved: false },
-                        commentCid: commentToBeRejected.cid!
-                    });
-
-                    await publishWithExpectedResult({
-                        publication: commentModerationDisapproval,
-                        expectedChallengeSuccess: false,
-                        expectedReason: expectedMessage
-                    });
-                });
-
-                itSkipIfRpc.sequential(`A rejected comment is not pinned to IPFS node after restarting the sub`, async () => {
-                    await community.stop();
-
-                    const updatePromise = new Promise((resolve) => community.once("update", resolve));
-                    await community.start();
-                    await updatePromise;
-
-                    const kuboRpc = Object.values(pkc.clients.kuboRpcClients)[0]._client;
-
-                    // Collect all pinned CIDs
-                    for await (const pin of kuboRpc.pin.ls()) {
-                        expect(pin.cid.toString()).to.not.equal(commentToBeRejected.cid); // pending comment should not be pinned in kubo
-                    }
-                });
-            }
-        );
+        // The 16 blocks below are fully independent (each builds its own community), so they run
+        // concurrently with each other. The inner sequential suite keeps each block's own tests in
+        // the order they depend on.
+        describe.concurrent(blockTitle, () => {
+            describe.sequential(blockTitle, blockBody);
+        });
     }
 }
 


### PR DESCRIPTION
## Why

The `windows-latest` node-local job failed on master with **every test passing**. Vitest printed its summary and flushed the JSON report 0.02s before the 28-minute step cap fired:

```
01:45:31.198   Test Files  185 passed | 4 skipped (189)
01:45:31.201        Tests  2596 passed | 71 skipped | 3 todo (2674)
01:45:31.202     Duration  1664.04s
01:45:31.821  JSON report written to .vitest-reports\node-local-kubo-rpc.json
01:45:32.010  ##[error]The action 'Run node tests (local config)' has timed out after 28 minutes.
```

The suite needs 27.7 min on that runner, so the cap had no headroom. Recent master runs finished the same job in 28m24s, 28m46s and 30m00s, all a hair under the line.

## Changes

**1. Timeout headroom.** Step cap 28 -> 33 min, job cap 35 -> 40 min. The step cap stays below the job cap so the Kubo goroutine-dump step still runs when the step fails on a hang.

**2. Concurrent rejection blocks.** `rejection.modqueue.community.test.ts` was the slowest file in the suite: 447s on Windows, 277s locally. Profiling the vitest report:

| bucket | Windows |
|---|---|
| `beforeAll`/`afterAll` | 172s |
| 16x `...retrieve its CommentUpdate` (fixed 10s wait) | 121s |
| two 36-instance tests at ~1.6s | 112s |
| everything else | ~42s |

The file is a 4x4 product of `commentModeration` variants and comment depths, and each of the 16 `describe` blocks builds its own community from scratch (`createCommunity` -> `edit` -> `start` -> publish a depth-N chain -> `delete`). The blocks are fully independent and each `pkcInstancePromise()` call returns a fresh instance, so they now run concurrently. An inner sequential suite keeps each block's own tests in the order they depend on.

## Measurements

Local, `--pkc-config local-kubo-rpc`, four consecutive runs:

| | duration | result |
|---|---|---|
| before | 276.71s | 488 passed |
| after, run 1 | 63.66s | 488 passed |
| after, run 2 | 63.41s | 488 passed |
| after, run 3 | 63.73s | 488 passed |
| after, run 4 | 63.51s | 488 passed |

4.3x faster, under 0.5s of variance, no failures.

## Risk

Concurrency here is only viable because kubo 0.43.0 fixed the MFS wedge — overlapping community setup now contends rather than deadlocks. On Windows this stacks on top of file parallelism (`maxForks: 3`), so up to 15 communities can be building at once. That is what this PR's CI run validates; watch the `windows-latest` node-local job.

## Notes

- Most of the test diff is prettier reindentation. Review with `git diff -w` — the semantic change is about 20 lines.
- Not addressed here: 12 of the 16 `retrieve its CommentUpdate` tests burn a full fixed 10s because the client emits `ERR_COMMUNITY_HAS_NO_POST_UPDATES` once and then goes quiet until the community's next IPNS update, which lands after the window closes. The wait's `onError` listener is also attached after `await update()`, so an error emitted during `update()` never resolves it. Worth a follow-up.
- Also not addressed: the whole Windows suite is 61 min of file-work at an effective concurrency of 2.2, because `config/vitest.config.ts` caps Windows at `maxForks: 3` (from `b581c2f53`, "prevent Kubo overload"). The same kubo 0.43.0 fix may make that cap raisable, which would matter more than any single file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved moderation rejection test coverage, including comment visibility, retrieval, approval status, publication, pinning, repeated moderation, and restart scenarios.
  * Added checks confirming rejected comments retain required metadata.
  * Enabled independent test cases to run concurrently while preserving reliable sequencing within each scenario.

* **Chores**
  * Increased CI time limits to improve reliability for longer-running local test jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->