### PR TITLE
fix(community): load communities whose DB predates the latest schema (#273)

### DIFF
--- a/src/runtime/node/community/db-handler.ts
+++ b/src/runtime/node/community/db-handler.ts
@@ -90,11 +90,13 @@ export class DbHandler {
     private _dbConfig!: { filename: string } & Database.Options;
     private _keyv!: KeyvBetterSqlite3;
     private _createdTables: boolean;
+    private _columnNamesByTable: Record<string, string[]>;
 
     constructor(community: DbHandler["_community"]) {
         this._community = community;
         this._transactionDepth = 0;
         this._createdTables = false;
+        this._columnNamesByTable = {};
         hideClassPrivateProps(this);
     }
 
@@ -168,6 +170,7 @@ export class DbHandler {
         await this.initDbConfigIfNeeded();
         const dbFilePath = this._dbConfig.filename;
         if (!this._db || !this._db.open) {
+            this._columnNamesByTable = {}; // a reopened file may have been migrated by another process
             this._db = new Database(dbFilePath, { ...this._dbConfig, ...dbConfigOptions });
             if (!this._db.readonly) {
                 this._db.pragma("journal_mode = WAL");
@@ -497,6 +500,7 @@ export class DbHandler {
             this._db.exec(`DROP TABLE IF EXISTS ${TABLES.COMMENT_UPDATES}`);
         }
 
+        this._columnNamesByTable = {}; // the loop below rewrites every table's schema
         const createTableFunctions = [
             this._createCommentsTable.bind(this),
             this._createCommentUpdatesTable.bind(this),
@@ -581,6 +585,7 @@ export class DbHandler {
         const newDbVersion = this.getDbVersion();
         assert.equal(newDbVersion, env.DB_VERSION);
         this._createdTables = true;
+        this._columnNamesByTable = {}; // every table now carries the latest schema
         if (needToMigrate)
             log(`Created/migrated the tables to the latest (${newDbVersion}) version and saved to path`, this._dbConfig.filename);
         if (backupDbPath) await fs.promises.rm(backupDbPath);
@@ -723,6 +728,19 @@ export class DbHandler {
     private _getColumnNames(tableName: string): string[] {
         const results = this._db.pragma(`table_info(${tableName})`) as { name: string }[];
         return results.map((col) => col.name);
+    }
+
+    // Query column lists are derived from the zod schemas, which describe the *code's* view of a
+    // record. A DB that has not been migrated yet is one or more columns behind that view, and
+    // createCommunity() reads the DB (resolveDbPostsCidRefs) before start() gets the chance to
+    // migrate it — selecting a column the table does not have throws and the community can never be
+    // loaded, let alone migrated (issue #273). Intersecting with the table's real columns keeps such
+    // a DB readable; the fields left out are optional on the wire and the migration in start()
+    // backfills the schema immediately after.
+    private _existingColumns(tableName: string, columns: string[]): string[] {
+        if (!this._columnNamesByTable[tableName]) this._columnNamesByTable[tableName] = this._getColumnNames(tableName);
+        const existing = this._columnNamesByTable[tableName];
+        return columns.filter((column) => existing.includes(column));
     }
 
     private async _copyTable(srcTable: string, dstTable: string, currentDbVersion: number) {
@@ -1451,8 +1469,8 @@ export class DbHandler {
     resolveRepliesCidRefsForEntries(entries: PageIpfs["comments"]): PageIpfs["comments"] {
         // For entries whose replies are in CID-ref format, resolve them by fetching descendants.
         // Collects all root CIDs from all entries, runs a single recursive query, then distributes results.
-        const commentUpdateCols = keys(CommentUpdateSchema.shape);
-        const commentIpfsCols = [...keys(CommentIpfsSchema.shape), "extraProps"];
+        const commentUpdateCols = this._existingColumns(TABLES.COMMENT_UPDATES, keys(CommentUpdateSchema.shape));
+        const commentIpfsCols = this._existingColumns(TABLES.COMMENTS, [...keys(CommentIpfsSchema.shape), "extraProps"]);
 
         // Gather all CIDs from CID-ref replies across all entries
         const allCids: string[] = [];
@@ -1611,8 +1629,12 @@ export class DbHandler {
     ): PageIpfs["comments"] {
         if (cids.length === 0) return [];
         const placeholders = cids.map(() => "?").join(",");
-        const commentUpdateSelects = opts.commentUpdateCols.map((col) => `cu.${col} AS commentUpdate_${col}`);
-        const commentIpfsSelects = opts.commentIpfsCols.map((col) => `c.${col} AS commentIpfs_${col}`);
+        const commentUpdateSelects = this._existingColumns(TABLES.COMMENT_UPDATES, opts.commentUpdateCols).map(
+            (col) => `cu.${col} AS commentUpdate_${col}`
+        );
+        const commentIpfsSelects = this._existingColumns(TABLES.COMMENTS, opts.commentIpfsCols).map(
+            (col) => `c.${col} AS commentIpfs_${col}`
+        );
 
         const queryStr = `
             SELECT ${commentIpfsSelects.join(", ")}, ${commentUpdateSelects.join(", ")}

--- a/test/node/community/pre-migration-load.db.community.test.ts
+++ b/test/node/community/pre-migration-load.db.community.test.ts
@@ -1,0 +1,114 @@
+// A local community whose DB is still on an older DB_VERSION must remain loadable by
+// pkc.createCommunity(), because that is the only way to reach start(), which is what runs the
+// migration. pkc-js 0.0.82 broke this: createCommunity() -> updateInstanceStateWithDbState ->
+// resolveDbPostsCidRefs queries the comments table with a column list derived from
+// CommentIpfsSchema.shape (which gained `crosspost` in DB_VERSION 41), so every pre-migration DB
+// carrying CID-ref posts threw `SqliteError: no such column: c.crosspost` before it could migrate.
+//
+// Issue: https://github.com/pkcprotocol/pkc-js/issues/273
+import { describe, beforeAll, afterAll, expect, it } from "vitest";
+import path from "node:path";
+import Database from "better-sqlite3";
+import env from "../../../dist/node/version.js";
+import {
+    mockPKC,
+    createSubWithNoChallenge,
+    publishRandomPost,
+    resolveWhenConditionIsTrue,
+    waitTillPostInCommunityInstancePages
+} from "../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
+import type { Comment } from "../../../dist/node/publications/comment/comment.js";
+
+// Rewrites a live community DB back to the state it would have had before the current DB_VERSION:
+// the `crosspost` column removed from the comments table and user_version rolled back one version.
+// This is the on-disk shape every community had after upgrading the client but before start()
+// migrated it.
+function downgradeCommunityDbBelowLatest(dbPath: string) {
+    const db = new Database(dbPath);
+    try {
+        db.pragma("foreign_keys = OFF");
+        db.exec("ALTER TABLE comments DROP COLUMN crosspost");
+        db.pragma(`user_version = ${env.DB_VERSION - 1}`);
+    } finally {
+        db.close();
+    }
+}
+
+function readCommentsColumns(dbPath: string): string[] {
+    const db = new Database(dbPath, { readonly: true });
+    try {
+        return (db.pragma("table_info(comments)") as { name: string }[]).map((col) => col.name);
+    } finally {
+        db.close();
+    }
+}
+
+function readDbVersion(dbPath: string): number {
+    const db = new Database(dbPath, { readonly: true });
+    try {
+        return db.pragma("user_version", { simple: true }) as number;
+    } finally {
+        db.close();
+    }
+}
+
+// Rewrites the community's sqlite file directly and reads DbHandler internals, neither of which is
+// reachable over RPC.
+describeSkipIfRpc("Loading a community whose DB is behind the latest DB_VERSION", () => {
+    let pkc: PKCType;
+    let community: LocalCommunity;
+    let dbPath: string;
+    let postCid: string;
+
+    beforeAll(async () => {
+        pkc = await mockPKC({});
+        community = (await createSubWithNoChallenge({}, pkc)) as LocalCommunity;
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+
+        // The failing query only runs for communities that have CID-ref posts in their internal
+        // state, which is why empty communities kept starting fine on the affected hosts.
+        const post = await publishRandomPost({ communityAddress: community.address, pkc });
+        postCid = post.cid!;
+        await waitTillPostInCommunityInstancePages(post as Comment & { cid: string }, community);
+
+        dbPath = path.join(pkc.dataPath!, "communities", community.address);
+        await community.stop();
+        downgradeCommunityDbBelowLatest(dbPath);
+    }, 180000);
+
+    afterAll(async () => {
+        await community.stop().catch(() => {});
+        await pkc.destroy();
+    });
+
+    it("the DB is set up on the pre-migration schema", () => {
+        expect(readCommentsColumns(dbPath)).to.not.include("crosspost");
+        expect(readDbVersion(dbPath)).to.equal(env.DB_VERSION - 1);
+    });
+
+    it("createCommunity() loads it instead of throwing on the missing column", async () => {
+        const reloaded = (await pkc.createCommunity({ address: community.address })) as LocalCommunity;
+        expect(reloaded.address).to.equal(community.address);
+        // The CID-ref posts still resolve, minus the column the old schema does not carry.
+        const preloadedSort = Object.keys(reloaded.posts?.pages ?? {})[0];
+        expect(preloadedSort).to.be.a("string");
+        const loadedPostCids = reloaded.posts!.pages![preloadedSort]!.comments.map((c) => c.cid);
+        expect(loadedPostCids).to.include(postCid);
+    });
+
+    it("start() then migrates the DB to the latest version", async () => {
+        const reloaded = (await pkc.createCommunity({ address: community.address })) as LocalCommunity;
+        await reloaded.start();
+        try {
+            await resolveWhenConditionIsTrue({ toUpdate: reloaded, predicate: async () => typeof reloaded.updatedAt === "number" });
+            expect(reloaded._dbHandler.getDbVersion()).to.equal(env.DB_VERSION);
+            expect(readCommentsColumns(dbPath)).to.include("crosspost");
+        } finally {
+            await reloaded.stop();
+        }
+    }, 180000);
+});


### PR DESCRIPTION
Closes #273.

## Problem

After upgrading to 0.0.82 (DB_VERSION 41), existing local communities fail to start with:

```
SqliteError: no such column: c.crosspost
```

Two production hosts saw 14 communities start and 65 fail — the 14 being the ones with no posts
in their internal state.

`createCommunity()` reads the DB *before* anything migrates it:

```
pkc.createCommunity({address})
  -> _createLocalCommunity
  -> updateInstancePropsWithStartedCommunityOrDb
  -> updateInstanceStateWithDbState
  -> resolveDbPostsCidRefs                          (src/runtime/node/util.ts)
  -> DbHandler.queryCommentAndCommentUpdateByCids   <- throws
```

`queryCommentAndCommentUpdateByCids` and `resolveRepliesCidRefsForEntries` build their SELECT lists
from `keys(CommentIpfsSchema.shape)`, which now contains `crosspost`, while the comments table on
disk is still a version behind. `createOrMigrateTablesIfNeeded()` only runs inside `start()`, which
is unreachable if the community cannot even be constructed.

This is a migration-ordering bug rather than a crosspost bug: `crosspost` is simply the first
`CommentIpfsSchema` field added since CID-ref posts (v38) landed. The v39 -> v40 bump added
`challengeCommentUpdate`, a DB-only column that never appears in these schema-derived lists, which
is why the ordering held until now. The v40 -> v41 migration itself is correct; it just never gets
to run.

## Fix

Intersect the schema-derived column lists with the columns the table actually has, in the two
queries reachable from the pre-migration read path. The fields left out are optional on the wire,
and `start()` brings the schema up to date immediately afterwards. This also immunizes future
`CommentIpfs` field additions against the same ordering trap.

The per-table column list is memoized so the extra pragma stays off the page-generation path
(`resolveRepliesCidRefsForEntries` is called per page generation), and is dropped whenever the
connection is reopened or the migration rewrites the tables.

## Tests

`test/node/community/pre-migration-load.db.community.test.ts` starts a community, publishes a post
so its internal state carries CID-ref posts, rolls the DB back to the pre-migration shape (drops
`crosspost`, `user_version = DB_VERSION - 1`), and then asserts `createCommunity()` loads it with
its posts intact and `start()` migrates it to the latest version.

Red before the change with the exact production stack:

```
SqliteError: no such column: c.crosspost
 -> DbHandler.queryCommentAndCommentUpdateByCids src/runtime/node/community/db-handler.ts:1623
 -> resolveDbPostsCidRefs src/runtime/node/util.ts:728
 -> updateInstanceStateWithDbState src/runtime/node/community/local-community/db-state.ts:130
```

Also verified against 28 real pre-migration community DBs: 26 failed to load before this change,
all 28 load and migrate v40 -> v41 after it.

Suites run (`local-kubo-rpc`): the new test, all six migration suites, `cid-ref-posts-preservation`,
`db.community`, `crosspost/db`, `crosspost/pages`, `page-generation`, `start.community` — all pass.

## Note for anyone already hit by this

Affected DBs were never modified (they never migrate), so rolling back to the previous release
restores service with nothing to undo.