### PR TITLE
test(crosspost): cover every tier 1 check refusing an invalid crosspost at publish()

### DIFF
--- a/test/node-and-browser/publications/comment/publish/crosspost.test.ts
+++ b/test/node-and-browser/publications/comment/publish/crosspost.test.ts
@@ -129,17 +129,71 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             });
         });
 
+        // publish() runs the same tier 1 verification the community runs at acceptance, so every check
+        // in _verifyCrosspost refuses the publication locally before a challenge is ever requested.
+        // Each case below is the client-side twin of a case in "the community enforces tier 1 at
+        // acceptance": same tampering, but with local signature validation left switched on. Every
+        // one asserts the reason, not just that something threw, since a bare toThrow() would also
+        // pass on a network failure or a broken fixture and would not prove which check refused.
+        //
+        // The one invalid crosspost that does not surface at publish() is an over-deep chain: the cap
+        // is enforced when createComment parses the options, before a Comment exists to publish. That
+        // path is covered in test/node-and-browser/crosspost/depth.test.ts.
         describe("the client refuses to publish an invalid crosspost", () => {
-            it("a cid that does not match the embedded bytes fails local validation", async () => {
-                const wrong = { ...crosspost, cid: "QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o" };
-                const post = await generateMockPost({ communityAddress, pkc, postProps: { crosspost: wrong } });
-                // Asserting the reason, not just that something threw: a bare toThrow() would also
-                // pass on a network failure or a broken fixture, so it would not prove check 1 of
-                // tier 1 is what refused the publication.
+            // Publishes nothing and asserts on the local rejection: an invalid crosspost must never
+            // reach the community's pubsub topic in the first place.
+            const expectPublishRefusedWith = async (badCrosspost: typeof crosspost, reason: string) => {
+                const post = await generateMockPost({ communityAddress, pkc, postProps: { crosspost: badCrosspost } });
                 await expect(post.publish()).rejects.toMatchObject({
                     code: "ERR_SIGNATURE_IS_INVALID",
-                    details: { signatureValidity: { reason: messages.ERR_CROSSPOST_CID_DOES_NOT_MATCH_EMBEDDED_COMMENT } }
+                    details: { signatureValidity: { reason } }
                 });
+            };
+
+            it("a cid that does not match the embedded bytes fails local validation", async () => {
+                const wrong = { ...crosspost, cid: "QmYjtig7VJQ6XsnUjqqJvj7QaMcCAwtrgNdahSiFofrE7o" };
+                await expectPublishRefusedWith(wrong, messages.ERR_CROSSPOST_CID_DOES_NOT_MATCH_EMBEDDED_COMMENT);
+            });
+
+            it("an embedded record with a broken author signature fails local validation", async () => {
+                // The cid is recomputed over the tampered bytes so check 1 passes and check 4 is what
+                // rejects: without that this would be indistinguishable from the cid mismatch above.
+                const tampered = clone(crosspost);
+                tampered.comment.content = "tampered, but consistently hashed";
+                tampered.cid = await calculateIpfsHash(deterministicStringify(tampered.comment)!);
+                await expectPublishRefusedWith(tampered, messages.ERR_CROSSPOST_COMMENT_SIGNATURE_IS_INVALID);
+            });
+
+            it("an embedded record carrying a reserved field fails local validation", async () => {
+                const tampered = clone(crosspost);
+                (tampered.comment as { cid?: string }).cid = crosspost.cid; // runtime-only on a CommentIpfs
+                tampered.cid = await calculateIpfsHash(deterministicStringify(tampered.comment)!);
+                await expectPublishRefusedWith(tampered, messages.ERR_CROSSPOST_COMMENT_INCLUDES_RESERVED_FIELD);
+            });
+
+            it("an embedded author carrying a reserved field fails local validation", async () => {
+                // author.shortAddress is derived at runtime and never on the wire. Checked separately
+                // from the record's own reserved fields, so a record that is clean at the top level
+                // can still be refused for what it carries under author.
+                const tampered = clone(crosspost);
+                (tampered.comment.author as { shortAddress?: string }).shortAddress = "somederivedshortaddress";
+                tampered.cid = await calculateIpfsHash(deterministicStringify(tampered.comment)!);
+                await expectPublishRefusedWith(tampered, messages.ERR_CROSSPOST_COMMENT_AUTHOR_INCLUDES_RESERVED_FIELD);
+            });
+
+            it("an embedded record with a signable field outside signedPropertyNames fails local validation", async () => {
+                // spoiler is signable and absent from the original, so it is absent from the record's
+                // signedPropertyNames too. Adding it after signing is the issue #249 hole: the pick
+                // down to signedPropertyNames in check 4 would drop it from what gets verified while
+                // it stays in what gets stored and rendered, so check 3 has to catch it first.
+                const tampered = clone(crosspost);
+                expect(tampered.comment.signature.signedPropertyNames).to.not.include("spoiler");
+                tampered.comment.spoiler = true;
+                tampered.cid = await calculateIpfsHash(deterministicStringify(tampered.comment)!);
+                await expectPublishRefusedWith(
+                    tampered,
+                    messages.ERR_CROSSPOST_COMMENT_INCLUDES_SIGNABLE_FIELD_NOT_IN_SIGNED_PROPERTY_NAMES
+                );
             });
         });
 


### PR DESCRIPTION
## What

`publish()` runs the same tier 1 verification the community runs at acceptance, but only **check 1** (`crosspost.cid` vs the embedded bytes) was pinned client-side. The other four checks in `_verifyCrosspost` were covered only by their community-side twins under *"the community enforces tier 1 at acceptance"*, so a regression that let a tampered crosspost past local validation would have cost the author a challenge before anything noticed.

This adds the client-side twin of each remaining check to `test/node-and-browser/publications/comment/publish/crosspost.test.ts`:

| Check | New test asserts `publish()` rejects with |
|---|---|
| 2a — reserved field on the embedded record | `ERR_CROSSPOST_COMMENT_INCLUDES_RESERVED_FIELD` |
| 2b — reserved field on the embedded author | `ERR_CROSSPOST_COMMENT_AUTHOR_INCLUDES_RESERVED_FIELD` |
| 3 — signable field outside `signedPropertyNames` | `ERR_CROSSPOST_COMMENT_INCLUDES_SIGNABLE_FIELD_NOT_IN_SIGNED_PROPERTY_NAMES` |
| 4 — broken author signature on the embedded record | `ERR_CROSSPOST_COMMENT_SIGNATURE_IS_INVALID` |

## Notes

- Every case asserts the **specific** `details.signatureValidity.reason`, not just that something threw. A bare `toThrow()` would also pass on a network failure or a broken fixture and would not prove which check refused the publication.
- Each tampering case recomputes `crosspost.cid` over the tampered bytes, so check 1 passes and the intended check is what rejects. Without that, all four would be indistinguishable from the existing cid-mismatch case.
- Check 3's fixture uses `spoiler`, which is signable and absent from the original record, so it is absent from that record's `signedPropertyNames` too. Adding it after signing is exactly the hole #249 closed: the `pick` down to `signedPropertyNames` in check 4 would drop it from what gets verified while it stays in what gets stored and rendered.
- An over-deep chain is the one invalid crosspost that never reaches `publish()`: the cap is enforced when `createComment` parses the options, and that path is already covered in `test/node-and-browser/crosspost/depth.test.ts`. Noted in a comment rather than duplicated.

## Testing

Test-only change, no `src/` changes.

- `npx tsc --project test/tsconfig.json --noEmit` passes
- `node test/run-test-config.js --pkc-config "remote-kubo-rpc,remote-pkc-rpc" test/node-and-browser/publications/comment/publish/crosspost.test.ts` — **38 passed**, both configs (Kubo Node remote and PKC RPC Remote)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for crossposted comments and authors.
  * Crossposts with mismatched content identifiers, invalid signatures, reserved fields, or incomplete signed fields are now rejected with specific reasons.

* **Documentation**
  * Clarified local validation coverage and deeper parsing checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->