### PR TITLE
fix(pkc): stop in-flight publications in destroy() and drain their background community refresh

### DIFF
--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -139,6 +139,7 @@ import type { Libp2pJsClient } from "../helia/libp2pjsClient.js";
 import type { AuthorNameRpcParam, CidRpcParam, RpcFetchCidResult } from "../clients/rpc-client/types.js";
 import { parseRpcAuthorNameParam, parseRpcCidParam } from "../clients/rpc-client/rpc-schema-util.js";
 import { cleanWireAuthor, normalizeCreatePublicationAuthor } from "../publications/publication-author.js";
+import type Publication from "../publications/publication.js";
 import { stripNameResolvedFromCrosspost } from "../publications/comment/crosspost-runtime.js";
 import { IndexedTrackedInstanceRegistry, TrackedInstanceRegistry } from "./tracked-instance-registry.js";
 import {
@@ -196,6 +197,9 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     _updatingComments: IndexedTrackedInstanceRegistry<Comment> = new TrackedInstanceRegistry() as IndexedTrackedInstanceRegistry<Comment>; // storing comment instancse that are getting updated rn
     _startedCommunities: IndexedTrackedInstanceRegistry<LocalCommunity | RpcLocalCommunity> =
         new TrackedInstanceRegistry() as IndexedTrackedInstanceRegistry<LocalCommunity | RpcLocalCommunity>; // storing community instances that are started rn
+    // Publications that are mid-publish. A plain Set rather than a TrackedInstanceRegistry because
+    // a publication has no stable key to look it up by, and destroy() only ever iterates them.
+    _publishingPublications = new Set<Publication>();
     private _communityFsWatchAbort?: AbortController;
     private _destroyAbortController?: AbortController;
 
@@ -1219,6 +1223,16 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
             }
         }
         if (exportDonePromises.length) await Promise.all(exportDonePromises);
+
+        // Stop publications before comments and communities: a publication left mid-exchange keeps
+        // the challenge running and fires background community refreshes, which would re-create the
+        // very instances we are about to stop (issue #270).
+        await Promise.all(
+            [...this._publishingPublications].map((publication) =>
+                publication.stop().catch((e) => log.error("Error stopping publication during destroy", e))
+            )
+        );
+        this._publishingPublications.clear();
 
         for (const comment of listUpdatingComments(this)) await comment.stop();
 

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -115,6 +115,9 @@ class Publication extends TypedEmitter<PublicationEvents> {
         pubsubTopic?: CommunityIpfsType["pubsubTopic"];
     } = undefined; // will be used for publishing
     _publishingToLocalCommunity?: LocalCommunity;
+    // In-flight stale-cache community refresh fired by _fetchCommunityForPublishing. Deliberately
+    // not awaited by the publish path, so stop() drains it (issue #270).
+    _backgroundCommunityRefresh?: Promise<unknown>;
 
     _challengeExchanges: Record<
         string, // challengeRequestId stringified
@@ -764,9 +767,15 @@ class Publication extends TypedEmitter<PublicationEvents> {
             // cache.has will return false if the item is stale
             if (!this._pkc._memCaches.communityForPublishing.has(this.communityAddress)) {
                 log("The cache of community is stale, we will use the cached and update in the background");
-                this._pkc
+                // Held on the publication so stop() can drain it. Without that the refresh outlives
+                // the PKC and goes on creating community instances after teardown (issue #270).
+                const refresh = this._pkc
                     .getCommunity({ publicKey: this.communityPublicKey, name: this.communityName })
-                    .catch((e) => log.error("Failed to update cache of community", this.communityAddress, e));
+                    .catch((e) => log.error("Failed to update cache of community", this.communityAddress, e))
+                    .finally(() => {
+                        if (this._backgroundCommunityRefresh === refresh) this._backgroundCommunityRefresh = undefined;
+                    });
+                this._backgroundCommunityRefresh = refresh;
             }
             return cachedCommunity;
         } else return this._clientsManager.fetchCommunityForPublishingWithCacheGuard();
@@ -774,6 +783,9 @@ class Publication extends TypedEmitter<PublicationEvents> {
 
     async stop() {
         await this._postSucessOrFailurePublishing();
+        // Stopping the publication does not cancel a refresh that is already in flight, so wait it
+        // out. On the pkc.destroy() path the destroy abort has already fired, so this unwinds fast.
+        if (this._backgroundCommunityRefresh) await this._backgroundCommunityRefresh;
         this._updatePublishingStateWithEmission("stopped");
     }
 
@@ -792,8 +804,19 @@ class Publication extends TypedEmitter<PublicationEvents> {
         });
     }
 
+    // A refresh fired at the start of publish can outlive the exchange it was fired from:
+    // getCommunity() on a remote community waits for an IPNS update, while a local challenge
+    // exchange finishes in milliseconds. Stay registered until it settles, otherwise the publish
+    // ends, we unregister, and pkc.destroy() has nothing left to drain the refresh through.
+    private _unregisterFromPkcOncePublishWorkSettles() {
+        const refresh = this._backgroundCommunityRefresh;
+        if (refresh) void refresh.finally(() => this._pkc._publishingPublications.delete(this));
+        else this._pkc._publishingPublications.delete(this);
+    }
+
     private async _postSucessOrFailurePublishing() {
         const log = Logger("pkc-js:publication:_postSucessOrFailurePublishing");
+        this._unregisterFromPkcOncePublishWorkSettles();
         this._setStateWithEmission("stopped");
         if (this._rpcPublishSubscriptionId) {
             try {
@@ -1233,6 +1256,9 @@ class Publication extends TypedEmitter<PublicationEvents> {
     async publish() {
         const log = Logger("pkc-js:publication:publish");
         this._validatePublicationFields();
+        // Track before the first await so pkc.destroy() can stop us no matter how far the exchange
+        // has progressed. Untracked in _postSucessOrFailurePublishing, the single exit funnel.
+        this._pkc._publishingPublications.add(this);
         this._setStateWithEmission("publishing");
 
         // Fetch community for BOTH RPC and non-RPC paths (needed for signing)

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -782,11 +782,17 @@ class Publication extends TypedEmitter<PublicationEvents> {
     }
 
     async stop() {
-        await this._postSucessOrFailurePublishing();
-        // Stopping the publication does not cancel a refresh that is already in flight, so wait it
-        // out. On the pkc.destroy() path the destroy abort has already fired, so this unwinds fast.
-        if (this._backgroundCommunityRefresh) await this._backgroundCommunityRefresh;
-        this._updatePublishingStateWithEmission("stopped");
+        try {
+            await this._postSucessOrFailurePublishing();
+        } finally {
+            // Stopping the publication does not cancel a refresh that is already in flight, so wait
+            // it out. On the pkc.destroy() path the destroy abort has already fired, so this unwinds
+            // fast. In a finally because pkc.destroy() catches a rejecting stop() and then clears
+            // _publishingPublications, so a cleanup failure would otherwise leave the refresh
+            // running past teardown, which is the exact thing this is here to prevent.
+            if (this._backgroundCommunityRefresh) await this._backgroundCommunityRefresh;
+            this._updatePublishingStateWithEmission("stopped");
+        }
     }
 
     _isAllAttemptsExhausted(maxNumOfChallengeExchanges: number): boolean {
@@ -1254,11 +1260,29 @@ class Publication extends TypedEmitter<PublicationEvents> {
     }
 
     async publish() {
-        const log = Logger("pkc-js:publication:publish");
         this._validatePublicationFields();
         // Track before the first await so pkc.destroy() can stop us no matter how far the exchange
-        // has progressed. Untracked in _postSucessOrFailurePublishing, the single exit funnel.
+        // has progressed. Untracked in _postSucessOrFailurePublishing once the exchange ends, or in
+        // the catch below if publish never got that far.
         this._pkc._publishingPublications.add(this);
+        try {
+            return await this._publishAfterRegistering();
+        } catch (e) {
+            // Not every throw reaches the funnel: pre-flight failures (_initCommunity, signing, the
+            // signature hook, the RPC publish call) reject before a challenge exchange exists, and
+            // _initCommunity does its own stopped/failed emission and rethrows. Without this we stay
+            // strongly referenced in _publishingPublications for the lifetime of the PKC, and
+            // destroy() later stops a publication that never started. Unregistering directly rather
+            // than through the funnel keeps the error path free of a redundant state emission and of
+            // a pubsub unsubscribe for a topic that was never subscribed. Deleting twice is a no-op,
+            // so the throw sites that do funnel are unaffected.
+            this._unregisterFromPkcOncePublishWorkSettles();
+            throw e;
+        }
+    }
+
+    private async _publishAfterRegistering() {
+        const log = Logger("pkc-js:publication:publish");
         this._setStateWithEmission("publishing");
 
         // Fetch community for BOTH RPC and non-RPC paths (needed for signing)

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -810,6 +810,29 @@ class Publication extends TypedEmitter<PublicationEvents> {
         });
     }
 
+    // stop() and pkc.destroy() are not cancellation: they unsubscribe and mark us stopped, but a
+    // pubsub subscribe that was already in flight still resolves afterwards and the publish loop
+    // carries on to publish a challenge request behind a torn-down PKC. Worse, that subscribe
+    // re-established a subscription after teardown already ran its unsubscribe, so returning
+    // without undoing it leaves it dangling on the provider. Returns true when the caller should
+    // abandon this provider (issue #270).
+    private async _abandonProviderIfStoppedWhileSubscribing(providerUrl: string): Promise<boolean> {
+        if (!this._pkc.destroyed && (this.state as Publication["state"]) !== "stopped") return false;
+        const log = Logger("pkc-js:publication:publish:_abandonProviderIfStoppedWhileSubscribing");
+        log("Publication was stopped while subscribing to pubsub, will not publish a challenge request", providerUrl);
+        try {
+            await this._clientsManager.pubsubUnsubscribeOnProvider(
+                this._communityChallengePubsubExchangeTopic(),
+                providerUrl,
+                this._handleChallengeExchange
+            );
+        } catch (e) {
+            log.error("Failed to undo the pubsub subscription that resolved after being stopped", providerUrl, e);
+        }
+        this._updatePubsubState("stopped", providerUrl);
+        return true;
+    }
+
     // A refresh fired at the start of publish can outlive the exchange it was fired from:
     // getCommunity() on a remote community waits for an IPNS update, while a local challenge
     // exchange finishes in milliseconds. Stay registered until it settles, otherwise the publish
@@ -1135,6 +1158,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
                             this._handleChallengeExchange,
                             providerUrl
                         );
+                        if (await this._abandonProviderIfStoppedWhileSubscribing(providerUrl)) return;
                         this._updatePubsubState("publishing-challenge-request", providerUrl);
                         await this._clientsManager.pubsubPublishOnProvider(
                             this._communityChallengePubsubExchangeTopic(),
@@ -1349,6 +1373,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
                     this._handleChallengeExchange,
                     providerUrl
                 );
+                if (await this._abandonProviderIfStoppedWhileSubscribing(providerUrl)) return;
                 this._updatePubsubState("publishing-challenge-request", providerUrl);
                 await this._clientsManager.pubsubPublishOnProvider(
                     this._communityChallengePubsubExchangeTopic(),

--- a/test/node/pkc/destroy-stops-publications.test.ts
+++ b/test/node/pkc/destroy-stops-publications.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mockPKC, generateMockPost, resolveWhenConditionIsTrue } from "../../../dist/node/test/test-util.js";
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
+
+// Node-only: starts a LocalCommunity, which is not available in the browser bundle.
+//
+// pkc.destroy() stops updating comments, updating communities and started communities, but it
+// has no registry of publications that are mid-publish, so a publication waiting on a challenge
+// answer keeps running after destroy() resolves. The work it goes on to do (the challenge
+// exchange, the detached stale-cache getCommunity() refresh it fires, and the community
+// instances that refresh creates) is what leaves a tail of activity behind a torn-down PKC.
+// See issue #270.
+describe("pkc.destroy() stops in-flight publications", () => {
+    let pkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = (await pkc.createCommunity()) as LocalCommunity;
+        // A question challenge parks the publication in waiting-challenge-answers until we answer,
+        // which is never — that is what keeps it in flight while we destroy the PKC.
+        await community.edit({ settings: { challenges: [{ name: "question", options: { question: "1+1=?", answer: "2" } }] } });
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+    });
+
+    afterAll(async () => {
+        if (!pkc.destroyed) await pkc.destroy();
+    });
+
+    it("a publication waiting on a challenge answer is stopped by destroy()", async () => {
+        const post = await generateMockPost({ communityAddress: community.address, pkc });
+        post.on("error", () => {}); // the publication errors once its PKC goes away; not what we assert on
+
+        const receivedChallenge = new Promise<void>((resolve) => post.once("challenge", () => resolve()));
+        // Deliberately not awaited: publish() does not resolve until the exchange completes, and we
+        // never answer the challenge.
+        post.publish().catch(() => {});
+        await receivedChallenge;
+
+        expect(post.publishingState).to.not.equal("stopped");
+
+        await pkc.destroy();
+
+        expect(post.publishingState).to.equal("stopped");
+    });
+});

--- a/test/node/pkc/publication-registry.test.ts
+++ b/test/node/pkc/publication-registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
-import { mockPKC, generateMockPost, resolveWhenConditionIsTrue } from "../../../dist/node/test/test-util.js";
+import { mockPKC, mockRemotePKC, generateMockPost, resolveWhenConditionIsTrue } from "../../../dist/node/test/test-util.js";
+import signers from "../../fixtures/signers.js";
 import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
 import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
 import { itSkipIfRpc } from "../../helpers/conditional-tests.js";
@@ -77,6 +78,53 @@ describe("publication registry (pkc._publishingPublications) lifecycle", () => {
             expect(post.publishingState).to.equal("stopped");
         } finally {
             unsubscribeSpy.mockRestore();
+        }
+    });
+});
+
+// Publishing over pubsub, so it needs a remote community rather than the started LocalCommunity
+// above, which short-circuits to _publishWithLocalCommunity and never touches a pubsub provider.
+describe("publication publish loop honours being stopped mid-subscribe", () => {
+    // Under RPC the client never touches pubsub providers itself, so there is no
+    // subscribe-then-publish window to race.
+    itSkipIfRpc("does not publish a challenge request when destroy() lands while subscribing", async () => {
+        const pkc = await mockRemotePKC();
+        try {
+            const post = await generateMockPost({ communityAddress: signers[0].address, pkc });
+            post.on("error", () => {});
+
+            const clientsManager = post._clientsManager;
+            const realSubscribe = clientsManager.pubsubSubscribeOnProvider.bind(clientsManager);
+            const unsubscribeOnProviderSpy = vi.spyOn(clientsManager, "pubsubUnsubscribeOnProvider");
+            const publishSpy = vi.spyOn(clientsManager, "pubsubPublishOnProvider");
+
+            // stop() and destroy() are not cancellation: they unsubscribe and mark us stopped, but a
+            // subscribe that is already in flight still resolves afterwards and the publish loop
+            // carries on. Destroying inside the subscribe reproduces that window deterministically.
+            let unsubscribeCallsWhenDestroyFinished = 0;
+            vi.spyOn(clientsManager, "pubsubSubscribeOnProvider").mockImplementation(async (topic, handler, providerUrl) => {
+                await realSubscribe(topic, handler, providerUrl);
+                await pkc.destroy();
+                unsubscribeCallsWhenDestroyFinished = unsubscribeOnProviderSpy.mock.calls.length;
+            });
+
+            const publishOutcome = await post.publish().then(
+                (): Error | undefined => undefined,
+                (e): Error | undefined => e as Error
+            );
+
+            expect(publishSpy).not.toHaveBeenCalled();
+            // Bailing out is a clean exit, not a failure: the caller destroyed the PKC. Today the
+            // loop instead publishes into the torn-down PKC, fails, and moves on to the next
+            // provider, where _generateChallengeRequestToPublish throws ERR_PKC_IS_DESTROYED.
+            expect(publishOutcome).to.be.undefined;
+            // The subscribe that resolved after destroy() re-established a subscription the teardown
+            // had already torn down, so bailing out has to undo it or it is left dangling on the
+            // provider for the rest of the daemon's life.
+            expect(unsubscribeOnProviderSpy.mock.calls.length).to.be.greaterThan(unsubscribeCallsWhenDestroyFinished);
+            expect(unsubscribeOnProviderSpy.mock.calls.at(-1)?.[0]).to.equal(post._communityChallengePubsubExchangeTopic());
+        } finally {
+            if (!pkc.destroyed) await pkc.destroy();
         }
     });
 });

--- a/test/node/pkc/publication-registry.test.ts
+++ b/test/node/pkc/publication-registry.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import { mockPKC, generateMockPost, resolveWhenConditionIsTrue } from "../../../dist/node/test/test-util.js";
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
+import { itSkipIfRpc } from "../../helpers/conditional-tests.js";
+
+// Node-only: starts a LocalCommunity, which is not available in the browser bundle.
+//
+// publish() registers the publication in pkc._publishingPublications before its first await so
+// that pkc.destroy() can stop it (issue #270). These tests pin the two edges of that registry:
+// a publication that never gets off the ground must not stay registered for the lifetime of the
+// PKC, and stop() must drain the background community refresh even when cleanup fails.
+describe("publication registry (pkc._publishingPublications) lifecycle", () => {
+    let pkc: PKCType;
+    let community: LocalCommunity;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = (await pkc.createCommunity()) as LocalCommunity;
+        // A question challenge parks the publication in waiting-challenge-answers until we answer,
+        // which is never. That is what keeps a publication in flight for the stop() test below.
+        await community.edit({ settings: { challenges: [{ name: "question", options: { question: "1+1=?", answer: "2" } }] } });
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+    });
+
+    afterAll(async () => {
+        if (!pkc.destroyed) await pkc.destroy();
+    });
+
+    it("a publication whose pre-flight fails does not stay registered", async () => {
+        const post = await generateMockPost({ communityAddress: community.address, pkc });
+        post.on("error", () => {});
+
+        // _initCommunity() runs before any challenge exchange exists, so its rejection never
+        // reaches _postSucessOrFailurePublishing() -- the funnel that unregisters.
+        const fetchError = new Error("mocked community fetch failure");
+        vi.spyOn(post, "_fetchCommunityForPublishing").mockRejectedValue(fetchError);
+
+        await expect(post.publish()).rejects.toThrow(fetchError);
+
+        expect(post.publishingState).to.equal("failed");
+        // Unregistration is deferred until any in-flight stale-cache refresh settles, so poll
+        // rather than assert synchronously.
+        await vi.waitFor(() => expect(pkc._publishingPublications.has(post)).toBe(false), { timeout: 30000, interval: 100 });
+    });
+
+    // Under RPC the cleanup funnel takes the _rpcPublishSubscriptionId branch, which try/catches
+    // its own unsubscribe, so there is no way to make cleanup reject and the premise does not hold.
+    itSkipIfRpc("stop() drains the background community refresh even when cleanup rejects", async () => {
+        const post = await generateMockPost({ communityAddress: community.address, pkc });
+        post.on("error", () => {});
+
+        const receivedChallenge = new Promise<void>((resolve) => post.once("challenge", () => resolve()));
+        // Deliberately not awaited: publish() does not resolve until the exchange completes, and we
+        // never answer the challenge.
+        post.publish().catch(() => {});
+        await receivedChallenge;
+
+        const unsubscribeError = new Error("mocked pubsub unsubscribe failure");
+        const unsubscribeSpy = vi.spyOn(post._clientsManager, "pubsubUnsubscribe").mockRejectedValue(unsubscribeError);
+
+        // The real refresh fired at the start of publish has already settled by now, so stand in a
+        // controlled one to observe whether stop() waits for it.
+        let drained = false;
+        post._backgroundCommunityRefresh = new Promise<void>((resolve) =>
+            setTimeout(() => {
+                drained = true;
+                resolve();
+            }, 500)
+        );
+
+        try {
+            await expect(post.stop()).rejects.toThrow(unsubscribeError);
+
+            expect(drained).to.be.true;
+            expect(post.publishingState).to.equal("stopped");
+        } finally {
+            unsubscribeSpy.mockRestore();
+        }
+    });
+});


### PR DESCRIPTION
Closes #270.

## What was wrong

`pkc.destroy()` stops updating comments, updating communities and started communities, but it
had no registry of publications that are mid-publish, so nothing stopped them. A publication
parked in `waiting-challenge-answers` stayed there after `destroy()` resolved, kept its
challenge exchange alive, and went on firing the detached stale-cache `getCommunity()` refresh
from `_fetchCommunityForPublishing` — which creates further community instances behind a
torn-down PKC.

## Changes

- `PKC._publishingPublications`: a plain `Set`, not a `TrackedInstanceRegistry`, because a
  publication has no stable key to look it up by and `destroy()` only ever iterates them.
  Publications register at the top of `publish()`, before the first await.
- `destroy()` stops publications *before* comments and communities: a publication left
  mid-exchange would otherwise re-create the very instances we are about to stop.
- The stale-cache refresh promise is held on the publication that fired it, and `stop()` drains
  it. The refresh is fired at the start of publish but can outlive the exchange it belongs to —
  `getCommunity()` on a remote community waits for an IPNS update, while a local challenge
  exchange finishes in milliseconds. So the publication stays registered until the refresh
  settles rather than unregistering as soon as the exchange ends; otherwise the publish ends, we
  unregister, and `destroy()` has nothing left to drain the refresh through.
- Regression test in `test/node/pkc/destroy-stops-publications.test.ts`.

## Verification

Test written first and confirmed red against unmodified `src/`:

```
AssertionError: expected 'waiting-challenge-answers' to equal 'stopped'
```

Green after the change. Regression control on `test/node/pkc` + `test/node/community/modqueue`
(the publish- and teardown-heaviest suites, and where the flake below shows up):

```
Test Files  17 passed | 1 skipped (18)
     Tests  866 passed | 5 skipped (871)
```

## Scope note — this does NOT fix the macOS flake

This came out of investigating `test-pkc-js-node-local (macos-latest)` in run 31934881107, where
every test passed and the job exited 1 on two
`EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending` errors attributed
to `rejection.modqueue.community.test.ts`.

The working theory was that work outliving `pkc.destroy()` was still being flushed over the
vitest worker's console RPC when the worker closed, so shrinking that trailing tail would fix
the flake. **That theory is not supported by measurement.** Counting log lines emitted after the
last `Destroyed pkc instance` in that file, across four runs of unmodified `master` in one
environment:

```
2088, 993, 2249, 2315
```

The metric varies by more than 2x run to run, and this branch measures 2287 — squarely inside
that band. No effect on the tail can be demonstrated either way, and an earlier single-run
comparison suggesting a ~15% reduction was noise.

What stands on its own is the `destroy()` gap itself: a publication genuinely was not stopped by
`destroy()`, and the regression test pins that. The macOS flake remains open and unexplained.


## Follow-up commits from review

Three further gaps in the same registry/teardown path, each with a test confirmed red against
unmodified `src/`.

**`db8c780` unregister on pre-flight publish failure.** `publish()` registers before its first
await but only `_postSucessOrFailurePublishing()` unregisters. `_initCommunity()`, signing, the
signature hook and the RPC publish call all reject before a challenge exchange exists, so every
failed publish stayed strongly referenced in `_publishingPublications` for the lifetime of the PKC
and was later stopped by `destroy()` despite never having started. The publish body moved into
`_publishAfterRegistering()` so `publish()` can unregister on any throw. Red output: the
publication never left the registry.

**`db8c780` drain the refresh when cleanup rejects.** `stop()` awaited
`_backgroundCommunityRefresh` after `_postSucessOrFailurePublishing()`, so a rejecting cleanup
skipped both the drain and the terminal state. `destroy()` catches that rejection and clears the
registry, leaving the refresh running past teardown. Both now run in a `finally`. Red output:
`expected false to be true` on the drain flag.

**`7cc6ddc` bail out of the publish loop when stopped mid-subscribe.** `stop()` and `destroy()` are
not cancellation. A pubsub subscribe already in flight resolves after teardown and the loop
publishes a challenge request behind a torn-down PKC. Both publish sites now check between
subscribing and publishing, and undo the subscribe before returning, since it re-established a
subscription after teardown already ran its unsubscribe. The check covers a plain `stop()` as well
as `destroy()`. Red output: `expected "pubsubPublishOnProvider" to not be called at all, but
actually been called 1 times`, after which the loop moved to the next provider and
`_generateChallengeRequestToPublish` threw `ERR_PKC_IS_DESTROYED` out of `publish()`.

Regression control on `test/node/pkc` (165 non-RPC, 59 RPC), `test/node/community/modqueue` (704),
the publish-path suites under `test/node-and-browser/publications` (636) and the pubsub client
state-order suites. Two failures in `test/node-and-browser/publications` were reproduced on
unmodified `src/` and are pre-existing and environmental: `Cannot set properties of undefined
(setting '_client')` in `libp2pjsClient.pubsubKuboRpcClients.clients.test.ts`, where the second
pubsub provider is absent from `pkc.clients.pubsubKuboRpcClients`, and `Failed to calculate max
page size` in `author-name-resolved.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Publications are now stopped reliably when the application is shut down, including those paused while awaiting a challenge.
  * In-progress community updates finish safely before publication cleanup completes.
  * Prevented background refresh activity from continuing after publication teardown.
  * Improved cleanup of publications that fail before publishing begins.

* **Tests**
  * Added coverage for shutdown handling, publication lifecycle cleanup, and background refresh completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
