### PR TITLE
feat(community): author profiles as a community configuration, with suggested.uiType (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ CommunitySuggested { // values suggested by the community owner, the client/user
   bannerUrl?: string
   backgroundUrl?: string
   language?: string
+  uiType?: string // how the owner suggests clients render this community, e.g. "author" for a profile; never affects validation or loading
   // TODO: menu links, wiki pages, sidebar widgets
 }
 CommunityFeatures { // any boolean that changes the functionality of the community, add "no" in front if doesn't default to false

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -12,6 +12,7 @@ Concise protocol reference for AI agents and contributors. Each doc covers one d
 | [signing.md](signing.md) | Ed25519 signatures, signedPropertyNames, CBORG encoding |
 | [pages.md](pages.md) | Pagination, sort types, ephemeral nature of pages |
 | [crossposts.md](crossposts.md) | `comment.crosspost`, the embedded record, tier-1 vs tier-2 verification, `features.noCrossposts` |
+| [author-communities.md](author-communities.md) | Profiles as a community configuration: identity-key address, owner-only posting via challenge excludes, crosspost feed |
 | [challenge-flow.md](challenge-flow.md) | 4-message encrypted challenge exchange |
 | [challenge-settings.md](challenge-settings.md) | Private (`settings.challenges`) vs public (`challenges`) boundary, sensitive options |
 | [challenge-authoring.md](challenge-authoring.md) | For challenge package authors: core `optionInputs` validation, the `validateChallengeSettings` hook, publication obligations |

--- a/docs/protocol/author-communities.md
+++ b/docs/protocol/author-communities.md
@@ -38,7 +38,8 @@ await community.edit({
                 publicOptions: ["error"], // publish the rejection text, see "What a reader can actually tell"
                 exclude: [
                     { role: ["owner"] },
-                    { publicationType: { reply: true, vote: true, commentEdit: true, commentModeration: true, communityEdit: true } }
+                    // no `vote`: votes are rejected by default, see below
+                    { publicationType: { reply: true, commentEdit: true, commentModeration: true, communityEdit: true } }
                 ]
             },
             {
@@ -60,9 +61,19 @@ only if **all** of its conditions hold:
 | owner, reply | excluded by either rule | excluded by `role` | accepted, unchallenged |
 | stranger, post | matches neither rule, so it runs and fails | dropped | **rejected** |
 | stranger, reply | excluded by `publicationType` | runs | challenged normally |
+| stranger, vote | matches neither rule, so it runs and fails | dropped | **rejected** |
 
 A failing challenge drops any challenge still pending, so the rejected stranger is never asked the
 question: they get one immediate failed verification rather than a challenge round trip.
+
+**Votes are rejected by default.** `vote` is deliberately absent from the `publicationType` exclude,
+so a stranger's vote hits the `fail` challenge exactly like a stranger's post, while the owner's own
+votes stay excluded by `role`. The reason is the karma model in [crossposts.md](crossposts.md): karma
+over a profile is read at tier 2 from each entry's origin community, so a vote published to the
+profile lands on the crosspost copy, is tallied by the owner's own delegate, and counts toward
+nothing a client should trust. It would only accumulate a misleading second score on the copy, and it
+does not drive ranking either, since `new` is the only sort a profile feed has a reason to serve. A
+profile that wants vote-driven reply sorting can opt back in by adding `vote: true` to the exclude.
 
 Set the `error` option. It is what the rejected publisher actually sees: a `fail` challenge reports
 through `challengeErrors`, not through the verification `reason`, and its default text is the generic
@@ -205,7 +216,8 @@ one community is legitimate, so idempotency belongs to whatever does the mirrori
 
 **Reply-able**, the default. The challenge exchange runs, the record carries a `pubsubTopic`, and
 strangers can reply over pubsub. This needs the second challenge in the config above, or replies are
-unguarded.
+unguarded. Strangers still cannot vote: the recommended config rejects votes regardless of flavor,
+see "Votes are rejected by default" above.
 
 **Feed-only.** Set `settings.disablePubsubChallengeExchange`. The record omits `pubsubTopic`, the node
 unsubscribes, and remote publishers fail fast with `ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED`. Nobody

--- a/docs/protocol/author-communities.md
+++ b/docs/protocol/author-communities.md
@@ -1,0 +1,195 @@
+# Author communities
+
+An **author community** is an ordinary community addressed by an author's identity key, configured so
+that only its owner can post, and fed by the owner crossposting their own comments into it. Informally,
+a profile. Issue [#31](https://github.com/pkcprotocol/pkc-js/issues/31).
+
+There is no `AuthorCommunityIpfs`, no envelope, no `community.type`, no `AuthorLocalCommunity`, no
+dedicated page verifier and no author-specific RPC. **An author community is a configuration, not a
+type**, so `getCommunity`, the schema, page verification, moderation, pseudonymity, export and the
+whole lifecycle apply unchanged. This document covers only what is different.
+
+## What is different
+
+Three things, none of which is a new mechanism:
+
+1. **The address is the author's identity key.** The community is published delegated, anchor to
+   minter, where the anchor `An` is the same key the author signs comments with. See
+   [delegated-ipns.md](delegated-ipns.md) for the chain, the setup calls and rotation.
+2. **Only the owner may post.** Enforced by challenge configuration, not by a feature flag. See below.
+3. **The feed is the owner's crossposts.** Ordinary comments carrying `comment.crosspost`, published
+   by the owner's own client. See [crossposts.md](crossposts.md).
+
+## Only the owner may post
+
+The built-in `fail` challenge exists to be paired with `exclude`: it always fails, so the only way past
+it is to be excluded. Two challenges express "the owner posts, anyone may reply":
+
+```js
+await community.edit({
+    roles: {
+        [An]: { role: "owner" }          // An is the anchor publicKey, see "The roles key" below
+    },
+    settings: {
+        challenges: [
+            {
+                name: "fail",
+                options: { error: "Only the owner can post to this profile." },
+                exclude: [
+                    { role: ["owner"] },
+                    { publicationType: { reply: true, vote: true, commentEdit: true, commentModeration: true, communityEdit: true } }
+                ]
+            },
+            {
+                name: "question",
+                options: { question: "...", answer: "..." },
+                exclude: [{ role: ["owner"] }]
+            }
+        ]
+    }
+})
+```
+
+How it resolves, given that an `exclude` array matches if **any** item matches, and an item matches
+only if **all** of its conditions hold:
+
+| publisher and type | challenge 0 (`fail`) | challenge 1 (`question`) | result |
+|---|---|---|---|
+| owner, post | excluded by `role` | excluded by `role` | accepted, unchallenged |
+| owner, reply | excluded by either rule | excluded by `role` | accepted, unchallenged |
+| stranger, post | matches neither rule, so it runs and fails | dropped | **rejected** |
+| stranger, reply | excluded by `publicationType` | runs | challenged normally |
+
+A failing challenge drops any challenge still pending, so the rejected stranger is never asked the
+question: they get one immediate failed verification rather than a challenge round trip.
+
+Set the `error` option. It is what the rejected publisher actually sees: a `fail` challenge reports
+through `challengeErrors`, not through the verification `reason`, and its default text is the generic
+`"You're not allowed to publish."`.
+
+**The restriction is legible on the wire.** `exclude` is copied verbatim from the private
+`settings.challenges` into the public signed `challenges` array, while `path`, `name` and `options`
+are stripped (see [challenge-settings.md](challenge-settings.md)). So a client reading the record can
+see `role: ["owner"]` against `publicationType` and render the profile accordingly, without publishing
+anything to find out. This is why no `features.onlyOwnerCanPost` flag exists: it would duplicate a fact
+the record already carries.
+
+Nothing enforces this read-side. A dishonest minter can accept a post from anyone, and the entry will
+verify like any other comment in the community it was published to. Owner-only posting is a property of
+an honest node's configuration, which is what the wire-visible `exclude` lets a reader check.
+
+### `roles` and `settings.challenges` are set in two different places
+
+`roles` is a top-level field on the **public signed record**, so it travels to readers and is what
+`exclude.role` matches against. `settings` is **private and local-only**. Both are passed through
+`createCommunity` or `community.edit`, but only one of them is published. Setting the challenges
+without the roles is the most likely way to get this wrong, and it fails in a confusing direction:
+
+- **`community.edit()` needs no role.** It is a direct method call, not a `CommentEdit` or
+  `CommunityEdit` publication, so configuring the profile always works.
+- **Publishing does need the role, on every path including RPC.** Publishing over RPC to a node that
+  runs the community takes the local shortcut, which only suppresses the pubsub echo; the challenge
+  pipeline and `exclude` evaluation still run. So does `checkPublicationValidity`, which gates
+  `CommentModeration` on the roles map separately.
+
+`createCommunity` never seeds `roles`, for delegated communities or any other kind. A profile whose
+excludes are configured but whose roles map is empty looks correct until the owner's first post is
+rejected by their own `fail` challenge.
+
+### The roles key
+
+`exclude.role` matches `community.roles[author.address]`, and `author.address` is `name || publicKey`.
+So the key must be whatever form the owner actually publishes under.
+
+- A PKC address, an IPNS name and a community `publicKey` are all the **same base58btc peer ID**
+  (`12D3Koo...`). The key is therefore literally the string passed as `anchor.publicKey`. It is not
+  `signer.publicKey`, which is base64 raw key material.
+- If the owner publishes with `author.name` set to a domain, `author.address` is that **domain**, and
+  a peer-ID key silently fails to match. `exclude` matching is a bare map lookup with no name
+  resolution, unlike `isPublicationAuthorPartOfRoles`.
+
+**Put both forms in the roles map** so the owner matches either way:
+
+```js
+roles: {
+    "12D3KooW...": { role: "owner" },
+    "owner.bso": { role: "owner" }
+}
+```
+
+The domain key inherits the weakness in [#267](https://github.com/pkcprotocol/pkc-js/issues/267):
+`exclude` compares a string the publisher partly controls, so a domain-keyed rule is only sound while
+`resolveAuthorNames` is on, which is the default. The peer-ID key has no such dependency, because
+`isStringDomain` forbids a raw address as an `author.name`.
+
+One further trap: the anchor schema accepts base36 and base32 CIDv1 peer-ID forms (`k51...`, `bafz...`)
+that are valid IPNS names but are not what the address derivation emits. A roles key written that way
+never matches.
+
+## The feed
+
+The owner's client publishes a crosspost into the profile alongside the real comment, so the profile
+shows the author's activity. Backfilling history by walking `author.previousCommentCid` works the same
+way. Both are client behavior: pkc-js ships the crosspost primitive and the community, and does not
+mirror anything on an author's behalf.
+
+Only the author can sign as the author, so a feed entry is either author-signed or it is a foreign
+record embedded by the minter. There is no third option, and the second was rejected because it made
+the profile's contents unattributable. Publishing a crosspost is what makes an entry the owner's.
+
+Adding to the feed is publishing. Removing from it is a `CommentEdit` with `deleted`, or a
+`CommentModeration` with `removed`, exactly as in any community. Nothing is retracted by omission.
+
+Reading a feed entry means reading a crosspost, so the tier-1 and tier-2 rules and the three render
+states in [crossposts.md](crossposts.md) apply unchanged. In particular, karma over a profile is the
+sum over independently verified entries and there is no signed profile-wide total, by design: a
+minter-computed number would be the owner's own delegate attesting to the owner's reputation.
+
+Duplicate crossposts of the same `cid` are not rejected. Two people crossposting the same comment to
+one community is legitimate, so idempotency belongs to whatever does the mirroring.
+
+## Two flavors
+
+**Reply-able**, the default. The challenge exchange runs, the record carries a `pubsubTopic`, and
+strangers can reply over pubsub. This needs the second challenge in the config above, or replies are
+unguarded.
+
+**Feed-only.** Set `settings.disablePubsubChallengeExchange`. The record omits `pubsubTopic`, the node
+unsubscribes, and remote publishers fail fast with `ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED`. Nobody
+can reply, and the owner must publish over RPC, because that is the only remaining path. The `fail`
+challenge is then belt and braces rather than the mechanism.
+
+## How the owner publishes
+
+Either flavor works over RPC to a node running the community, whether that is `bitsocial-cli`'s
+embedded RPC or a hosted service. The client's signature survives end to end: the RPC server parses
+into a schema that requires `signature` and accepts no `signer`, so it never re-signs, and the
+ephemeral key it generates covers only the outer challenge-request envelope. The author of a comment
+published through a hosted service is the author, not the service.
+
+A browser-only author with no RPC access to their minter can only publish over pubsub, which is why
+the feed-only flavor is for self-hosted or RPC-reachable profiles. Multi-tenant authentication for a
+hosted minter is a service-layer concern and lives outside this repo.
+
+## Key lifetime
+
+The anchor key signs both the author's comments and the `An -> Mn` record, because the profile is
+addressed by the author's identity. There is no rotation story: changing that key changes the author's
+identity and orphans the profile, and compromise of it takes both. Minter rotation is different and is
+fully supported, see [delegated-ipns.md](delegated-ipns.md); it re-points `An` at a new `Mn'` and the
+address does not move.
+
+Migration between minters reuses `exportCommunity`, which is type-blind and already sqlite-based. The
+community address in the database is the anchor, and the minter key is node-local configuration that
+is never part of an export, so the database is portable by construction.
+
+## Open questions
+
+- **A discovery hint on the author object.** A client seeing one of millions of authors has no cheap
+  way to know whether that author's identity key resolves to a profile worth fetching. The key is
+  always derivable from `comment.signature.publicKey`, so a hint would only save a failed lookup, but
+  at scale that may be worth a signed optional boolean on `AuthorPubsubSchema`. Deferred rather than
+  rejected: it is permanent wire surface once published.
+- **Delegating profile moderation** to a third party. The schema already supports it; v1 seeds the
+  roles map with the owner alone.
+- **Convergence**, one name carrying both a community feed and its owner's author feed.

--- a/docs/protocol/author-communities.md
+++ b/docs/protocol/author-communities.md
@@ -35,6 +35,7 @@ await community.edit({
             {
                 name: "fail",
                 options: { error: "Only the owner can post to this profile." },
+                publicOptions: ["error"], // publish the rejection text, see "What a reader can actually tell"
                 exclude: [
                     { role: ["owner"] },
                     { publicationType: { reply: true, vote: true, commentEdit: true, commentModeration: true, communityEdit: true } }
@@ -65,12 +66,16 @@ question: they get one immediate failed verification rather than a challenge rou
 
 Set the `error` option. It is what the rejected publisher actually sees: a `fail` challenge reports
 through `challengeErrors`, not through the verification `reason`, and its default text is the generic
-`"You're not allowed to publish."`.
+`"You're not allowed to publish."`. Naming it in `publicOptions` publishes that sentence in the record
+too, which is worth doing here: a reader then sees the intent without publishing anything. It is still
+a hint rather than an attestation, for the reason below.
 
 ### What a reader can actually tell
 
 `exclude` is copied verbatim from the private `settings.challenges` into the public signed `challenges`
-array, while `path`, `name` and `options` are stripped (see
+array, while `path` and `name` are stripped. `options` are private by default and leave only by name:
+the owner lists individual option names in `settings.challenges[i].publicOptions`, and those, and only
+those, are published as `challenges[i].publicOptions` (see
 [challenge-settings.md](challenge-settings.md)). Be precise about what that does and does not give a
 client, because it is easy to overclaim:
 
@@ -79,10 +84,17 @@ matched against. A reader can see that the owner and every non-post publication 
 that nobody else does.
 
 **Not legible**: whether challenge 0 can be passed at all. `name` and `options` are exactly what
-distinguish `fail` from, say, `question`, and both are stripped, so a community that gates non-owner
+distinguish `fail` from, say, `question`, and neither is published, so a community that gates non-owner
 posts behind an answerable challenge publishes the same exemption structure as one that forbids them
-outright. `description` differs by default but is operator-settable free text, so it is a hint, not a
-discriminator.
+outright. `type` does not separate them either: both are `text/plain`. `description` differs by default
+but is operator-settable free text, so it is a hint, not a discriminator.
+
+`publicOptions` is the same kind of hint. A profile that opts its `error` in publishes the rejection
+sentence, and that is a better hint than `description` because a passable challenge has no reason to
+carry one. It is still not a discriminator: the value is free text chosen by the same node that decides
+whether to honor it, and a custom challenge file may declare an `error` option of its own and publish an
+identical string while remaining passable. What a client learns from `publicOptions` is what the owner
+says the rule is, which is exactly what it learns from the rest of the record.
 
 So "only the owner posts here" is a **reasonable inference from the record, not a fact the record
 attests**. A client should render it as a strong hint, and find out for certain the same way it would

--- a/docs/protocol/author-communities.md
+++ b/docs/protocol/author-communities.md
@@ -156,6 +156,29 @@ One further trap: the anchor schema accepts base36 and base32 CIDv1 peer-ID form
 that are valid IPNS names but are not what the address derivation emits. A roles key written that way
 never matches.
 
+## Declaring the profile to UIs
+
+`suggested.uiType: "author"` is how a profile tells clients what it is. It lives in `suggested`
+alongside `primaryColor` and `avatarUrl` because it is the same kind of thing: a rendering hint the
+owner sets, which a client may ignore without breaking interoperability. It is not a record type and
+does not weaken "a configuration, not a type": nothing in pkc-js branches on it, it plays no role in
+validation or loading, and a record that lies about it verifies fine, exactly like a record with a
+misleading `title`.
+
+```js
+await community.edit({ suggested: { uiType: "author" } })
+```
+
+`"author"` is the only defined value. Absence means an ordinary community. Clients must ignore values
+they do not recognize, so the vocabulary can grow without breaking old clients.
+
+This is the only recommended way for a client to decide how to render the record. The tempting
+inference `roles[community.address].role === "owner"` is not reliable in either direction: any
+ordinary community can hold the owner role over its own address and nothing forbids or even
+discourages it, while `createCommunity` never seeds `roles`, so a half-configured profile lacks the
+entry. Both signals are claims by the same node that writes the record, so the inference buys no
+extra trust over the declaration, it only buys false positives.
+
 ## The feed
 
 The owner's client publishes a crosspost into the profile alongside the real comment, so the profile
@@ -220,12 +243,6 @@ is never part of an export, so the database is portable by construction.
   always derivable from `comment.signature.publicKey`, so a hint would only save a failed lookup, but
   at scale that may be worth a signed optional boolean on `AuthorPubsubSchema`. Deferred rather than
   rejected: it is permanent wire surface once published.
-- **A field saying this is a profile.** Nothing in the record declares itself a profile rather than an
-  ordinary community, and the pieces that imply one are spread across the anchor, the roles map and the
-  challenge excludes. Right now a client can do `const isAuthor = roles[community.address].role ===
-  "owner"` and it is accurate, because an ordinary community has no reason to hold the owner role over
-  its own address. Whether that is enough, or whether it deserves an explicit field, is open. Like the
-  hint above, a field is permanent wire surface once published.
 - **Delegating profile moderation** to a third party. The schema already supports it; v1 seeds the
   roles map with the owner alone.
 - **Convergence**, one name carrying both a community feed and its owner's author feed.

--- a/docs/protocol/author-communities.md
+++ b/docs/protocol/author-communities.md
@@ -67,16 +67,34 @@ Set the `error` option. It is what the rejected publisher actually sees: a `fail
 through `challengeErrors`, not through the verification `reason`, and its default text is the generic
 `"You're not allowed to publish."`.
 
-**The restriction is legible on the wire.** `exclude` is copied verbatim from the private
-`settings.challenges` into the public signed `challenges` array, while `path`, `name` and `options`
-are stripped (see [challenge-settings.md](challenge-settings.md)). So a client reading the record can
-see `role: ["owner"]` against `publicationType` and render the profile accordingly, without publishing
-anything to find out. This is why no `features.onlyOwnerCanPost` flag exists: it would duplicate a fact
-the record already carries.
+### What a reader can actually tell
 
-Nothing enforces this read-side. A dishonest minter can accept a post from anyone, and the entry will
-verify like any other comment in the community it was published to. Owner-only posting is a property of
-an honest node's configuration, which is what the wire-visible `exclude` lets a reader check.
+`exclude` is copied verbatim from the private `settings.challenges` into the public signed `challenges`
+array, while `path`, `name` and `options` are stripped (see
+[challenge-settings.md](challenge-settings.md)). Be precise about what that does and does not give a
+client, because it is easy to overclaim:
+
+**Legible**: which publishers are exempt from which challenge, and the `roles` map the exemption is
+matched against. A reader can see that the owner and every non-post publication skip challenge 0, and
+that nobody else does.
+
+**Not legible**: whether challenge 0 can be passed at all. `name` and `options` are exactly what
+distinguish `fail` from, say, `question`, and both are stripped, so a community that gates non-owner
+posts behind an answerable challenge publishes the same exemption structure as one that forbids them
+outright. `description` differs by default but is operator-settable free text, so it is a hint, not a
+discriminator.
+
+So "only the owner posts here" is a **reasonable inference from the record, not a fact the record
+attests**. A client should render it as a strong hint, and find out for certain the same way it would
+for any community, by publishing and reading the verification.
+
+That is also the honest reason there is no `features.onlyOwnerCanPost`. Such a flag would be a clearer
+declaration, but it would be a claim by the same node that writes the challenge config, so it would not
+be any more verifiable. It would save the inference, not add a guarantee.
+
+Nothing enforces any of this read-side in the first place. A dishonest minter can accept a post from
+anyone, and the entry will verify like any other comment in the community it was published to.
+Owner-only posting is a property of an honest node's configuration.
 
 ### `roles` and `settings.challenges` are set in two different places
 

--- a/docs/protocol/author-communities.md
+++ b/docs/protocol/author-communities.md
@@ -220,6 +220,12 @@ is never part of an export, so the database is portable by construction.
   always derivable from `comment.signature.publicKey`, so a hint would only save a failed lookup, but
   at scale that may be worth a signed optional boolean on `AuthorPubsubSchema`. Deferred rather than
   rejected: it is permanent wire surface once published.
+- **A field saying this is a profile.** Nothing in the record declares itself a profile rather than an
+  ordinary community, and the pieces that imply one are spread across the anchor, the roles map and the
+  challenge excludes. Right now a client can do `const isAuthor = roles[community.address].role ===
+  "owner"` and it is accurate, because an ordinary community has no reason to hold the owner role over
+  its own address. Whether that is enough, or whether it deserves an explicit field, is open. Like the
+  hint above, a field is permanent wire surface once published.
 - **Delegating profile moderation** to a third party. The schema already supports it; v1 seeds the
   roles map with the owner alone.
 - **Convergence**, one name carrying both a community feed and its owner's author feed.

--- a/docs/protocol/author-communities.md
+++ b/docs/protocol/author-communities.md
@@ -16,14 +16,23 @@ Three things, none of which is a new mechanism:
 1. **The address is the author's identity key.** The community is published delegated, anchor to
    minter, where the anchor `An` is the same key the author signs comments with. See
    [delegated-ipns.md](delegated-ipns.md) for the chain, the setup calls and rotation.
-2. **Only the owner may post.** Enforced by challenge configuration, not by a feature flag. See below.
+2. **Only the owner may post.** Enforced by disabling the pubsub challenge exchange, backed by
+   challenge configuration, not by a feature flag. See below.
 3. **The feed is the owner's crossposts.** Ordinary comments carrying `comment.crosspost`, published
    by the owner's own client. See [crossposts.md](crossposts.md).
 
 ## Only the owner may post
 
-The built-in `fail` challenge exists to be paired with `exclude`: it always fails, so the only way past
-it is to be excluded. Two challenges express "the owner posts, anyone may reply":
+The default profile is **feed-only**: `settings.disablePubsubChallengeExchange` is set, so the pubsub
+challenge exchange is off and the remote publishing path does not exist. The record omits
+`pubsubTopic`, the node never subscribes to the exchange topic, and a remote publisher fails fast with
+`ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED` before anything reaches the community. The owner publishes
+over RPC to the node running the community, the one path that remains, see "How the owner publishes".
+
+A `fail` challenge excluding the owner alone backs the setting up, because the remaining path is a
+real one: the local shortcut only suppresses the pubsub echo and the challenge pipeline still runs. On
+a multi-tenant minter the challenge is what rejects the other tenants, and if the exchange is ever
+re-enabled the configuration fails closed rather than open.
 
 ```js
 await community.edit({
@@ -31,14 +40,39 @@ await community.edit({
         [An]: { role: "owner" }          // An is the anchor publicKey, see "The roles key" below
     },
     settings: {
+        disablePubsubChallengeExchange: true, // feed-only: nobody can publish over pubsub
         challenges: [
             {
                 name: "fail",
                 options: { error: "Only the owner can post to this profile." },
                 publicOptions: ["error"], // publish the rejection text, see "What a reader can actually tell"
+                exclude: [{ role: ["owner"] }]
+            }
+        ]
+    }
+})
+```
+
+### The reply-able flavor
+
+To let strangers reply, leave the exchange enabled and make the challenge configuration carry the
+whole restriction. The built-in `fail` challenge exists to be paired with `exclude`: it always fails,
+so the only way past it is to be excluded. Two challenges express "the owner posts, anyone may reply":
+
+```js
+await community.edit({
+    roles: {
+        [An]: { role: "owner" }
+    },
+    settings: {
+        challenges: [
+            {
+                name: "fail",
+                options: { error: "Only the owner can post to this profile." },
+                publicOptions: ["error"],
                 exclude: [
                     { role: ["owner"] },
-                    // no `vote`: votes are rejected by default, see below
+                    // no `vote`: votes stay rejected in this flavor too, see below
                     { publicationType: { reply: true, commentEdit: true, commentModeration: true, communityEdit: true } }
                 ]
             },
@@ -66,22 +100,29 @@ only if **all** of its conditions hold:
 A failing challenge drops any challenge still pending, so the rejected stranger is never asked the
 question: they get one immediate failed verification rather than a challenge round trip.
 
-**Votes are rejected by default.** `vote` is deliberately absent from the `publicationType` exclude,
-so a stranger's vote hits the `fail` challenge exactly like a stranger's post, while the owner's own
-votes stay excluded by `role`. The reason is the karma model in [crossposts.md](crossposts.md): karma
-over a profile is read at tier 2 from each entry's origin community, so a vote published to the
-profile lands on the crosspost copy, is tallied by the owner's own delegate, and counts toward
-nothing a client should trust. It would only accumulate a misleading second score on the copy, and it
-does not drive ranking either, since `new` is the only sort a profile feed has a reason to serve. A
-profile that wants vote-driven reply sorting can opt back in by adding `vote: true` to the exclude.
+**Votes stay rejected.** In the feed-only default nobody can send one in the first place; in this
+flavor `vote` is deliberately absent from the `publicationType` exclude, so a stranger's vote hits the
+`fail` challenge exactly like a stranger's post, while the owner's own votes stay excluded by `role`.
+The reason is the karma model in [crossposts.md](crossposts.md): karma over a profile is read at
+tier 2 from each entry's origin community, so a vote published to the profile lands on the crosspost
+copy, is tallied by the owner's own delegate, and counts toward nothing a client should trust. It
+would only accumulate a misleading second score on the copy, and it does not drive ranking either,
+since `new` is the only sort a profile feed has a reason to serve. A profile that wants vote-driven
+reply sorting can opt back in by adding `vote: true` to the exclude.
 
-Set the `error` option. It is what the rejected publisher actually sees: a `fail` challenge reports
-through `challengeErrors`, not through the verification `reason`, and its default text is the generic
-`"You're not allowed to publish."`. Naming it in `publicOptions` publishes that sentence in the record
-too, which is worth doing here: a reader then sees the intent without publishing anything. It is still
-a hint rather than an attestation, for the reason below.
+Set the `error` option, in either flavor. It is what the rejected publisher actually sees: a `fail`
+challenge reports through `challengeErrors`, not through the verification `reason`, and its default
+text is the generic `"You're not allowed to publish."`. Naming it in `publicOptions` publishes that
+sentence in the record too, which is worth doing here: a reader then sees the intent without
+publishing anything. It is still a hint rather than an attestation, for the reason below.
 
 ### What a reader can actually tell
+
+The feed-only default is legible through an absence: a record with no `pubsubTopic` tells a reader
+the challenge exchange is off, so no publisher can even open one, and honest clients fail fast rather
+than try. That is the strongest owner-only signal a profile can carry, because there is no challenge
+whose passability is left to guess at. The rest of this section is about the reply-able flavor, where
+the restriction lives in the challenge configuration and legibility gets subtler.
 
 `exclude` is copied verbatim from the private `settings.challenges` into the public signed `challenges`
 array, while `path` and `name` are stripped. `options` are private by default and leave only by name:
@@ -214,15 +255,19 @@ one community is legitimate, so idempotency belongs to whatever does the mirrori
 
 ## Two flavors
 
-**Reply-able**, the default. The challenge exchange runs, the record carries a `pubsubTopic`, and
-strangers can reply over pubsub. This needs the second challenge in the config above, or replies are
-unguarded. Strangers still cannot vote: the recommended config rejects votes regardless of flavor,
-see "Votes are rejected by default" above.
+**Feed-only**, the default. `settings.disablePubsubChallengeExchange` is set, the record omits
+`pubsubTopic`, and nobody can publish over pubsub, replies and votes included. The owner publishes
+over RPC, because that is the only remaining path, and the `fail` challenge is belt and braces rather
+than the mechanism. A profile is a broadcast of one author's activity, so this is the shape most
+profiles want, and it is also the cheapest: the node runs no exchange topic at all.
 
-**Feed-only.** Set `settings.disablePubsubChallengeExchange`. The record omits `pubsubTopic`, the node
-unsubscribes, and remote publishers fail fast with `ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED`. Nobody
-can reply, and the owner must publish over RPC, because that is the only remaining path. The `fail`
-challenge is then belt and braces rather than the mechanism.
+**Reply-able**, the opt-in. Leave the exchange enabled, so the record carries a `pubsubTopic` and
+strangers can reply over pubsub. The restriction then lives entirely in the challenge configuration
+above, which needs the second challenge or replies are unguarded. Strangers still cannot vote, see
+"Votes stay rejected" above. An owner who can only publish over pubsub themselves, such as a
+browser-only author with no RPC access to their minter, must also leave the exchange enabled; if they
+still want no replies, they drop the `publicationType` exclude and the second challenge, so the `fail`
+challenge rejects everything the owner does not sign.
 
 ## How the owner publishes
 
@@ -233,8 +278,8 @@ ephemeral key it generates covers only the outer challenge-request envelope. The
 published through a hosted service is the author, not the service.
 
 A browser-only author with no RPC access to their minter can only publish over pubsub, which is why
-the feed-only flavor is for self-hosted or RPC-reachable profiles. Multi-tenant authentication for a
-hosted minter is a service-layer concern and lives outside this repo.
+the feed-only default assumes a self-hosted or RPC-reachable profile. Multi-tenant authentication for
+a hosted minter is a service-layer concern and lives outside this repo.
 
 ## Key lifetime
 

--- a/docs/protocol/author-communities.md
+++ b/docs/protocol/author-communities.md
@@ -46,7 +46,7 @@ await community.edit({
                 name: "fail",
                 options: { error: "Only the owner can post to this profile." },
                 publicOptions: ["error"], // publish the rejection text, see "What a reader can actually tell"
-                exclude: [{ role: ["owner"] }]
+                exclude: [{ roles: ["owner"] }]
             }
         ]
     }
@@ -71,7 +71,7 @@ await community.edit({
                 options: { error: "Only the owner can post to this profile." },
                 publicOptions: ["error"],
                 exclude: [
-                    { role: ["owner"] },
+                    { roles: ["owner"] },
                     // no `vote`: votes stay rejected in this flavor too, see below
                     { publicationType: { reply: true, commentEdit: true, commentModeration: true, communityEdit: true } }
                 ]
@@ -79,7 +79,7 @@ await community.edit({
             {
                 name: "question",
                 options: { question: "...", answer: "..." },
-                exclude: [{ role: ["owner"] }]
+                exclude: [{ roles: ["owner"] }]
             }
         ]
     }
@@ -163,7 +163,7 @@ Owner-only posting is a property of an honest node's configuration.
 ### `roles` and `settings.challenges` are set in two different places
 
 `roles` is a top-level field on the **public signed record**, so it travels to readers and is what
-`exclude.role` matches against. `settings` is **private and local-only**. Both are passed through
+`exclude.roles` matches against. `settings` is **private and local-only**. Both are passed through
 `createCommunity` or `community.edit`, but only one of them is published. Setting the challenges
 without the roles is the most likely way to get this wrong, and it fails in a confusing direction:
 
@@ -180,17 +180,28 @@ rejected by their own `fail` challenge.
 
 ### The roles key
 
-`exclude.role` matches `community.roles[author.address]`, and `author.address` is `name || publicKey`.
-So the key must be whatever form the owner actually publishes under.
+`exclude.roles` does not look the publisher up by `author.address`. It walks the roles map and binds
+each key to the **signer** of the publication, the same way `isPublicationAuthorPartOfRoles` does for
+moderation authority (see the identity table in `challenge-flow.md`). Either form of the owner's
+identity is a valid key, and each one matches by its own rule:
 
-- A PKC address, an IPNS name and a community `publicKey` are all the **same base58btc peer ID**
-  (`12D3Koo...`). The key is therefore literally the string passed as `anchor.publicKey`. It is not
-  `signer.publicKey`, which is base64 raw key material.
-- If the owner publishes with `author.name` set to a domain, `author.address` is that **domain**, and
-  a peer-ID key silently fails to match. `exclude` matching is a bare map lookup with no name
-  resolution, unlike `isPublicationAuthorPartOfRoles`.
+- **The peer-ID key** (`author.publicKey`) matches when it equals the address derived from
+  `signature.publicKey`. That holds whatever `author.name` the owner sends, and it costs nothing: keys
+  are compared before any name is resolved, so an owner listed this way never waits on a resolver.
+- **The domain key** (`author.name`) matches only when the owner publishes with that exact name and
+  the name resolves, fresh, to the signer. Resolution runs regardless of `resolveAuthorNames` and
+  bypasses the cache, because a role grants authority and must reflect current state. An owner who
+  holds the domain but publishes without `author.name` does not match a domain-only map.
 
-**Put both forms in the roles map** so the owner matches either way:
+A PKC address, an IPNS name and a community `publicKey` are all the **same base58btc peer ID**
+(`12D3Koo...`), so the peer-ID key is literally the string passed as `anchor.publicKey`. It is not
+`signer.publicKey`, which is base64 raw key material. Wire fields and roles keys always carry the
+base58btc form. The base36 and base32 encodings of the same key (`k51...`, `bafz...`) only appear in
+gateway paths, and the address schema is a plain string, so a roles key copied from a gateway URL is
+accepted and never matches.
+
+Both keys can sit in the map side by side. The peer-ID key is what `createCommunity` gives an owner;
+the domain key is what an owner adds once they publish under a domain and want the record to show it:
 
 ```js
 roles: {
@@ -199,14 +210,11 @@ roles: {
 }
 ```
 
-The domain key inherits the weakness in [#267](https://github.com/pkcprotocol/pkc-js/issues/267):
-`exclude` compares a string the publisher partly controls, so a domain-keyed rule is only sound while
-`resolveAuthorNames` is on, which is the default. The peer-ID key has no such dependency, because
-`isStringDomain` forbids a raw address as an `author.name`.
-
-One further trap: the anchor schema accepts base36 and base32 CIDv1 peer-ID forms (`k51...`, `bafz...`)
-that are valid IPNS names but are not what the address derivation emits. A roles key written that way
-never matches.
+A resolver failure while matching a domain key is a non-match today: the node logs it at debug level,
+the owner's post falls through to the `fail` challenge and is rejected with the challenge's own text,
+so nothing tells a moderator that the node's `resolveAuthorNames` or `nameResolvers` are the problem.
+Surfacing that as a distinct error is tracked in
+[#353](https://github.com/pkcprotocol/pkc-js/issues/353).
 
 ## Declaring the profile to UIs
 

--- a/docs/protocol/community-architecture.md
+++ b/docs/protocol/community-architecture.md
@@ -29,7 +29,7 @@ The `CommunityIpfsType` record is what gets published to IPNS. It's the communit
 - `roles`: `{ [authorAddress]: { role: "owner" | "admin" | "moderator" } }`
 - `challenges[]`: configured challenge system
 - `features`: feature flags (requirePostLink, noVideos, etc.)
-- `suggested`: suggested client settings (primaryColor, language, etc.)
+- `suggested`: suggested client settings (primaryColor, language, uiType, etc.)
 - `encryption`: public key for encrypted challenge exchanges
 - `posts`: pre-loaded first pages + `pageCids` for pagination
 - `stats`: hourly/daily/weekly/monthly/yearly/all-time post, reply, and active user counts

--- a/docs/protocol/crossposts.md
+++ b/docs/protocol/crossposts.md
@@ -139,6 +139,35 @@ timeout: bound it yourself and treat the timeout as "unverified", not as "forged
 - Do not present the embedded record's **author** as fact either. See below.
 - Karma and deletion/removal state require tier 2 by definition.
 
+#### The three states a crosspost renders in
+
+Tier 2 has three outcomes, and they are three different things to put on screen. Naming them matters
+because the third one is the one clients get wrong.
+
+| state | condition | render as |
+|---|---|---|
+| live | `raw.commentUpdate` is defined and verifies against the community named in the embedded record, with no `removed` or `deleted` | the comment, with its score and mod state |
+| removed | same, but the update carries `removed` or `deleted` | removed or deleted by that community |
+| unknown | tier 2 never completed: the community is unreachable or gone, the update failed verification, or the wait timed out | the author-signed text, marked unverified |
+
+**Never collapse unknown into removed.** They come from opposite causes: removed is that community
+telling you something, unknown is that community telling you nothing. A client that renders both as
+`[removed]` makes an unreachable community indistinguishable from a moderating one, and makes a
+crosspost to a community that has since gone quiet look like it was taken down.
+
+Unknown is not opaque. `original.on("error", ...)` in the tier-2 snippet above carries why the fetch
+failed, so a client can say "could not reach that community" rather than showing a bare unverified
+badge, and can retry rather than treating the state as final. Absence of evidence is not evidence of
+removal, and the timeout in that snippet is a client-chosen bound, not a protocol verdict.
+
+**Karma counts live entries only**, never raw tier-1 entries. A crosspost is self-attested until tier
+2: anyone can embed a record nobody can check, so counting unverified entries makes score inflatable
+by crossposting. An entry whose update verifies is countable even if that community is permanently
+gone, since the signature attests those exact bytes regardless of who is still serving them; a client
+that wants the distinction should call it last-known rather than live.
+
+This applies to any crosspost anywhere, not only to feeds made of them.
+
 #### The embedded record's author: `crosspost.comment.author.nameResolved`
 
 Tier 1 proves who **signed** the embedded record, not who they are. `address` is derived as

--- a/docs/protocol/crossposts.md
+++ b/docs/protocol/crossposts.md
@@ -160,11 +160,14 @@ failed, so a client can say "could not reach that community" rather than showing
 badge, and can retry rather than treating the state as final. Absence of evidence is not evidence of
 removal, and the timeout in that snippet is a client-chosen bound, not a protocol verdict.
 
-**Karma counts live entries only**, never raw tier-1 entries. A crosspost is self-attested until tier
-2: anyone can embed a record nobody can check, so counting unverified entries makes score inflatable
-by crossposting. An entry whose update verifies is countable even if that community is permanently
-gone, since the signature attests those exact bytes regardless of who is still serving them; a client
-that wants the distinction should call it last-known rather than live.
+**Karma counts an entry when its `CommentUpdate` verifies and carries no `removed` or `deleted`.**
+Verification is the whole test, not liveness: the community's signature attests those exact bytes
+regardless of who is still serving them, so an entry whose update verifies counts even if that
+community is permanently gone. Last-known entries are therefore eligible, and a client that wants to
+distinguish them in the UI should still count them.
+
+Unknown entries never count. A crosspost is self-attested until tier 2, so anyone can embed a record
+nobody can check, and counting unverified entries makes score inflatable by crossposting.
 
 This applies to any crosspost anywhere, not only to feeds made of them.
 

--- a/src/community/schema.ts
+++ b/src/community/schema.ts
@@ -40,7 +40,8 @@ export const CommunitySuggestedSchema = z.looseObject({
     avatarUrl: z.string().min(1).optional(),
     bannerUrl: z.string().min(1).optional(),
     backgroundUrl: z.string().min(1).optional(),
-    language: z.string().optional()
+    language: z.string().optional(),
+    uiType: z.string().optional() // how the owner suggests clients render this community, e.g. "author" for a profile; never affects validation or loading
     // TODO: menu links, wiki pages, sidebar widgets
 });
 

--- a/test/node-and-browser/author-community/wire-legibility.test.ts
+++ b/test/node-and-browser/author-community/wire-legibility.test.ts
@@ -1,0 +1,109 @@
+// A client has to be able to tell an author community apart from an ordinary community by reading its
+// record, because owner-only posting has no feature flag and no read-side check: it is challenge
+// configuration, and the only thing that makes it legible is that `exclude` is published while `name`,
+// `path` and `options` are stripped. See docs/protocol/author-communities.md and challenge-settings.md.
+//
+// This runs in the browser and touches no network: the point is what a reader can conclude from bytes.
+// The producing half, that a real community actually puts these rules on the wire, is asserted in
+// test/node/author-community/author-community.test.ts.
+import { beforeAll, afterAll, describe, expect, it } from "vitest";
+import { clone } from "remeda";
+import signers from "../../fixtures/signers.js";
+import newFormatFixture from "../../fixtures/signatures/community/valid_community_ipfs_new_format.json" with { type: "json" };
+import { getAvailablePKCConfigsToTestAgainst } from "../../../dist/node/test/test-util.js";
+import { parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails } from "../../../dist/node/schema/schema-util.js";
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { CommunityIpfsType } from "../../../dist/node/community/types.js";
+
+const OWNER_ADDRESS = signers[0].address;
+
+// The public half of the challenge settings, i.e. what survives into the signed record. No `name`, no
+// `options`: a reader never learns that the challenge behind this is `fail`, only that a non-owner
+// posting is not excluded from whatever it is.
+const ownerOnlyPublicChallenge = {
+    exclude: [
+        { role: ["owner"] },
+        { publicationType: { reply: true, vote: true, commentEdit: true, commentModeration: true, communityEdit: true } }
+    ],
+    description: "A challenge that automatically fails with a custom error message.",
+    type: "text/plain"
+};
+
+function buildProfileRecord(): CommunityIpfsType {
+    const record = clone(newFormatFixture) as CommunityIpfsType;
+    return <CommunityIpfsType>{
+        ...record,
+        anchor: { publicKey: OWNER_ADDRESS },
+        roles: { [OWNER_ADDRESS]: { role: "owner" } },
+        challenges: [ownerOnlyPublicChallenge]
+    };
+}
+
+// What a client would implement: is this community one where only its owner posts, and who is that?
+function readOwnerOnlyPosting(record: CommunityIpfsType): { ownerOnly: boolean; owners: string[] } {
+    const ownerOnly = (record.challenges ?? []).some((challenge) => {
+        const excludes = challenge.exclude ?? [];
+        const ownerIsExcused = excludes.some((exclude) => exclude.role?.includes("owner"));
+        const repliesAreExcused = excludes.some((exclude) => exclude.publicationType?.reply === true);
+        const postsAreExcused = excludes.some((exclude) => exclude.publicationType?.post === true);
+        return ownerIsExcused && repliesAreExcused && !postsAreExcused;
+    });
+    const owners = Object.entries(record.roles ?? {})
+        .filter(([, value]) => value.role === "owner")
+        .map(([address]) => address);
+    return { ownerOnly, owners };
+}
+
+describe.concurrent("author community: the posting restriction is legible from the record alone", () => {
+    it("preserves exclude rules through the record parse", () => {
+        const parsed = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(buildProfileRecord());
+        expect(parsed.challenges[0].exclude).to.deep.equal(ownerOnlyPublicChallenge.exclude);
+    });
+
+    it("lets a reader conclude that only the owner may post, and who the owner is", () => {
+        const parsed = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(buildProfileRecord());
+        const { ownerOnly, owners } = readOwnerOnlyPosting(parsed);
+        expect(ownerOnly).to.be.true;
+        expect(owners).to.deep.equal([OWNER_ADDRESS]);
+    });
+
+    it("does not read an ordinary community as owner-only", () => {
+        const ordinary = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(clone(newFormatFixture) as CommunityIpfsType);
+        expect(readOwnerOnlyPosting(ordinary).ownerOnly).to.be.false;
+    });
+
+    // A community that excuses posts as well is not owner-only, it is unrestricted. Without this the
+    // reader above would report any community carrying a role exclude as a profile.
+    it("does not read a community that also excuses posts as owner-only", () => {
+        const record = buildProfileRecord();
+        record.challenges[0].exclude!.push({ publicationType: { post: true } });
+        const parsed = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(record);
+        expect(readOwnerOnlyPosting(parsed).ownerOnly).to.be.false;
+    });
+
+    it("carries the anchor claim, so a reader knows the address is the author's identity key", () => {
+        const parsed = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(buildProfileRecord());
+        expect(parsed.anchor).to.deep.equal({ publicKey: OWNER_ADDRESS });
+    });
+});
+
+getAvailablePKCConfigsToTestAgainst().map((config) => {
+    describe.concurrent(`author community: a loaded instance exposes the restriction - ${config.name}`, () => {
+        let pkc: PKCType;
+
+        beforeAll(async () => {
+            pkc = await config.pkcInstancePromise();
+        });
+
+        afterAll(async () => {
+            await pkc.destroy();
+        });
+
+        it("exposes challenges[].exclude and roles on the community instance", async () => {
+            const community = await pkc.createCommunity({ address: OWNER_ADDRESS });
+            community.initCommunityIpfsPropsNoMerge(buildProfileRecord());
+            expect(community.challenges[0].exclude).to.deep.equal(ownerOnlyPublicChallenge.exclude);
+            expect(community.roles?.[OWNER_ADDRESS]).to.deep.equal({ role: "owner" });
+        });
+    });
+});

--- a/test/node-and-browser/author-community/wire-legibility.test.ts
+++ b/test/node-and-browser/author-community/wire-legibility.test.ts
@@ -1,9 +1,10 @@
 // What a client can and cannot conclude about an author community by reading its record. Owner-only
-// posting has no feature flag and no read-side check: it is challenge configuration, and `exclude` is
-// published while `name` and `path` are stripped and `options` stay private unless the owner names them
-// in publicOptions. That publishes the exemption structure but not the policy, which is the distinction
-// the last test in the first block pins down. See "What a reader can actually tell" in
-// docs/protocol/author-communities.md, and challenge-settings.md.
+// posting has no feature flag and no read-side check. The feed-only default's signal is an absence,
+// no pubsubTopic, because the exchange is disabled outright. The reply-able flavor is challenge
+// configuration, and `exclude` is published while `name` and `path` are stripped and `options` stay
+// private unless the owner names them in publicOptions. That publishes the exemption structure but
+// not the policy, which is the distinction the last test in the first block pins down. See "What a
+// reader can actually tell" in docs/protocol/author-communities.md, and challenge-settings.md.
 //
 // This runs in the browser and touches no network: the point is what a reader can conclude from bytes.
 // The producing half, that a real community actually puts these rules on the wire, is asserted in
@@ -21,9 +22,10 @@ const OWNER_ADDRESS = signers[0].address;
 
 const OWNER_ONLY_ERROR = "Only the owner can post to this profile.";
 
-// No `vote` in the publicationType exclude: the recommended profile config rejects votes by default,
-// so a stranger's vote faces the gate exactly like a stranger's post. See "Votes are rejected by
-// default" in docs/protocol/author-communities.md.
+// The reply-able flavor's exclude. No `vote` in the publicationType item: votes stay rejected, so a
+// stranger's vote faces the gate exactly like a stranger's post. See "Votes stay rejected" in
+// docs/protocol/author-communities.md. The feed-only default carries a simpler signal entirely, the
+// absence of pubsubTopic, tested below.
 const ownerOnlyExclude = [
     { role: ["owner"] },
     { publicationType: { reply: true, commentEdit: true, commentModeration: true, communityEdit: true } }
@@ -66,6 +68,14 @@ function buildProfileRecord(challenge: Record<string, unknown> = ownerOnlyPublic
         challenges: [clone(challenge)],
         suggested: { uiType: "author" }
     };
+}
+
+// The feed-only default: settings.disablePubsubChallengeExchange makes the record omit pubsubTopic,
+// and the backing fail challenge excludes the owner alone rather than carving out replies.
+function buildFeedOnlyProfileRecord(): CommunityIpfsType {
+    const record = buildProfileRecord({ ...clone(ownerOnlyPublicChallenge), exclude: [{ role: ["owner"] }] });
+    delete record.pubsubTopic;
+    return record;
 }
 
 // What a client can actually implement. Note what it is NOT called: the record does not say only the
@@ -137,6 +147,22 @@ describe.concurrent("author community: what the posting restriction looks like o
         // Even the rejection text the profile opted into publishing is reproducible by the answerable
         // one, so it narrows nothing: both sides carry it and both sides remain what they were.
         expect(answerable.challenges[0].publicOptions).to.deep.equal(unpassable.challenges[0].publicOptions);
+    });
+
+    // The feed-only default's signal is an absence: no pubsubTopic means the exchange is off, nobody
+    // can publish remotely, and honest clients fail fast instead of trying. That is a stronger
+    // owner-only signal than any exclude inference, because there is no challenge whose passability
+    // is left to guess at. See "What a reader can actually tell" in the protocol doc.
+    it("reads a missing pubsubTopic as the exchange being disabled, the feed-only default", () => {
+        const feedOnly = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(buildFeedOnlyProfileRecord());
+        expect(feedOnly.pubsubTopic).to.be.undefined;
+        // an ordinary community carries one, so the absence is a real discriminator, unlike the
+        // exclude structure
+        const ordinary = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(clone(newFormatFixture) as CommunityIpfsType);
+        expect(ordinary.pubsubTopic).to.be.a("string");
+        // the exemption reader above is a reply-able-flavor tool and does not detect this shape: the
+        // role-only exclude excuses no replies, so a feed-only client must look at pubsubTopic
+        expect(readPostingExemptions(feedOnly).nonOwnerPostsAreGated).to.be.false;
     });
 
     it("carries the anchor claim, so a reader knows the address is the author's identity key", () => {

--- a/test/node-and-browser/author-community/wire-legibility.test.ts
+++ b/test/node-and-browser/author-community/wire-legibility.test.ts
@@ -1,8 +1,9 @@
 // What a client can and cannot conclude about an author community by reading its record. Owner-only
 // posting has no feature flag and no read-side check: it is challenge configuration, and `exclude` is
-// published while `name`, `path` and `options` are stripped. That publishes the exemption structure but
-// not the policy, which is the distinction the last test in the first block pins down. See "What a
-// reader can actually tell" in docs/protocol/author-communities.md, and challenge-settings.md.
+// published while `name` and `path` are stripped and `options` stay private unless the owner names them
+// in publicOptions. That publishes the exemption structure but not the policy, which is the distinction
+// the last test in the first block pins down. See "What a reader can actually tell" in
+// docs/protocol/author-communities.md, and challenge-settings.md.
 //
 // This runs in the browser and touches no network: the point is what a reader can conclude from bytes.
 // The producing half, that a real community actually puts these rules on the wire, is asserted in
@@ -18,6 +19,8 @@ import type { CommunityIpfsType } from "../../../dist/node/community/types.js";
 
 const OWNER_ADDRESS = signers[0].address;
 
+const OWNER_ONLY_ERROR = "Only the owner can post to this profile.";
+
 const ownerOnlyExclude = [
     { role: ["owner"] },
     { publicationType: { reply: true, vote: true, commentEdit: true, commentModeration: true, communityEdit: true } }
@@ -25,20 +28,27 @@ const ownerOnlyExclude = [
 
 // The public half of the challenge settings, i.e. what survives into the signed record. No `name`, no
 // `options`: a reader never learns that the challenge behind this is `fail`, only that a non-owner
-// posting is not excluded from whatever it is.
+// posting is not excluded from whatever it is. publicOptions carries the one option the profile config
+// in the doc opts into, which is the strongest hint a profile can put on the wire.
 const ownerOnlyPublicChallenge = {
     exclude: ownerOnlyExclude,
     description: "A challenge that automatically fails with a custom error message.",
-    type: "text/plain"
+    type: "text/plain",
+    publicOptions: { error: OWNER_ONLY_ERROR }
 };
 
 // The same exemption structure in front of an answerable challenge. `name` and `options` are exactly
-// what would tell these apart, and both are stripped, so this is what the limit of wire legibility
+// what would tell these apart and neither is published, so this is what the limit of wire legibility
 // looks like: a community anyone can post to after answering a question.
+//
+// It publishes the identical publicOptions on purpose. A challenge file declares its own optionInputs,
+// so a passable custom challenge may declare an `error` option and publish the same sentence. That is
+// why an opted-in option is a hint about intent and never a discriminator of policy.
 const answerablePublicChallenge = {
     exclude: ownerOnlyExclude,
     description: "Ask a question, answer it correctly to publish.",
-    type: "text/plain"
+    type: "text/plain",
+    publicOptions: { error: OWNER_ONLY_ERROR }
 };
 
 // The challenge is cloned rather than aliased: the constants above are shared across a concurrent
@@ -120,6 +130,9 @@ describe.concurrent("author community: what the posting restriction looks like o
         expect(answerable.challenges[0].description).to.not.equal(unpassable.challenges[0].description);
         expect(answerable.challenges[0]).to.not.have.property("name");
         expect(answerable.challenges[0]).to.not.have.property("options");
+        // Even the rejection text the profile opted into publishing is reproducible by the answerable
+        // one, so it narrows nothing: both sides carry it and both sides remain what they were.
+        expect(answerable.challenges[0].publicOptions).to.deep.equal(unpassable.challenges[0].publicOptions);
     });
 
     it("carries the anchor claim, so a reader knows the address is the author's identity key", () => {

--- a/test/node-and-browser/author-community/wire-legibility.test.ts
+++ b/test/node-and-browser/author-community/wire-legibility.test.ts
@@ -60,7 +60,8 @@ function buildProfileRecord(challenge: Record<string, unknown> = ownerOnlyPublic
         ...record,
         anchor: { publicKey: OWNER_ADDRESS },
         roles: { [OWNER_ADDRESS]: { role: "owner" } },
-        challenges: [clone(challenge)]
+        challenges: [clone(challenge)],
+        suggested: { uiType: "author" }
     };
 }
 
@@ -139,6 +140,16 @@ describe.concurrent("author community: what the posting restriction looks like o
         const parsed = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(buildProfileRecord());
         expect(parsed.anchor).to.deep.equal({ publicKey: OWNER_ADDRESS });
     });
+
+    // suggested.uiType is the recommended way for a client to decide how to render the record: a hint
+    // the owner sets, spoofable like `title`, with absence meaning an ordinary community. See
+    // "Declaring the profile to UIs" in docs/protocol/author-communities.md.
+    it("carries suggested.uiType through the parse, and an ordinary community carries none", () => {
+        const profile = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(buildProfileRecord());
+        expect(profile.suggested?.uiType).to.equal("author");
+        const ordinary = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(clone(newFormatFixture) as CommunityIpfsType);
+        expect(ordinary.suggested?.uiType).to.be.undefined;
+    });
 });
 
 getAvailablePKCConfigsToTestAgainst().map((config) => {
@@ -158,6 +169,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             community.initCommunityIpfsPropsNoMerge(buildProfileRecord());
             expect(community.challenges[0].exclude).to.deep.equal(ownerOnlyPublicChallenge.exclude);
             expect(community.roles?.[OWNER_ADDRESS]).to.deep.equal({ role: "owner" });
+            expect(community.suggested?.uiType).to.equal("author");
         });
     });
 });

--- a/test/node-and-browser/author-community/wire-legibility.test.ts
+++ b/test/node-and-browser/author-community/wire-legibility.test.ts
@@ -21,9 +21,12 @@ const OWNER_ADDRESS = signers[0].address;
 
 const OWNER_ONLY_ERROR = "Only the owner can post to this profile.";
 
+// No `vote` in the publicationType exclude: the recommended profile config rejects votes by default,
+// so a stranger's vote faces the gate exactly like a stranger's post. See "Votes are rejected by
+// default" in docs/protocol/author-communities.md.
 const ownerOnlyExclude = [
     { role: ["owner"] },
-    { publicationType: { reply: true, vote: true, commentEdit: true, commentModeration: true, communityEdit: true } }
+    { publicationType: { reply: true, commentEdit: true, commentModeration: true, communityEdit: true } }
 ];
 
 // The public half of the challenge settings, i.e. what survives into the signed record. No `name`, no

--- a/test/node-and-browser/author-community/wire-legibility.test.ts
+++ b/test/node-and-browser/author-community/wire-legibility.test.ts
@@ -1,7 +1,8 @@
-// A client has to be able to tell an author community apart from an ordinary community by reading its
-// record, because owner-only posting has no feature flag and no read-side check: it is challenge
-// configuration, and the only thing that makes it legible is that `exclude` is published while `name`,
-// `path` and `options` are stripped. See docs/protocol/author-communities.md and challenge-settings.md.
+// What a client can and cannot conclude about an author community by reading its record. Owner-only
+// posting has no feature flag and no read-side check: it is challenge configuration, and `exclude` is
+// published while `name`, `path` and `options` are stripped. That publishes the exemption structure but
+// not the policy, which is the distinction the last test in the first block pins down. See "What a
+// reader can actually tell" in docs/protocol/author-communities.md, and challenge-settings.md.
 //
 // This runs in the browser and touches no network: the point is what a reader can conclude from bytes.
 // The producing half, that a real community actually puts these rules on the wire, is asserted in
@@ -17,31 +18,45 @@ import type { CommunityIpfsType } from "../../../dist/node/community/types.js";
 
 const OWNER_ADDRESS = signers[0].address;
 
+const ownerOnlyExclude = [
+    { role: ["owner"] },
+    { publicationType: { reply: true, vote: true, commentEdit: true, commentModeration: true, communityEdit: true } }
+];
+
 // The public half of the challenge settings, i.e. what survives into the signed record. No `name`, no
 // `options`: a reader never learns that the challenge behind this is `fail`, only that a non-owner
 // posting is not excluded from whatever it is.
 const ownerOnlyPublicChallenge = {
-    exclude: [
-        { role: ["owner"] },
-        { publicationType: { reply: true, vote: true, commentEdit: true, commentModeration: true, communityEdit: true } }
-    ],
+    exclude: ownerOnlyExclude,
     description: "A challenge that automatically fails with a custom error message.",
     type: "text/plain"
 };
 
-function buildProfileRecord(): CommunityIpfsType {
+// The same exemption structure in front of an answerable challenge. `name` and `options` are exactly
+// what would tell these apart, and both are stripped, so this is what the limit of wire legibility
+// looks like: a community anyone can post to after answering a question.
+const answerablePublicChallenge = {
+    exclude: ownerOnlyExclude,
+    description: "Ask a question, answer it correctly to publish.",
+    type: "text/plain"
+};
+
+function buildProfileRecord(challenge: Record<string, unknown> = ownerOnlyPublicChallenge): CommunityIpfsType {
     const record = clone(newFormatFixture) as CommunityIpfsType;
     return <CommunityIpfsType>{
         ...record,
         anchor: { publicKey: OWNER_ADDRESS },
         roles: { [OWNER_ADDRESS]: { role: "owner" } },
-        challenges: [ownerOnlyPublicChallenge]
+        challenges: [challenge]
     };
 }
 
-// What a client would implement: is this community one where only its owner posts, and who is that?
-function readOwnerOnlyPosting(record: CommunityIpfsType): { ownerOnly: boolean; owners: string[] } {
-    const ownerOnly = (record.challenges ?? []).some((challenge) => {
+// What a client can actually implement. Note what it is NOT called: the record does not say only the
+// owner may post, it says non-owner posts face a challenge nobody else faces. Whether that challenge
+// is passable is not on the wire, so this reports the exemption structure and leaves the policy to be
+// inferred. See "What a reader can actually tell" in docs/protocol/author-communities.md.
+function readPostingExemptions(record: CommunityIpfsType): { nonOwnerPostsAreGated: boolean; owners: string[] } {
+    const nonOwnerPostsAreGated = (record.challenges ?? []).some((challenge) => {
         const excludes = challenge.exclude ?? [];
         const ownerIsExcused = excludes.some((exclude) => exclude.role?.includes("owner"));
         const repliesAreExcused = excludes.some((exclude) => exclude.publicationType?.reply === true);
@@ -51,34 +66,51 @@ function readOwnerOnlyPosting(record: CommunityIpfsType): { ownerOnly: boolean; 
     const owners = Object.entries(record.roles ?? {})
         .filter(([, value]) => value.role === "owner")
         .map(([address]) => address);
-    return { ownerOnly, owners };
+    return { nonOwnerPostsAreGated, owners };
 }
 
-describe.concurrent("author community: the posting restriction is legible from the record alone", () => {
+describe.concurrent("author community: what the posting restriction looks like on the wire", () => {
     it("preserves exclude rules through the record parse", () => {
         const parsed = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(buildProfileRecord());
         expect(parsed.challenges[0].exclude).to.deep.equal(ownerOnlyPublicChallenge.exclude);
     });
 
-    it("lets a reader conclude that only the owner may post, and who the owner is", () => {
+    it("lets a reader see that non-owner posts are gated, and who the owner is", () => {
         const parsed = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(buildProfileRecord());
-        const { ownerOnly, owners } = readOwnerOnlyPosting(parsed);
-        expect(ownerOnly).to.be.true;
+        const { nonOwnerPostsAreGated, owners } = readPostingExemptions(parsed);
+        expect(nonOwnerPostsAreGated).to.be.true;
         expect(owners).to.deep.equal([OWNER_ADDRESS]);
     });
 
-    it("does not read an ordinary community as owner-only", () => {
+    it("does not read an ordinary community as gating posts", () => {
         const ordinary = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(clone(newFormatFixture) as CommunityIpfsType);
-        expect(readOwnerOnlyPosting(ordinary).ownerOnly).to.be.false;
+        expect(readPostingExemptions(ordinary).nonOwnerPostsAreGated).to.be.false;
     });
 
-    // A community that excuses posts as well is not owner-only, it is unrestricted. Without this the
-    // reader above would report any community carrying a role exclude as a profile.
-    it("does not read a community that also excuses posts as owner-only", () => {
+    // A community that excuses posts as well gates nothing. Without this the reader above would report
+    // any community carrying a role exclude as a profile.
+    it("does not read a community that also excuses posts as gating them", () => {
         const record = buildProfileRecord();
         record.challenges[0].exclude!.push({ publicationType: { post: true } });
         const parsed = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(record);
-        expect(readOwnerOnlyPosting(parsed).ownerOnly).to.be.false;
+        expect(readPostingExemptions(parsed).nonOwnerPostsAreGated).to.be.false;
+    });
+
+    // The limit of wire legibility, and the reason the reader above reports an exemption structure
+    // rather than a policy. A community anyone can post to after answering a question publishes the
+    // same exclude rules as one that forbids non-owner posts outright, because `name` and `options` are
+    // exactly what would tell them apart and both are stripped. Nothing on the wire distinguishes them,
+    // so "only the owner posts here" is an inference, never a fact the record attests.
+    it("cannot distinguish an unpassable gate from an answerable one", () => {
+        const unpassable = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(buildProfileRecord(ownerOnlyPublicChallenge));
+        const answerable = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(buildProfileRecord(answerablePublicChallenge));
+
+        expect(readPostingExemptions(answerable)).to.deep.equal(readPostingExemptions(unpassable));
+        expect(answerable.challenges[0].exclude).to.deep.equal(unpassable.challenges[0].exclude);
+        // description is the only field that differs, and it is operator-settable free text
+        expect(answerable.challenges[0].description).to.not.equal(unpassable.challenges[0].description);
+        expect(answerable.challenges[0]).to.not.have.property("name");
+        expect(answerable.challenges[0]).to.not.have.property("options");
     });
 
     it("carries the anchor claim, so a reader knows the address is the author's identity key", () => {
@@ -88,7 +120,7 @@ describe.concurrent("author community: the posting restriction is legible from t
 });
 
 getAvailablePKCConfigsToTestAgainst().map((config) => {
-    describe.concurrent(`author community: a loaded instance exposes the restriction - ${config.name}`, () => {
+    describe.concurrent(`author community: a loaded instance exposes the exemption rules - ${config.name}`, () => {
         let pkc: PKCType;
 
         beforeAll(async () => {

--- a/test/node-and-browser/author-community/wire-legibility.test.ts
+++ b/test/node-and-browser/author-community/wire-legibility.test.ts
@@ -41,13 +41,16 @@ const answerablePublicChallenge = {
     type: "text/plain"
 };
 
+// The challenge is cloned rather than aliased: the constants above are shared across a concurrent
+// suite, so a record holding one by reference lets a test that mutates its own record corrupt every
+// other test's input.
 function buildProfileRecord(challenge: Record<string, unknown> = ownerOnlyPublicChallenge): CommunityIpfsType {
     const record = clone(newFormatFixture) as CommunityIpfsType;
     return <CommunityIpfsType>{
         ...record,
         anchor: { publicKey: OWNER_ADDRESS },
         roles: { [OWNER_ADDRESS]: { role: "owner" } },
-        challenges: [challenge]
+        challenges: [clone(challenge)]
     };
 }
 
@@ -94,6 +97,10 @@ describe.concurrent("author community: what the posting restriction looks like o
         record.challenges[0].exclude!.push({ publicationType: { post: true } });
         const parsed = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(record);
         expect(readPostingExemptions(parsed).nonOwnerPostsAreGated).to.be.false;
+        // A record must own its challenge. If it aliases the shared constant, this push leaks into
+        // every later test in the file and the one below silently compares two corrupted records.
+        expect(ownerOnlyPublicChallenge.exclude).to.have.lengthOf(2);
+        expect(answerablePublicChallenge.exclude).to.have.lengthOf(2);
     });
 
     // The limit of wire legibility, and the reason the reader above reports an exemption structure
@@ -105,6 +112,8 @@ describe.concurrent("author community: what the posting restriction looks like o
         const unpassable = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(buildProfileRecord(ownerOnlyPublicChallenge));
         const answerable = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(buildProfileRecord(answerablePublicChallenge));
 
+        // Asserted positively first, so this cannot pass by both sides reading as "not gated"
+        expect(readPostingExemptions(unpassable).nonOwnerPostsAreGated).to.be.true;
         expect(readPostingExemptions(answerable)).to.deep.equal(readPostingExemptions(unpassable));
         expect(answerable.challenges[0].exclude).to.deep.equal(unpassable.challenges[0].exclude);
         // description is the only field that differs, and it is operator-settable free text

--- a/test/node-and-browser/author-community/wire-legibility.test.ts
+++ b/test/node-and-browser/author-community/wire-legibility.test.ts
@@ -27,7 +27,7 @@ const OWNER_ONLY_ERROR = "Only the owner can post to this profile.";
 // docs/protocol/author-communities.md. The feed-only default carries a simpler signal entirely, the
 // absence of pubsubTopic, tested below.
 const ownerOnlyExclude = [
-    { role: ["owner"] },
+    { roles: ["owner"] },
     { publicationType: { reply: true, commentEdit: true, commentModeration: true, communityEdit: true } }
 ];
 
@@ -73,7 +73,7 @@ function buildProfileRecord(challenge: Record<string, unknown> = ownerOnlyPublic
 // The feed-only default: settings.disablePubsubChallengeExchange makes the record omit pubsubTopic,
 // and the backing fail challenge excludes the owner alone rather than carving out replies.
 function buildFeedOnlyProfileRecord(): CommunityIpfsType {
-    const record = buildProfileRecord({ ...clone(ownerOnlyPublicChallenge), exclude: [{ role: ["owner"] }] });
+    const record = buildProfileRecord({ ...clone(ownerOnlyPublicChallenge), exclude: [{ roles: ["owner"] }] });
     delete record.pubsubTopic;
     return record;
 }
@@ -85,7 +85,7 @@ function buildFeedOnlyProfileRecord(): CommunityIpfsType {
 function readPostingExemptions(record: CommunityIpfsType): { nonOwnerPostsAreGated: boolean; owners: string[] } {
     const nonOwnerPostsAreGated = (record.challenges ?? []).some((challenge) => {
         const excludes = challenge.exclude ?? [];
-        const ownerIsExcused = excludes.some((exclude) => exclude.role?.includes("owner"));
+        const ownerIsExcused = excludes.some((exclude) => exclude.roles?.includes("owner"));
         const repliesAreExcused = excludes.some((exclude) => exclude.publicationType?.reply === true);
         const postsAreExcused = excludes.some((exclude) => exclude.publicationType?.post === true);
         return ownerIsExcused && repliesAreExcused && !postsAreExcused;

--- a/test/node/author-community/author-community.test.ts
+++ b/test/node/author-community/author-community.test.ts
@@ -122,6 +122,9 @@ function ownerOnlyPostingChallenge(): CommunityChallengeSetting {
     return {
         name: "fail",
         options: { error: OWNER_ONLY_ERROR },
+        // Options are private by default. Naming `error` here publishes that one value, so a reader sees
+        // the rejection text without publishing anything. It is a hint, not proof: see the wire test below.
+        publicOptions: ["error"],
         exclude: [
             { role: ["owner"] },
             { publicationType: { reply: true, vote: true, commentEdit: true, commentModeration: true, communityEdit: true } }
@@ -259,6 +262,13 @@ describe.sequential("author community: a community configured as a profile", () 
             expect(published).to.not.have.property("path");
             // options carries the error text and, for other challenges, the answer
             expect(published).to.not.have.property("options");
+        });
+
+        // Only what the owner named in publicOptions crosses the boundary, and it crosses as a separate
+        // field. A profile publishing its rejection text is the whole reason this config sets it.
+        it("publishes only the option the owner opted into, under publicOptions", () => {
+            const published = community.raw.communityIpfs!.challenges[0];
+            expect(published.publicOptions).to.deep.equal({ error: OWNER_ONLY_ERROR });
         });
     });
 

--- a/test/node/author-community/author-community.test.ts
+++ b/test/node/author-community/author-community.test.ts
@@ -3,9 +3,10 @@
 // docs/protocol/author-communities.md.
 //
 // The point of this file is that none of that needs new machinery: the delegated community comes from
-// #237, owner-only posting is the built-in `fail` challenge paired with an `exclude`, and the feed is
-// ordinary comments carrying `comment.crosspost` from #32. If any of those seams stop composing, these
-// tests fail even though nothing named "author community" exists in src/.
+// #237, owner-only posting is settings.disablePubsubChallengeExchange (#229) backed by the built-in
+// `fail` challenge paired with an `exclude`, and the feed is ordinary comments carrying
+// `comment.crosspost` from #32. If any of those seams stop composing, these tests fail even though
+// nothing named "author community" exists in src/.
 //
 // These run under RPC too. The owner's role is matched against a domain in one case, and name
 // resolution happens wherever the community lives, so under RPC this file stands up its own RPC server
@@ -117,19 +118,30 @@ async function createHarness(): Promise<{ pkc: PKCType; teardown: () => Promise<
     };
 }
 
-// The two excludes that express "the owner posts, anyone may reply". An exclude array matches if ANY
-// item matches, and an item matches only if ALL of its conditions hold, so the `fail` challenge runs
-// for exactly two cases: a non-owner publishing a post, and a non-owner publishing a vote. `vote` is
-// deliberately absent from the publicationType exclude: profile karma is read from each entry's origin
-// community at tier 2, so a vote on the copy would be tallied by the owner's own delegate and count
-// toward nothing. See "Votes are rejected by default" in the protocol doc.
-function ownerOnlyPostingChallenge(): CommunityChallengeSetting {
+// The default (feed-only) config's challenge: `fail` excluding the owner alone, backing up
+// settings.disablePubsubChallengeExchange. The setting removes the remote publishing path, but the
+// challenge pipeline still runs on the local/RPC shortcut, so this is what rejects everyone but the
+// owner on the one path that remains.
+function ownerOnlyChallenge(): CommunityChallengeSetting {
     return {
         name: "fail",
         options: { error: OWNER_ONLY_ERROR },
         // Options are private by default. Naming `error` here publishes that one value, so a reader sees
         // the rejection text without publishing anything. It is a hint, not proof: see the wire test below.
         publicOptions: ["error"],
+        exclude: [{ role: ["owner"] }]
+    };
+}
+
+// The reply-able flavor keeps the exchange on and narrows the `fail` challenge instead. An exclude
+// array matches if ANY item matches, and an item matches only if ALL of its conditions hold, so the
+// challenge runs for exactly two cases: a non-owner publishing a post, and a non-owner publishing a
+// vote. `vote` is deliberately absent from the publicationType exclude: profile karma is read from
+// each entry's origin community at tier 2, so a vote on the copy would be tallied by the owner's own
+// delegate and count toward nothing. See "Votes stay rejected" in the protocol doc.
+function replyAbleChallenge(): CommunityChallengeSetting {
+    return {
+        ...ownerOnlyChallenge(),
         exclude: [
             { role: ["owner"] },
             { publicationType: { reply: true, commentEdit: true, commentModeration: true, communityEdit: true } }
@@ -173,11 +185,13 @@ describe.sequential("author community: a community configured as a profile", () 
         community = await createSubWithNoChallenge({ anchor: { publicKey: anchorSigner.address } }, pkc);
         minterAddress = community.signer.address;
 
-        // Both roles keys, because exclude.role matches community.roles[author.address] and
-        // author.address is `name || publicKey`. See "The roles key" in the protocol doc.
+        // The default feed-only config from the protocol doc: the exchange is disabled, so every
+        // publish in this suite goes through the local/RPC shortcut, where the challenge pipeline
+        // still runs. Both roles keys, because exclude.role matches community.roles[author.address]
+        // and author.address is `name || publicKey`. See "The roles key" in the protocol doc.
         await community.edit({
             roles: { [anchorSigner.address]: { role: "owner" }, [OWNER_DOMAIN]: { role: "owner" } },
-            settings: { ...community.settings, challenges: [ownerOnlyPostingChallenge()] }
+            settings: { ...community.settings, disablePubsubChallengeExchange: true, challenges: [ownerOnlyChallenge()] }
         });
         await startProfile(community, anchorSigner);
     });
@@ -231,22 +245,24 @@ describe.sequential("author community: a community configured as a profile", () 
             expect(verification.challengeErrors?.["0"]).to.equal(OWNER_ONLY_ERROR);
         });
 
-        // The second exclude is what keeps the profile reply-able: only posts are owner-only.
-        it("accepts a stranger's reply", async () => {
+        // The role exclude is the only exclude, so the feed-only default is owner-only for every
+        // publication type, replies included. Replying is the reply-able flavor's opt-in, below.
+        it("rejects a stranger's reply with the same error", async () => {
             const ownerPost = await publishRandomPost({
                 communityAddress: community.address,
                 pkc,
                 postProps: { signer: anchorSigner }
             });
             const reply = await generateMockComment(ownerPost as CommentIpfsWithCidDefined, pkc, false);
-            await publishWithExpectedResult({ publication: reply, expectedChallengeSuccess: true });
+            const verification = await publishAndCaptureVerification(reply);
+            expect(verification.challengeSuccess).to.be.false;
+            expect(verification.challengeErrors?.["0"]).to.equal(OWNER_ONLY_ERROR);
         });
     });
 
-    // Votes are rejected by default: `vote` is deliberately absent from the publicationType exclude, so
-    // a stranger's vote hits the `fail` challenge exactly like a stranger's post, while the owner stays
-    // excluded by role. See "Votes are rejected by default" in the protocol doc for why a vote on a
-    // profile copy counts toward nothing.
+    // Votes stay rejected: under the default config a stranger's vote hits the `fail` challenge
+    // exactly like a stranger's post, while the owner stays excluded by role. See "Votes stay
+    // rejected" in the protocol doc for why a vote on a profile copy counts toward nothing.
     describe("votes are rejected by default", () => {
         let ownerPost: Comment;
 
@@ -271,15 +287,73 @@ describe.sequential("author community: a community configured as a profile", () 
         });
     });
 
+    // The reply-able opt-in: the exchange stays on and the publicationType exclude is what keeps
+    // replies open while posts and votes stay owner-only. See "The reply-able flavor" in the doc.
+    describe("the reply-able flavor", () => {
+        let replyAbleCommunity: ProfileCommunity;
+        let replyAbleAnchor: SignerType;
+        let ownerPost: Comment;
+
+        beforeAll(async () => {
+            replyAbleAnchor = await createSigner();
+            replyAbleCommunity = await createSubWithNoChallenge({ anchor: { publicKey: replyAbleAnchor.address } }, pkc);
+            await replyAbleCommunity.edit({
+                roles: { [replyAbleAnchor.address]: { role: "owner" } },
+                settings: { ...replyAbleCommunity.settings, challenges: [replyAbleChallenge()] }
+            });
+            await startProfile(replyAbleCommunity, replyAbleAnchor);
+            ownerPost = await publishRandomPost({
+                communityAddress: replyAbleCommunity.address,
+                pkc,
+                postProps: { signer: replyAbleAnchor }
+            });
+        });
+
+        afterAll(async () => {
+            await replyAbleCommunity.delete();
+        });
+
+        it("carries a pubsubTopic, since the exchange stays enabled", () => {
+            expect(replyAbleCommunity.raw.communityIpfs!.pubsubTopic).to.be.a("string");
+        });
+
+        // The second exclude is what keeps this flavor reply-able: only posts and votes are owner-only.
+        it("accepts a stranger's reply", async () => {
+            const reply = await generateMockComment(ownerPost as CommentIpfsWithCidDefined, pkc, false);
+            await publishWithExpectedResult({ publication: reply, expectedChallengeSuccess: true });
+        });
+
+        it("rejects a stranger's post with the configured error", async () => {
+            const post = await generateMockPost({ communityAddress: replyAbleCommunity.address, pkc });
+            const verification = await publishAndCaptureVerification(post);
+            expect(verification.challengeSuccess).to.be.false;
+            expect(verification.challengeErrors?.["0"]).to.equal(OWNER_ONLY_ERROR);
+        });
+
+        it("still rejects a stranger's vote", async () => {
+            const vote = await generateMockVote(ownerPost as CommentIpfsWithCidDefined, 1, pkc);
+            const verification = await publishAndCaptureVerification(vote);
+            expect(verification.challengeSuccess).to.be.false;
+            expect(verification.challengeErrors?.["0"]).to.equal(OWNER_ONLY_ERROR);
+        });
+    });
+
     // This is the assertion the whole design rests on. Owner-only posting has no feature flag and no
     // read-side check, so a client can only know a community is a profile by reading the exclude rules
     // off the record. If exclude ever stops being copied into the public challenges array, the
     // restriction becomes invisible and nothing else in the suite would catch it.
     describe("the restriction is legible on the wire", () => {
+        // The feed-only default's strongest signal: a record with no pubsubTopic tells a reader the
+        // exchange is off, so no publisher can even open one. See "What a reader can actually tell".
+        it("publishes no pubsubTopic, which is what tells a reader the exchange is disabled", () => {
+            expect(community.raw.communityIpfs!.pubsubTopic).to.be.undefined;
+            expect("pubsubTopic" in community.raw.communityIpfs!).to.be.false;
+        });
+
         it("publishes the exclude rules verbatim in the signed record", () => {
             const published = community.raw.communityIpfs!.challenges;
             expect(published).to.have.lengthOf(1);
-            expect(published[0].exclude).to.deep.equal(ownerOnlyPostingChallenge().exclude);
+            expect(published[0].exclude).to.deep.equal(ownerOnlyChallenge().exclude);
         });
 
         it("publishes the roles map, which is what exclude.role is matched against", () => {
@@ -397,7 +471,7 @@ describe.sequential("author community: a community configured as a profile", () 
             // isPublicationAuthorPartOfRoles, so publishing under a domain misses this entirely.
             await peerIdOnlyCommunity.edit({
                 roles: { [otherAnchor.address]: { role: "owner" } },
-                settings: { ...peerIdOnlyCommunity.settings, challenges: [ownerOnlyPostingChallenge()] }
+                settings: { ...peerIdOnlyCommunity.settings, challenges: [ownerOnlyChallenge()] }
             });
             await startProfile(peerIdOnlyCommunity, otherAnchor);
         });

--- a/test/node/author-community/author-community.test.ts
+++ b/test/node/author-community/author-community.test.ts
@@ -26,6 +26,7 @@ import {
     createSubWithNoChallenge,
     generateMockComment,
     generateMockPost,
+    generateMockVote,
     isRpcFlagOn,
     mockPKC,
     mockRpcServerForTests,
@@ -37,6 +38,7 @@ import {
 import { createAnchorIpnsRecord, createSigner } from "../../../dist/node/signer/index.js";
 import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
 import type { Comment } from "../../../dist/node/publications/comment/comment.js";
+import type Vote from "../../../dist/node/publications/vote/vote.js";
 import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
 import type { RpcLocalCommunity } from "../../../dist/node/community/rpc-local-community.js";
 import type { CommentIpfsWithCidDefined } from "../../../dist/node/publications/comment/types.js";
@@ -117,7 +119,10 @@ async function createHarness(): Promise<{ pkc: PKCType; teardown: () => Promise<
 
 // The two excludes that express "the owner posts, anyone may reply". An exclude array matches if ANY
 // item matches, and an item matches only if ALL of its conditions hold, so the `fail` challenge runs
-// for exactly one case: a non-owner publishing a post.
+// for exactly two cases: a non-owner publishing a post, and a non-owner publishing a vote. `vote` is
+// deliberately absent from the publicationType exclude: profile karma is read from each entry's origin
+// community at tier 2, so a vote on the copy would be tallied by the owner's own delegate and count
+// toward nothing. See "Votes are rejected by default" in the protocol doc.
 function ownerOnlyPostingChallenge(): CommunityChallengeSetting {
     return {
         name: "fail",
@@ -127,14 +132,14 @@ function ownerOnlyPostingChallenge(): CommunityChallengeSetting {
         publicOptions: ["error"],
         exclude: [
             { role: ["owner"] },
-            { publicationType: { reply: true, vote: true, commentEdit: true, commentModeration: true, communityEdit: true } }
+            { publicationType: { reply: true, commentEdit: true, commentModeration: true, communityEdit: true } }
         ]
     };
 }
 
 // A `fail` challenge reports through challengeErrors, not through the verification `reason`, so
 // publishWithExpectedResult's expectedReason cannot see it.
-async function publishAndCaptureVerification(publication: Comment): Promise<DecryptedChallengeVerificationMessageType> {
+async function publishAndCaptureVerification(publication: Comment | Vote): Promise<DecryptedChallengeVerificationMessageType> {
     const verification = new Promise<DecryptedChallengeVerificationMessageType>((resolve, reject) => {
         publication.once("challengeverification", resolve);
         publication.once("error", reject);
@@ -235,6 +240,34 @@ describe.sequential("author community: a community configured as a profile", () 
             });
             const reply = await generateMockComment(ownerPost as CommentIpfsWithCidDefined, pkc, false);
             await publishWithExpectedResult({ publication: reply, expectedChallengeSuccess: true });
+        });
+    });
+
+    // Votes are rejected by default: `vote` is deliberately absent from the publicationType exclude, so
+    // a stranger's vote hits the `fail` challenge exactly like a stranger's post, while the owner stays
+    // excluded by role. See "Votes are rejected by default" in the protocol doc for why a vote on a
+    // profile copy counts toward nothing.
+    describe("votes are rejected by default", () => {
+        let ownerPost: Comment;
+
+        beforeAll(async () => {
+            ownerPost = await publishRandomPost({
+                communityAddress: community.address,
+                pkc,
+                postProps: { signer: anchorSigner }
+            });
+        });
+
+        it("rejects a stranger's vote with the configured error", async () => {
+            const vote = await generateMockVote(ownerPost as CommentIpfsWithCidDefined, 1, pkc);
+            const verification = await publishAndCaptureVerification(vote);
+            expect(verification.challengeSuccess).to.be.false;
+            expect(verification.challengeErrors?.["0"]).to.equal(OWNER_ONLY_ERROR);
+        });
+
+        it("accepts the owner's vote, matched on the role exclude", async () => {
+            const vote = await generateMockVote(ownerPost as CommentIpfsWithCidDefined, 1, pkc, anchorSigner);
+            await publishWithExpectedResult({ publication: vote, expectedChallengeSuccess: true });
         });
     });
 

--- a/test/node/author-community/author-community.test.ts
+++ b/test/node/author-community/author-community.test.ts
@@ -1,0 +1,276 @@
+// An author community (issue #31) is an ordinary community addressed by the author's identity key,
+// configured so only its owner can post, whose feed is the owner's crossposts. See
+// docs/protocol/author-communities.md.
+//
+// The point of this file is that none of that needs new machinery: the delegated community comes from
+// #237, owner-only posting is the built-in `fail` challenge paired with an `exclude`, and the feed is
+// ordinary comments carrying `comment.crosspost` from #32. If any of those seams stop composing, these
+// tests fail even though nothing named "author community" exists in src/.
+//
+// Naming follows docs/protocol/delegated-ipns.md: An/As = anchor keypair (the author's identity, held
+// by the owner), Mn/Ms = minter keypair (held by the node).
+import { beforeAll, afterAll, describe, expect, it } from "vitest";
+import {
+    createMockNameResolver,
+    createSubWithNoChallenge,
+    generateMockComment,
+    generateMockPost,
+    mockPKC,
+    publishRandomPost,
+    publishWithExpectedResult,
+    resolveWhenConditionIsTrue
+} from "../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { createAnchorIpnsRecord } from "../../../dist/node/signer/index.js";
+import type { PKC } from "../../../dist/node/pkc/pkc.js";
+import type { Comment } from "../../../dist/node/publications/comment/comment.js";
+import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
+import type { CommentIpfsWithCidDefined } from "../../../dist/node/publications/comment/types.js";
+import type { CommunityChallengeSetting } from "../../../dist/node/community/types.js";
+import type { SignerType } from "../../../dist/node/signer/types.js";
+import type { DecryptedChallengeVerificationMessageType } from "../../../dist/node/pubsub-messages/types.js";
+
+const OWNER_DOMAIN = "author-community-owner.bso";
+const OWNER_ONLY_ERROR = "Only the owner can post to this profile.";
+
+// The two excludes that express "the owner posts, anyone may reply". An exclude array matches if ANY
+// item matches, and an item matches only if ALL of its conditions hold, so the `fail` challenge runs
+// for exactly one case: a non-owner publishing a post.
+function ownerOnlyPostingChallenge(): CommunityChallengeSetting {
+    return {
+        name: "fail",
+        options: { error: OWNER_ONLY_ERROR },
+        exclude: [
+            { role: ["owner"] },
+            { publicationType: { reply: true, vote: true, commentEdit: true, commentModeration: true, communityEdit: true } }
+        ]
+    };
+}
+
+// A `fail` challenge reports through challengeErrors, not through the verification `reason`, so
+// publishWithExpectedResult's expectedReason cannot see it.
+async function publishAndCaptureVerification(publication: Comment): Promise<DecryptedChallengeVerificationMessageType> {
+    const verification = new Promise<DecryptedChallengeVerificationMessageType>((resolve, reject) => {
+        publication.once("challengeverification", resolve);
+        publication.once("error", reject);
+    });
+    await publication.publish();
+    return verification;
+}
+
+// Skipped under RPC: the community runs on the RPC server, which has its own PKC and therefore not the
+// mock name resolver constructed here, so checkAuthorIdentity on the server cannot resolve the owner's
+// domain and the domain-keyed role case would fail for an unrelated reason. The RPC dimension of
+// delegation setup is covered by test/node/community/delegation-setup.test.ts.
+describeSkipIfRpc.sequential("author community: a community configured as a profile", () => {
+    let pkc: PKC;
+    let anchorSigner: SignerType; // As stays in the test; the node never receives it
+    let community: LocalCommunity;
+    let minterAddress: string;
+    const resolverRecords = new Map<string, string>();
+
+    beforeAll(async () => {
+        pkc = await mockPKC({ nameResolvers: [createMockNameResolver({ records: resolverRecords })] });
+        anchorSigner = await pkc.createSigner();
+        resolverRecords.set(OWNER_DOMAIN, anchorSigner.address);
+
+        community = <LocalCommunity>await createSubWithNoChallenge({ anchor: { publicKey: anchorSigner.address } }, pkc);
+        minterAddress = community.signer.address;
+
+        // Both roles keys, because exclude.role matches community.roles[author.address] and
+        // author.address is `name || publicKey`. See "The roles key" in the protocol doc.
+        await community.edit({
+            roles: { [anchorSigner.address]: { role: "owner" }, [OWNER_DOMAIN]: { role: "owner" } },
+            settings: { ...community.settings, challenges: [ownerOnlyPostingChallenge()] }
+        });
+
+        // A delegated community refuses to start until its anchor record is published (#234). The first
+        // record is signed at sequence 0, since there is no prior sequence to discover.
+        await community.publishAnchorRecord(await createAnchorIpnsRecord({ anchorSigner, minterIpnsName: minterAddress, sequence: 0 }));
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    describe("identity is the author's key", () => {
+        it("is addressed by the anchor, not by the minter that signs its record", () => {
+            expect(community.address).to.equal(anchorSigner.address);
+            expect(community.publicKey).to.equal(anchorSigner.address);
+            expect(minterAddress).to.not.equal(anchorSigner.address);
+        });
+
+        it("publishes the signed anchor claim, so a reader can recover the identity", () => {
+            expect(community.raw.communityIpfs!.anchor).to.deep.equal({ publicKey: anchorSigner.address });
+            expect(community.raw.communityIpfs!.signature.signedPropertyNames).to.include("anchor");
+        });
+    });
+
+    describe("only the owner may post", () => {
+        it("accepts the owner's post, matched on the peer-id roles key", async () => {
+            const post = await generateMockPost({ communityAddress: community.address, pkc, postProps: { signer: anchorSigner } });
+            await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+        });
+
+        // author.address becomes the domain once author.name is set, so this exercises the other roles
+        // key. checkAuthorIdentity resolves the domain and compares it against the signer first.
+        it("accepts the owner's post when they publish under their domain, matched on the domain roles key", async () => {
+            const post = await generateMockPost({
+                communityAddress: community.address,
+                pkc,
+                postProps: { signer: anchorSigner, author: { name: OWNER_DOMAIN } }
+            });
+            await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+        });
+
+        it("rejects a stranger's post with the configured error", async () => {
+            const post = await generateMockPost({ communityAddress: community.address, pkc });
+            const verification = await publishAndCaptureVerification(post);
+            expect(verification.challengeSuccess).to.be.false;
+            expect(verification.challengeErrors?.["0"]).to.equal(OWNER_ONLY_ERROR);
+        });
+
+        // The second exclude is what keeps the profile reply-able: only posts are owner-only.
+        it("accepts a stranger's reply", async () => {
+            const ownerPost = await publishRandomPost({
+                communityAddress: community.address,
+                pkc,
+                postProps: { signer: anchorSigner }
+            });
+            const reply = await generateMockComment(ownerPost as CommentIpfsWithCidDefined, pkc, false);
+            await publishWithExpectedResult({ publication: reply, expectedChallengeSuccess: true });
+        });
+    });
+
+    // This is the assertion the whole design rests on. Owner-only posting has no feature flag and no
+    // read-side check, so a client can only know a community is a profile by reading the exclude rules
+    // off the record. If exclude ever stops being copied into the public challenges array, the
+    // restriction becomes invisible and nothing else in the suite would catch it.
+    describe("the restriction is legible on the wire", () => {
+        it("publishes the exclude rules verbatim in the signed record", () => {
+            const published = community.raw.communityIpfs!.challenges;
+            expect(published).to.have.lengthOf(1);
+            expect(published[0].exclude).to.deep.equal(ownerOnlyPostingChallenge().exclude);
+        });
+
+        it("publishes the roles map, which is what exclude.role is matched against", () => {
+            expect(community.raw.communityIpfs!.roles).to.deep.equal({
+                [anchorSigner.address]: { role: "owner" },
+                [OWNER_DOMAIN]: { role: "owner" }
+            });
+        });
+
+        it("strips the private half of the challenge settings", () => {
+            const published = community.raw.communityIpfs!.challenges[0];
+            expect(published).to.not.have.property("name");
+            expect(published).to.not.have.property("path");
+            // options carries the error text and, for other challenges, the answer
+            expect(published).to.not.have.property("options");
+        });
+    });
+
+    describe("the feed is the owner's crossposts", () => {
+        let originCommunity: LocalCommunity;
+        let crosspostingPost: Comment;
+
+        beforeAll(async () => {
+            originCommunity = <LocalCommunity>await createSubWithNoChallenge({}, pkc);
+            await originCommunity.start();
+            await resolveWhenConditionIsTrue({
+                toUpdate: originCommunity,
+                predicate: async () => typeof originCommunity.updatedAt === "number"
+            });
+        });
+
+        afterAll(async () => {
+            await originCommunity.delete();
+        });
+
+        it("accepts a crosspost of the owner's comment in another community", async () => {
+            const original = await publishRandomPost({
+                communityAddress: originCommunity.address,
+                pkc,
+                postProps: { signer: anchorSigner }
+            });
+            crosspostingPost = await generateMockPost({
+                communityAddress: community.address,
+                pkc,
+                postProps: { signer: anchorSigner, crosspost: { cid: original.cid!, comment: original.raw.comment! } }
+            });
+            await publishWithExpectedResult({ publication: crosspostingPost, expectedChallengeSuccess: true });
+            expect(crosspostingPost.cid).to.be.a("string");
+        });
+
+        // The community verifies its own record, pages included, before publishing it
+        // (_validateCommunitySizeSchemaAndSignatureBeforePublishing -> verifyCommunity -> verifyPage), so
+        // a feed of crossposts reaching the wire at all is the shared page verifier accepting it with no
+        // author-community special casing.
+        it("carries the crosspost into the published feed, through the shared page verifier", async () => {
+            await resolveWhenConditionIsTrue({
+                toUpdate: community,
+                predicate: async () =>
+                    Object.values(community.posts.pages).some((page) =>
+                        page?.comments.some((pageComment) => pageComment.cid === crosspostingPost.cid)
+                    )
+            });
+
+            const pageComment = Object.values(community.posts.pages)
+                .flatMap((page) => page?.comments ?? [])
+                .find((comment) => comment.cid === crosspostingPost.cid);
+            expect(pageComment).to.not.be.undefined;
+            expect(pageComment!.crosspost?.cid).to.equal(crosspostingPost.raw.comment!.crosspost!.cid);
+        });
+    });
+});
+
+// The failure mode the protocol doc warns about: the excludes are configured, the roles map exists, but
+// it is keyed on a form the owner does not publish under. Everything looks correct until the first post.
+describeSkipIfRpc.sequential("author community: a roles map keyed on the wrong form locks the owner out", () => {
+    let pkc: PKC;
+    let anchorSigner: SignerType;
+    let community: LocalCommunity;
+    const resolverRecords = new Map<string, string>();
+
+    beforeAll(async () => {
+        pkc = await mockPKC({ nameResolvers: [createMockNameResolver({ records: resolverRecords })] });
+        anchorSigner = await pkc.createSigner();
+        resolverRecords.set(OWNER_DOMAIN, anchorSigner.address);
+
+        community = <LocalCommunity>await createSubWithNoChallenge({ anchor: { publicKey: anchorSigner.address } }, pkc);
+        // Only the peer-id key. exclude.role does a bare map lookup with no name resolution, unlike
+        // isPublicationAuthorPartOfRoles, so publishing under a domain misses this entirely.
+        await community.edit({
+            roles: { [anchorSigner.address]: { role: "owner" } },
+            settings: { ...community.settings, challenges: [ownerOnlyPostingChallenge()] }
+        });
+        await community.publishAnchorRecord(
+            await createAnchorIpnsRecord({ anchorSigner, minterIpnsName: community.signer.address, sequence: 0 })
+        );
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+    });
+
+    afterAll(async () => {
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("rejects the owner's own post when they publish under a domain the roles map does not carry", async () => {
+        const post = await generateMockPost({
+            communityAddress: community.address,
+            pkc,
+            postProps: { signer: anchorSigner, author: { name: OWNER_DOMAIN } }
+        });
+        const verification = await publishAndCaptureVerification(post);
+        expect(verification.challengeSuccess).to.be.false;
+        expect(verification.challengeErrors?.["0"]).to.equal(OWNER_ONLY_ERROR);
+    });
+
+    it("accepts the same owner publishing without a name, which matches the peer-id key", async () => {
+        const post = await generateMockPost({ communityAddress: community.address, pkc, postProps: { signer: anchorSigner } });
+        await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+    });
+});

--- a/test/node/author-community/author-community.test.ts
+++ b/test/node/author-community/author-community.test.ts
@@ -15,8 +15,10 @@
 // Naming follows docs/protocol/delegated-ipns.md: An/As = anchor keypair (the author's identity, held
 // by the owner), Mn/Ms = minter keypair (held by the node).
 import { beforeAll, afterAll, describe, expect, it } from "vitest";
+import fs from "fs";
 import path from "path";
 import net from "node:net";
+import { v4 as uuidv4 } from "uuid";
 import PKC from "../../../dist/node/index.js";
 import PKCWsServer from "../../../dist/node/rpc/src/index.js";
 import {
@@ -83,10 +85,11 @@ async function createHarness(): Promise<{ pkc: PKCType; teardown: () => Promise<
         return { pkc, teardown: async () => await pkc.destroy() };
     }
 
-    const serverPKC = await mockRpcServerPKC({
-        dataPath: path.join(process.cwd(), ".tmp", "pkc-rpc-author-community"),
-        nameResolvers
-    });
+    // A fresh dataPath per run. This suite creates communities on the server, so a fixed path would
+    // accumulate them across runs, and any run that dies before afterAll leaves a started community
+    // behind for the next server to resume at startup, which eventually times out the beforeAll hook.
+    const dataPath = path.join(process.cwd(), ".tmp", `pkc-rpc-author-community-${uuidv4()}`);
+    const serverPKC = await mockRpcServerPKC({ dataPath, nameResolvers });
     const rpcPort = await getAvailablePort();
     const rpcUrl = `ws://localhost:${rpcPort}`;
     const rpcServer: PKCWsServerType = await PKCWsServer.PKCWsServer({
@@ -107,6 +110,7 @@ async function createHarness(): Promise<{ pkc: PKCType; teardown: () => Promise<
         teardown: async () => {
             await pkc.destroy();
             await rpcServer.destroy();
+            fs.rmSync(dataPath, { recursive: true, force: true });
         }
     };
 }

--- a/test/node/author-community/author-community.test.ts
+++ b/test/node/author-community/author-community.test.ts
@@ -7,31 +7,109 @@
 // ordinary comments carrying `comment.crosspost` from #32. If any of those seams stop composing, these
 // tests fail even though nothing named "author community" exists in src/.
 //
+// These run under RPC too. The owner's role is matched against a domain in one case, and name
+// resolution happens wherever the community lives, so under RPC this file stands up its own RPC server
+// with the mock resolver on the SERVER pkc. Pointing at the shared test server instead would leave the
+// server unable to resolve a domain minted in this process, which would look like a role mismatch.
+//
 // Naming follows docs/protocol/delegated-ipns.md: An/As = anchor keypair (the author's identity, held
 // by the owner), Mn/Ms = minter keypair (held by the node).
 import { beforeAll, afterAll, describe, expect, it } from "vitest";
+import path from "path";
+import net from "node:net";
+import PKC from "../../../dist/node/index.js";
+import PKCWsServer from "../../../dist/node/rpc/src/index.js";
 import {
     createMockNameResolver,
     createSubWithNoChallenge,
     generateMockComment,
     generateMockPost,
+    isRpcFlagOn,
     mockPKC,
+    mockRpcServerForTests,
+    mockRpcServerPKC,
     publishRandomPost,
     publishWithExpectedResult,
     resolveWhenConditionIsTrue
 } from "../../../dist/node/test/test-util.js";
-import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
-import { createAnchorIpnsRecord } from "../../../dist/node/signer/index.js";
-import type { PKC } from "../../../dist/node/pkc/pkc.js";
+import { createAnchorIpnsRecord, createSigner } from "../../../dist/node/signer/index.js";
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
 import type { Comment } from "../../../dist/node/publications/comment/comment.js";
 import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
+import type { RpcLocalCommunity } from "../../../dist/node/community/rpc-local-community.js";
 import type { CommentIpfsWithCidDefined } from "../../../dist/node/publications/comment/types.js";
 import type { CommunityChallengeSetting } from "../../../dist/node/community/types.js";
 import type { SignerType } from "../../../dist/node/signer/types.js";
 import type { DecryptedChallengeVerificationMessageType } from "../../../dist/node/pubsub-messages/types.js";
 
+type PKCWsServerType = Awaited<ReturnType<typeof PKCWsServer.PKCWsServer>>;
+type ProfileCommunity = LocalCommunity | RpcLocalCommunity;
+
 const OWNER_DOMAIN = "author-community-owner.bso";
+// A second domain rather than re-pointing the first: checkAuthorIdentity resolves with a 30 minute
+// cache, so a domain that has already resolved once in this process keeps its old address and the
+// publication would be rejected for a signer mismatch instead of by the challenge under test.
+const OTHER_OWNER_DOMAIN = "author-community-other-owner.bso";
 const OWNER_ONLY_ERROR = "Only the owner can post to this profile.";
+const RPC_AUTH_KEY = "test-author-community";
+
+const getAvailablePort = async (startPort = 39880): Promise<number> => {
+    for (let port = startPort; port < startPort + 100; port++) {
+        try {
+            return await new Promise<number>((resolve, reject) => {
+                const server = net.createServer();
+                server.unref();
+                server.on("error", reject);
+                server.listen(port, () => {
+                    server.close(() => resolve(port));
+                });
+            });
+        } catch {
+            continue;
+        }
+    }
+    throw new Error(`No available port found in range ${startPort}-${startPort + 99}`);
+};
+
+// The resolver reads this map at resolve time, so entries can be added after the pkc is built. Under
+// RPC the server pkc is in this same process, so it shares the map by reference.
+const resolverRecords = new Map<string, string>();
+
+// A pkc whose community-hosting side can resolve OWNER_DOMAIN, under either config.
+async function createHarness(): Promise<{ pkc: PKCType; teardown: () => Promise<void> }> {
+    const nameResolvers = [createMockNameResolver({ records: resolverRecords, includeDefaultRecords: true })];
+    if (!isRpcFlagOn()) {
+        const pkc = await mockPKC({ nameResolvers });
+        return { pkc, teardown: async () => await pkc.destroy() };
+    }
+
+    const serverPKC = await mockRpcServerPKC({
+        dataPath: path.join(process.cwd(), ".tmp", "pkc-rpc-author-community"),
+        nameResolvers
+    });
+    const rpcPort = await getAvailablePort();
+    const rpcUrl = `ws://localhost:${rpcPort}`;
+    const rpcServer: PKCWsServerType = await PKCWsServer.PKCWsServer({
+        port: rpcPort,
+        authKey: RPC_AUTH_KEY,
+        pkcOptions: {
+            kuboRpcClientsOptions: ["http://localhost:15001/api/v0"],
+            httpRoutersOptions: [],
+            dataPath: serverPKC.dataPath
+        }
+    });
+    (rpcServer as unknown as Record<string, Function>)._initPKC(serverPKC);
+    mockRpcServerForTests(rpcServer);
+
+    const pkc = await PKC({ pkcRpcClientsOptions: [rpcUrl], dataPath: undefined, httpRoutersOptions: [] });
+    return {
+        pkc,
+        teardown: async () => {
+            await pkc.destroy();
+            await rpcServer.destroy();
+        }
+    };
+}
 
 // The two excludes that express "the owner posts, anyone may reply". An exclude array matches if ANY
 // item matches, and an item matches only if ALL of its conditions hold, so the `fail` challenge runs
@@ -58,23 +136,29 @@ async function publishAndCaptureVerification(publication: Comment): Promise<Decr
     return verification;
 }
 
-// Skipped under RPC: the community runs on the RPC server, which has its own PKC and therefore not the
-// mock name resolver constructed here, so checkAuthorIdentity on the server cannot resolve the owner's
-// domain and the domain-keyed role case would fail for an unrelated reason. The RPC dimension of
-// delegation setup is covered by test/node/community/delegation-setup.test.ts.
-describeSkipIfRpc.sequential("author community: a community configured as a profile", () => {
-    let pkc: PKC;
-    let anchorSigner: SignerType; // As stays in the test; the node never receives it
-    let community: LocalCommunity;
+// A delegated community refuses to start until its anchor record is published (#234). The first record
+// is signed at sequence 0, since there is no prior sequence to discover.
+async function startProfile(community: ProfileCommunity, anchorSigner: SignerType) {
+    await community.publishAnchorRecord(
+        await createAnchorIpnsRecord({ anchorSigner, minterIpnsName: community.signer.address, sequence: 0 })
+    );
+    await community.start();
+    await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+}
+
+describe.sequential("author community: a community configured as a profile", () => {
+    let pkc: PKCType;
+    let teardown: () => Promise<void>;
+    let anchorSigner: SignerType; // As is generated wherever the owner is, never on the node
+    let community: ProfileCommunity;
     let minterAddress: string;
-    const resolverRecords = new Map<string, string>();
 
     beforeAll(async () => {
-        pkc = await mockPKC({ nameResolvers: [createMockNameResolver({ records: resolverRecords })] });
-        anchorSigner = await pkc.createSigner();
+        ({ pkc, teardown } = await createHarness());
+        anchorSigner = await createSigner();
         resolverRecords.set(OWNER_DOMAIN, anchorSigner.address);
 
-        community = <LocalCommunity>await createSubWithNoChallenge({ anchor: { publicKey: anchorSigner.address } }, pkc);
+        community = await createSubWithNoChallenge({ anchor: { publicKey: anchorSigner.address } }, pkc);
         minterAddress = community.signer.address;
 
         // Both roles keys, because exclude.role matches community.roles[author.address] and
@@ -83,20 +167,22 @@ describeSkipIfRpc.sequential("author community: a community configured as a prof
             roles: { [anchorSigner.address]: { role: "owner" }, [OWNER_DOMAIN]: { role: "owner" } },
             settings: { ...community.settings, challenges: [ownerOnlyPostingChallenge()] }
         });
-
-        // A delegated community refuses to start until its anchor record is published (#234). The first
-        // record is signed at sequence 0, since there is no prior sequence to discover.
-        await community.publishAnchorRecord(await createAnchorIpnsRecord({ anchorSigner, minterIpnsName: minterAddress, sequence: 0 }));
-        await community.start();
-        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+        await startProfile(community, anchorSigner);
     });
 
     afterAll(async () => {
         await community.delete();
-        await pkc.destroy();
+        await teardown();
     });
 
     describe("identity is the author's key", () => {
+        // Guards the harness rather than the feature. Under RPC the community has to live on the server
+        // this file stood up, or the suite would quietly be re-running the non-RPC path and the domain
+        // case would prove nothing about resolution happening where the community is.
+        it("exercises the configuration under test", () => {
+            expect(Boolean(pkc._pkcRpcClient)).to.equal(isRpcFlagOn());
+        });
+
         it("is addressed by the anchor, not by the minter that signs its record", () => {
             expect(community.address).to.equal(anchorSigner.address);
             expect(community.publicKey).to.equal(anchorSigner.address);
@@ -173,11 +259,11 @@ describeSkipIfRpc.sequential("author community: a community configured as a prof
     });
 
     describe("the feed is the owner's crossposts", () => {
-        let originCommunity: LocalCommunity;
+        let originCommunity: ProfileCommunity;
         let crosspostingPost: Comment;
 
         beforeAll(async () => {
-            originCommunity = <LocalCommunity>await createSubWithNoChallenge({}, pkc);
+            originCommunity = await createSubWithNoChallenge({}, pkc);
             await originCommunity.start();
             await resolveWhenConditionIsTrue({
                 toUpdate: originCommunity,
@@ -224,53 +310,51 @@ describeSkipIfRpc.sequential("author community: a community configured as a prof
             expect(pageComment!.crosspost?.cid).to.equal(crosspostingPost.raw.comment!.crosspost!.cid);
         });
     });
-});
 
-// The failure mode the protocol doc warns about: the excludes are configured, the roles map exists, but
-// it is keyed on a form the owner does not publish under. Everything looks correct until the first post.
-describeSkipIfRpc.sequential("author community: a roles map keyed on the wrong form locks the owner out", () => {
-    let pkc: PKC;
-    let anchorSigner: SignerType;
-    let community: LocalCommunity;
-    const resolverRecords = new Map<string, string>();
+    // The failure mode the protocol doc warns about: the excludes are configured and the roles map
+    // exists, but it is keyed on a form the owner does not publish under. Everything looks correct until
+    // the first post. This block is also what proves the challenge is genuinely wired up, since it is
+    // the one rejection that has to happen for the acceptance tests above to mean anything.
+    describe("a roles map keyed on the wrong form locks the owner out", () => {
+        let peerIdOnlyCommunity: ProfileCommunity;
+        let otherAnchor: SignerType;
 
-    beforeAll(async () => {
-        pkc = await mockPKC({ nameResolvers: [createMockNameResolver({ records: resolverRecords })] });
-        anchorSigner = await pkc.createSigner();
-        resolverRecords.set(OWNER_DOMAIN, anchorSigner.address);
+        beforeAll(async () => {
+            otherAnchor = await createSigner();
+            resolverRecords.set(OTHER_OWNER_DOMAIN, otherAnchor.address);
 
-        community = <LocalCommunity>await createSubWithNoChallenge({ anchor: { publicKey: anchorSigner.address } }, pkc);
-        // Only the peer-id key. exclude.role does a bare map lookup with no name resolution, unlike
-        // isPublicationAuthorPartOfRoles, so publishing under a domain misses this entirely.
-        await community.edit({
-            roles: { [anchorSigner.address]: { role: "owner" } },
-            settings: { ...community.settings, challenges: [ownerOnlyPostingChallenge()] }
+            peerIdOnlyCommunity = await createSubWithNoChallenge({ anchor: { publicKey: otherAnchor.address } }, pkc);
+            // Only the peer-id key. exclude.role does a bare map lookup with no name resolution, unlike
+            // isPublicationAuthorPartOfRoles, so publishing under a domain misses this entirely.
+            await peerIdOnlyCommunity.edit({
+                roles: { [otherAnchor.address]: { role: "owner" } },
+                settings: { ...peerIdOnlyCommunity.settings, challenges: [ownerOnlyPostingChallenge()] }
+            });
+            await startProfile(peerIdOnlyCommunity, otherAnchor);
         });
-        await community.publishAnchorRecord(
-            await createAnchorIpnsRecord({ anchorSigner, minterIpnsName: community.signer.address, sequence: 0 })
-        );
-        await community.start();
-        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
-    });
 
-    afterAll(async () => {
-        await community.delete();
-        await pkc.destroy();
-    });
-
-    it("rejects the owner's own post when they publish under a domain the roles map does not carry", async () => {
-        const post = await generateMockPost({
-            communityAddress: community.address,
-            pkc,
-            postProps: { signer: anchorSigner, author: { name: OWNER_DOMAIN } }
+        afterAll(async () => {
+            await peerIdOnlyCommunity.delete();
         });
-        const verification = await publishAndCaptureVerification(post);
-        expect(verification.challengeSuccess).to.be.false;
-        expect(verification.challengeErrors?.["0"]).to.equal(OWNER_ONLY_ERROR);
-    });
 
-    it("accepts the same owner publishing without a name, which matches the peer-id key", async () => {
-        const post = await generateMockPost({ communityAddress: community.address, pkc, postProps: { signer: anchorSigner } });
-        await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+        it("rejects the owner's own post when they publish under a domain the roles map does not carry", async () => {
+            const post = await generateMockPost({
+                communityAddress: peerIdOnlyCommunity.address,
+                pkc,
+                postProps: { signer: otherAnchor, author: { name: OTHER_OWNER_DOMAIN } }
+            });
+            const verification = await publishAndCaptureVerification(post);
+            expect(verification.challengeSuccess).to.be.false;
+            expect(verification.challengeErrors?.["0"]).to.equal(OWNER_ONLY_ERROR);
+        });
+
+        it("accepts the same owner publishing without a name, which matches the peer-id key", async () => {
+            const post = await generateMockPost({
+                communityAddress: peerIdOnlyCommunity.address,
+                pkc,
+                postProps: { signer: otherAnchor }
+            });
+            await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+        });
     });
 });

--- a/test/node/author-community/author-community.test.ts
+++ b/test/node/author-community/author-community.test.ts
@@ -272,6 +272,28 @@ describe.sequential("author community: a community configured as a profile", () 
         });
     });
 
+    // The record declares itself a profile through suggested.uiType, set through the same edit() as the
+    // rest of the configuration. It is a rendering hint clients may ignore, spoofable like `title`, and
+    // nothing in pkc-js branches on it. See "Declaring the profile to UIs" in the protocol doc.
+    describe("declaring the profile to UIs", () => {
+        it("edit({ suggested: { uiType } }) lands in the published signed record", async () => {
+            expect(community.raw.communityIpfs!.suggested?.uiType).to.be.undefined;
+            await community.edit({ suggested: { uiType: "author" } });
+            // edit() patches raw.communityIpfs from internal state immediately, old signature and all,
+            // so the record carrying the hint is not proof it was re-signed. Wait for the signature that
+            // covers it: signedPropertyNames lists only the fields present at signing time.
+            await resolveWhenConditionIsTrue({
+                toUpdate: community,
+                predicate: async () => community.raw.communityIpfs?.signature.signedPropertyNames.includes("suggested") === true
+            });
+            expect(community.raw.communityIpfs!.suggested?.uiType).to.equal("author");
+        });
+
+        it("exposes the hint on the community instance", () => {
+            expect(community.suggested?.uiType).to.equal("author");
+        });
+    });
+
     describe("the feed is the owner's crossposts", () => {
         let originCommunity: ProfileCommunity;
         let crosspostingPost: Comment;

--- a/test/node/author-community/author-community.test.ts
+++ b/test/node/author-community/author-community.test.ts
@@ -18,10 +18,7 @@
 import { beforeAll, afterAll, describe, expect, it } from "vitest";
 import fs from "fs";
 import path from "path";
-import net from "node:net";
-import { v4 as uuidv4 } from "uuid";
 import PKC from "../../../dist/node/index.js";
-import PKCWsServer from "../../../dist/node/rpc/src/index.js";
 import {
     createMockNameResolver,
     createSubWithNoChallenge,
@@ -46,8 +43,8 @@ import type { CommentIpfsWithCidDefined } from "../../../dist/node/publications/
 import type { CommunityChallengeSetting } from "../../../dist/node/community/types.js";
 import type { SignerType } from "../../../dist/node/signer/types.js";
 import type { DecryptedChallengeVerificationMessageType } from "../../../dist/node/pubsub-messages/types.js";
+import { createInProcessRpcServer, uniqueTmpDataPath } from "../../helpers/rpc-server-harness.js";
 
-type PKCWsServerType = Awaited<ReturnType<typeof PKCWsServer.PKCWsServer>>;
 type ProfileCommunity = LocalCommunity | RpcLocalCommunity;
 
 const OWNER_DOMAIN = "author-community-owner.bso";
@@ -57,24 +54,6 @@ const OWNER_DOMAIN = "author-community-owner.bso";
 const OTHER_OWNER_DOMAIN = "author-community-other-owner.bso";
 const OWNER_ONLY_ERROR = "Only the owner can post to this profile.";
 const RPC_AUTH_KEY = "test-author-community";
-
-const getAvailablePort = async (startPort = 39880): Promise<number> => {
-    for (let port = startPort; port < startPort + 100; port++) {
-        try {
-            return await new Promise<number>((resolve, reject) => {
-                const server = net.createServer();
-                server.unref();
-                server.on("error", reject);
-                server.listen(port, () => {
-                    server.close(() => resolve(port));
-                });
-            });
-        } catch {
-            continue;
-        }
-    }
-    throw new Error(`No available port found in range ${startPort}-${startPort + 99}`);
-};
 
 // The resolver reads this map at resolve time, so entries can be added after the pkc is built. Under
 // RPC the server pkc is in this same process, so it shares the map by reference.
@@ -91,20 +70,11 @@ async function createHarness(): Promise<{ pkc: PKCType; teardown: () => Promise<
     // A fresh dataPath per run. This suite creates communities on the server, so a fixed path would
     // accumulate them across runs, and any run that dies before afterAll leaves a started community
     // behind for the next server to resume at startup, which eventually times out the beforeAll hook.
-    const dataPath = path.join(process.cwd(), ".tmp", `pkc-rpc-author-community-${uuidv4()}`);
+    // The mock resolver goes on the server pkc here, since the shared harness injects the pkc as-is.
+    const dataPath = uniqueTmpDataPath("pkc-rpc-author-community");
     const serverPKC = await mockRpcServerPKC({ dataPath, nameResolvers });
-    const rpcPort = await getAvailablePort();
-    const rpcUrl = `ws://localhost:${rpcPort}`;
-    const rpcServer: PKCWsServerType = await PKCWsServer.PKCWsServer({
-        port: rpcPort,
-        authKey: RPC_AUTH_KEY,
-        pkcOptions: {
-            kuboRpcClientsOptions: ["http://localhost:15001/api/v0"],
-            httpRoutersOptions: [],
-            dataPath: serverPKC.dataPath
-        }
-    });
-    (rpcServer as unknown as Record<string, Function>)._initPKC(serverPKC);
+    const { rpcServer, rpcUrl } = await createInProcessRpcServer({ serverPKC, authKey: RPC_AUTH_KEY });
+    // The harness only binds and injects; publishing over RPC still needs the test relaxations.
     mockRpcServerForTests(rpcServer);
 
     const pkc = await PKC({ pkcRpcClientsOptions: [rpcUrl], dataPath: undefined, httpRoutersOptions: [] });
@@ -112,7 +82,7 @@ async function createHarness(): Promise<{ pkc: PKCType; teardown: () => Promise<
         pkc,
         teardown: async () => {
             await pkc.destroy();
-            await rpcServer.destroy();
+            await rpcServer.destroy(); // also destroys the injected serverPKC
             fs.rmSync(dataPath, { recursive: true, force: true });
         }
     };
@@ -129,7 +99,7 @@ function ownerOnlyChallenge(): CommunityChallengeSetting {
         // Options are private by default. Naming `error` here publishes that one value, so a reader sees
         // the rejection text without publishing anything. It is a hint, not proof: see the wire test below.
         publicOptions: ["error"],
-        exclude: [{ role: ["owner"] }]
+        exclude: [{ roles: ["owner"] }]
     };
 }
 
@@ -143,7 +113,7 @@ function replyAbleChallenge(): CommunityChallengeSetting {
     return {
         ...ownerOnlyChallenge(),
         exclude: [
-            { role: ["owner"] },
+            { roles: ["owner"] },
             { publicationType: { reply: true, commentEdit: true, commentModeration: true, communityEdit: true } }
         ]
     };
@@ -187,8 +157,8 @@ describe.sequential("author community: a community configured as a profile", () 
 
         // The default feed-only config from the protocol doc: the exchange is disabled, so every
         // publish in this suite goes through the local/RPC shortcut, where the challenge pipeline
-        // still runs. Both roles keys, because exclude.role matches community.roles[author.address]
-        // and author.address is `name || publicKey`. See "The roles key" in the protocol doc.
+        // still runs. Both roles keys: each is bound to the signer by its own rule, and the suite
+        // exercises both. See "The roles key" in the protocol doc.
         await community.edit({
             roles: { [anchorSigner.address]: { role: "owner" }, [OWNER_DOMAIN]: { role: "owner" } },
             settings: { ...community.settings, disablePubsubChallengeExchange: true, challenges: [ownerOnlyChallenge()] }
@@ -227,9 +197,10 @@ describe.sequential("author community: a community configured as a profile", () 
             await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
         });
 
-        // author.address becomes the domain once author.name is set, so this exercises the other roles
-        // key. checkAuthorIdentity resolves the domain and compares it against the signer first.
-        it("accepts the owner's post when they publish under their domain, matched on the domain roles key", async () => {
+        // With both keys in the map the peer-id key still matches first and no name is resolved, so
+        // this only proves the domain form does not break the owner. The domain-only block below is
+        // what exercises the domain key's own rule.
+        it("accepts the owner's post when they publish under their domain", async () => {
             const post = await generateMockPost({
                 communityAddress: community.address,
                 pkc,
@@ -356,7 +327,7 @@ describe.sequential("author community: a community configured as a profile", () 
             expect(published[0].exclude).to.deep.equal(ownerOnlyChallenge().exclude);
         });
 
-        it("publishes the roles map, which is what exclude.role is matched against", () => {
+        it("publishes the roles map, which is what exclude.roles is matched against", () => {
             expect(community.raw.communityIpfs!.roles).to.deep.equal({
                 [anchorSigner.address]: { role: "owner" },
                 [OWNER_DOMAIN]: { role: "owner" }
@@ -454,50 +425,62 @@ describe.sequential("author community: a community configured as a profile", () 
         });
     });
 
-    // The failure mode the protocol doc warns about: the excludes are configured and the roles map
-    // exists, but it is keyed on a form the owner does not publish under. Everything looks correct until
-    // the first post. This block is also what proves the challenge is genuinely wired up, since it is
-    // the one rejection that has to happen for the acceptance tests above to mean anything.
-    describe("a roles map keyed on the wrong form locks the owner out", () => {
-        let peerIdOnlyCommunity: ProfileCommunity;
+    // The one lock-out left after #267: the excludes are configured and the roles map exists, but it
+    // carries only the owner's domain, and the domain key matches only when the owner publishes under
+    // that exact name and it resolves to the signer. Everything looks correct until the first post
+    // sent without author.name. This block is also what proves the challenge is genuinely wired up,
+    // since it is the one owner rejection that has to happen for the acceptance tests above to mean
+    // anything.
+    describe("a roles map keyed on the domain alone", () => {
+        let domainOnlyCommunity: ProfileCommunity;
         let otherAnchor: SignerType;
 
         beforeAll(async () => {
             otherAnchor = await createSigner();
             resolverRecords.set(OTHER_OWNER_DOMAIN, otherAnchor.address);
 
-            peerIdOnlyCommunity = await createSubWithNoChallenge({ anchor: { publicKey: otherAnchor.address } }, pkc);
-            // Only the peer-id key. exclude.role does a bare map lookup with no name resolution, unlike
-            // isPublicationAuthorPartOfRoles, so publishing under a domain misses this entirely.
-            await peerIdOnlyCommunity.edit({
-                roles: { [otherAnchor.address]: { role: "owner" } },
-                settings: { ...peerIdOnlyCommunity.settings, challenges: [ownerOnlyChallenge()] }
+            domainOnlyCommunity = await createSubWithNoChallenge({ anchor: { publicKey: otherAnchor.address } }, pkc);
+            await domainOnlyCommunity.edit({
+                roles: { [OTHER_OWNER_DOMAIN]: { role: "owner" } },
+                settings: { ...domainOnlyCommunity.settings, challenges: [ownerOnlyChallenge()] }
             });
-            await startProfile(peerIdOnlyCommunity, otherAnchor);
+            await startProfile(domainOnlyCommunity, otherAnchor);
         });
 
         afterAll(async () => {
-            await peerIdOnlyCommunity.delete();
+            await domainOnlyCommunity.delete();
         });
 
-        it("rejects the owner's own post when they publish under a domain the roles map does not carry", async () => {
+        it("rejects the owner's own post when they publish without the name the roles map carries", async () => {
             const post = await generateMockPost({
-                communityAddress: peerIdOnlyCommunity.address,
+                communityAddress: domainOnlyCommunity.address,
                 pkc,
-                postProps: { signer: otherAnchor, author: { name: OTHER_OWNER_DOMAIN } }
+                postProps: { signer: otherAnchor }
             });
             const verification = await publishAndCaptureVerification(post);
             expect(verification.challengeSuccess).to.be.false;
             expect(verification.challengeErrors?.["0"]).to.equal(OWNER_ONLY_ERROR);
         });
 
-        it("accepts the same owner publishing without a name, which matches the peer-id key", async () => {
+        it("accepts the same owner publishing under the domain, which resolves to the signer", async () => {
             const post = await generateMockPost({
-                communityAddress: peerIdOnlyCommunity.address,
+                communityAddress: domainOnlyCommunity.address,
                 pkc,
-                postProps: { signer: otherAnchor }
+                postProps: { signer: otherAnchor, author: { name: OTHER_OWNER_DOMAIN } }
             });
             await publishWithExpectedResult({ publication: post, expectedChallengeSuccess: true });
+        });
+
+        // Rejected either by the author identity check or by the challenge, depending on where the
+        // signer mismatch is caught first; only the outcome matters here, so the reason is not pinned.
+        it("rejects an impostor claiming the domain, since the name must resolve to the signer", async () => {
+            const post = await generateMockPost({
+                communityAddress: domainOnlyCommunity.address,
+                pkc,
+                postProps: { author: { name: OTHER_OWNER_DOMAIN } }
+            });
+            const verification = await publishAndCaptureVerification(post);
+            expect(verification.challengeSuccess).to.be.false;
         });
     });
 });

--- a/test/node/pkc/destroy-stops-publications.test.ts
+++ b/test/node/pkc/destroy-stops-publications.test.ts
@@ -26,7 +26,9 @@ describe("pkc.destroy() stops in-flight publications", () => {
     });
 
     afterAll(async () => {
-        if (!pkc.destroyed) await pkc.destroy();
+        // beforeAll may fail before pkc is assigned, and dereferencing it here would throw a TypeError
+        // that replaces the real setup failure in the report.
+        if (pkc && !pkc.destroyed) await pkc.destroy();
     });
 
     it("a publication waiting on a challenge answer is stopped by destroy()", async () => {


### PR DESCRIPTION
Implements author communities (#31) now that crossposts (#32) have landed. Closes #31. Supersedes #227, which is being closed.

## The short version

An author community needs no new machinery. It is a configuration of an ordinary community, so this PR is documentation, the tests that prove the configuration composes, and one line of schema: `suggested.uiType`, the rendering hint a profile declares itself with. The default configuration is feed-only: `settings.disablePubsubChallengeExchange` is set, so nobody can publish to a profile over pubsub and the owner publishes over RPC.

## What changed since the #227 design

The pause note on #31 already established that a profile should not be a distinct record type. Crossposts landing removed the rest of the reason for bespoke machinery, because a crosspost is a native comment of the profile that embeds the foreign record. Gone: `AuthorCommunityIpfs`, the `{ authorCommunity? | community? }` envelope, `community.type`, `AuthorLocalCommunity`, the `crossPostedComments` table, `verifyAuthorCommunityPage`, the `listAuthorComments` / `syncAuthorComments` pair and the minter refresh job.

One further deletion happened while writing this up. The owner-only posting rule was going to be `features.onlyOwnerCanPost`. It does not need to be, because the restriction is already legible to a remote reader without a new wire field, in both flavors:

- in the feed-only default, the record omits `pubsubTopic`, which tells a reader the challenge exchange is off and nobody can publish remotely at all
- in the reply-able flavor, the built-in `fail` challenge is paired with `exclude` (which its own source comment says it exists for), and `exclude` is copied verbatim from the private `settings.challenges` into the public signed `challenges` array, while `path` and `name` are stripped and `options` stay private unless the owner names them in `publicOptions`

A flag would duplicate a fact the record carries. That is the single most load-bearing assumption in this design, which is why both halves have tests that do nothing but assert it.

## What ships

**`docs/protocol/author-communities.md`**, rewritten from 1201 lines to a short configuration guide: identity-key addressing over delegated publishing, the feed-only default and the reply-able opt-in with its challenge config, the feed, how the owner publishes, and key lifetime.

**`docs/protocol/crossposts.md`** gains the three render states (live, removed, unknown) under tier 2. They apply to any crosspost, not only to a feed of them. The point of naming them is that clients collapse unknown into removed, which makes an unreachable community indistinguishable from a moderating one.

**Tests.** `test/node` covers the producing half against a real delegated community. `test/node-and-browser` covers the reading half with no network.

**A guard in `test/node/pkc/destroy-stops-publications.test.ts`**, unrelated to profiles. Its `afterAll` dereferenced `pkc` unconditionally, so a `beforeAll` failure before the assignment threw a `TypeError` that replaced the real setup error in the report.

## The default is feed-only, and votes are rejected in both flavors

The pubsub challenge exchange is disabled by default: the recommended config sets `settings.disablePubsubChallengeExchange: true` (#229). A profile is a broadcast of one author's activity, so the remote publishing path has no default job. The record omits `pubsubTopic`, remote publishers fail fast with `ERR_COMMUNITY_CHALLENGE_EXCHANGE_DISABLED`, and the owner publishes over RPC, the one path that remains. This is also the cheapest shape, since the node runs no exchange topic, and the most legible one, since a missing `pubsubTopic` leaves no challenge whose passability a reader has to guess at.

The `fail` challenge shrinks to a role-only exclude and stays as belt and braces: the challenge pipeline still runs on the local/RPC shortcut, which is what rejects the other tenants on a multi-tenant minter, and it makes the config fail closed if the exchange is ever re-enabled. The trade-off is stated in the doc: the default assumes an RPC-reachable minter, so a browser-only owner must keep the exchange enabled.

The two-challenge config ("the owner posts, anyone may reply") is now the reply-able opt-in. Votes are rejected there too: `vote` is deliberately absent from the `publicationType` exclude, because karma over a profile is read at tier 2 from each entry's origin community, so a vote on the crosspost copy is tallied by the owner's own delegate and counts toward nothing a client should trust. A profile that wants vote-driven reply sorting adds `vote: true` back.

## The record now declares itself: `suggested.uiType`

The "field saying this is a profile" open question is settled: a profile sets `suggested.uiType: "author"`. It lives in `suggested` next to `primaryColor` because it is the same kind of thing, a rendering hint the owner sets which clients may ignore without breaking interoperability. Nothing in pkc-js branches on it, it plays no role in validation or loading, and it is spoofable exactly like `title`, so it does not weaken "a configuration, not a type". `"author"` is the only defined value, absence means an ordinary community, and clients must ignore values they do not recognize.

The inference the earlier draft recommended, `roles[community.address].role === "owner"`, turned out to be unreliable in both directions: any ordinary community can hold the owner role over its own address, and `createCommunity` never seeds `roles`, so a half-configured profile lacks the entry. The doc now demotes it and recommends the field as the only check.

The one `src/` line is `uiType: z.string().optional()` on `CommunitySuggestedSchema`, so TypeScript consumers get typed access instead of re-inventing the key name. `suggested` already travels in the signed record, so the hint is signature-covered for free. The edit-path test waits for `signedPropertyNames` to include `suggested` rather than for the value to appear, because `edit()` patches the in-memory record ahead of the re-signed publish and the value alone does not prove a signature covers it.

## Two things the docs now warn about, both found while writing the tests

**`roles` and `settings.challenges` are set in two different places and only one is published.** `createCommunity` never seeds `roles`, so a profile with excludes configured and an empty roles map looks correct until the owner's first post is rejected by their own challenge. Documented rather than fixed: auto-seeding would change the creation path for every community type and deserves its own change. Note the boundary, which is easy to get wrong: `community.edit()` needs no role, since it is a direct method rather than a publication, but publishing does need it on every path including RPC, because the local shortcut only suppresses the pubsub echo and the challenge pipeline still runs.

**Both forms of the owner's identity are valid `roles` keys, each with its own rule.** Since #294 the matcher binds every roles key to the publication's signer instead of looking the publisher up by `author.address`. The peer-id key matches on the signature whatever `author.name` the owner sends, and it is compared before any name is resolved. The domain key matches only when the owner publishes with that exact `author.name` and it resolves, fresh, to the signer, so a domain-only map locks out an owner who publishes without the name. The doc states both rules and there is a test for the domain-only lock-out, not just for the success.
## A profile does not need fourteen sorts

Configurable page sorts (#73) is a much larger win for profiles than it is for boards, and the profile
case was not part of that issue's original motivation, so it is recorded here and there.

A profile feed is one author's own posts in the order they made them. `new` is the only post sort a
client has a reason to open, and a reply-able profile needs one reply sort. Today a profile still
generates the full default set on every update cycle: nine post sorts and five reply sorts, chunked,
added to IPFS and rotated, almost all of it for nobody.

The population is what makes it matter. Boards are counted in the dozens. Profiles are potentially one
per author, so they will outnumber communities by a wide margin, and each one pays the same per-cycle
generation, block and rotating-CID cost as a real community. Cutting a profile to one post sort and one
reply sort is the same fourteen-pages-to-two saving 5chan gets, multiplied by the number of authors
rather than the number of boards.

Nothing here blocks this PR. It is a note that the profile shape should
be weighed alongside the board shape when `settings.pages` is designed.

## Related

- #267, filed separately: challenge excludes and roles match a conflated author address string, which is spoofable when `resolveAuthorNames` is off, plus a dead resolver block in `isPublicationAuthorPartOfRoles`. Not a blocker here, and the peer-id roles key recommended in the doc is not affected.
- The discovery hint on the author object is deferred and recorded as an open question in the doc.
- #73, configurable page sorts: noted above as the largest resource saving available to profiles, since a profile only ever needs `new`.

## Rebased onto master, and one correction that came out of it

`publicOptions` (#287) landed after this branch was written, so the doc's claim that `options` are stripped was no longer the whole story: an owner names individual options in `settings.challenges[i].publicOptions` and those are published as `challenges[i].publicOptions`.

The conclusion survives intact, and the profile config is better for it. The recommended config now opts its `fail` error in, so a reader sees "Only the owner can post to this profile." straight from the record. That is a better hint than `description`, because a passable challenge has no reason to carry a rejection sentence. It is still not a discriminator: the value is free text written by the same node that decides whether to honor it, and a custom challenge file may declare an `error` option of its own and publish an identical string while remaining passable. `type` does not separate them either, since `fail` and `question` both publish `text/plain`.

Both halves have a test. The node suite asserts a real profile publishes exactly the option it opted into and nothing else. The wire suite gives the answerable challenge the identical `publicOptions` on purpose, so the indistinguishability test now holds against the strongest hint a profile can put on the wire rather than against a record carrying none.

## Rebased onto master again: `exclude.roles` and the signer-bound matcher

#294 (#267) landed after the previous rebase. It renamed `exclude.role` to `exclude.roles`, made writing the old field to `settings.challenges` a hard error, and replaced the `community.roles[author.address]` lookup with a matcher bound to the signer. The branch merged cleanly and was wrong at runtime in three places: every profile config wrote `role`, the wire reader accessed a property the `Exclude` type no longer declares, and one test block asserted the exact behavior #294 deleted (a peer-id-only roles map rejecting the owner under a domain).

The doc's "The roles key" section is rewritten around the new rule, above. The two-key example stays as "either works", not as a workaround. The lock-out block now covers the lock-out that remains, a domain-only roles map. Two things came out of reading the matcher and are filed separately: a resolver failure while matching a domain role key is a silent non-match with only a debug log, so a moderator never learns their node's resolver is the problem (#353), and nothing tests that the peer-id key short-circuits before any resolution when both keys are present (#354).

The node suite also moves to `test/helpers/rpc-server-harness.ts`, which binds port 0 instead of probing a port and rebinding it, closing the port-race review thread.

## Verification

The one `src/` change is the schema line, so `npm run build` passes. `npx tsc --project test/tsconfig.json --noEmit` is clean, and both suites pass:

- `test/node/author-community/`, 25 tests, under `--pkc-config "local-kubo-rpc,remote-pkc-rpc"`. The main profile runs the feed-only default, so stranger posts, replies and votes are all rejected and the published record omits `pubsubTopic`; a separate block covers the reply-able flavor, where a stranger's reply passes while posts and votes stay rejected.
- `test/node-and-browser/author-community/`, 10 tests, under `--pkc-config "remote-kubo-rpc,remote-pkc-rpc"`. This includes the feed-only signal: a missing `pubsubTopic` is a real discriminator against an ordinary record, and the exclude-structure reader deliberately does not detect that shape.

The node suite runs under RPC rather than being skipped. It was initially `describeSkipIfRpc`, because the owner's role is matched against a domain in one case and name resolution happens wherever the community lives, so the shared test RPC server cannot resolve a domain minted in the test process. That reason only applied to the domain case, so instead the file stands up its own RPC server with the mock resolver on the server pkc, following the pattern in `test/node/pkc/pkc-settings-nameresolvers-rpc.test.ts`.

One test exists purely to guard that: it asserts the pkc has an RPC client exactly when the RPC flag is on, so the suite cannot silently degrade into re-running the non-RPC path and reporting green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional display-type hint so clients can suggest specialized community rendering, such as author profiles.
  * Documented author-community support for owner-managed posting, identity-based addressing, and crosspost feeds.

* **Documentation**
  * Added protocol guidance for author communities, challenge configuration, and crosspost states.
  * Documented moderation verification, retry handling, karma eligibility, external specifications, and IPFS gateway update latency.

* **Tests**
  * Added coverage for author-community permissions, identity matching, sanitized records, crosspost feeds, and challenge handling.
  * Improved test cleanup so setup failures report the underlying error instead of a secondary exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




