### PR TITLE
feat(pkc): cancel in-flight community fetches via abortSignal, publication.stop() and destroy()

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ console.log(multisubCommunityAddresses)
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | address | `string` | The `Address` of the community |
+| options.abortSignal | `AbortSignal` | Optional. Cancels the fetch instead of waiting out the `community-ipns` timeout. Rejects with `ERR_GET_COMMUNITY_ABORTED`. |
 
 #### Returns
 
@@ -678,6 +679,13 @@ console.log(multisubCommunityAddresses)
 const communityAddress = '12D3KooW...'
 const community = await pkc.getCommunity({address: communityAddress})
 console.log(community)
+
+// Give up on a community that will not load, without waiting for the timeout
+const abortController = new AbortController()
+setTimeout(() => abortController.abort(), 10000)
+const communityOrAborted = await pkc
+  .getCommunity({address: communityAddress}, {abortSignal: abortController.signal})
+  .catch((e) => (e.code === 'ERR_GET_COMMUNITY_ABORTED' ? undefined : Promise.reject(e)))
 
 let currentPostCid = community.lastPostCid
 const scrollAllCommunityPosts = async () => {

--- a/README.md
+++ b/README.md
@@ -712,6 +712,7 @@ Prints:
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | cid | `string` | The IPFS CID of the comment |
+| abortSignal | `AbortSignal` | Optional. Cancels the fetch instead of waiting out the `comment-ipfs` timeout. Rejects with `ERR_GET_COMMENT_ABORTED`. |
 
 #### Returns
 
@@ -731,6 +732,13 @@ if (comment.parentCid) { // comment with no parent cid is a post
 }
 pkc.getCommunity({address: comment.communityAddress}).then(community => console.log('community:', community))
 pkc.getComment({cid: comment.previousCid}).then(previousComment => console.log('previous comment:', previousComment))
+
+// Give up on a comment that will not load, without waiting for the timeout
+const abortController = new AbortController()
+setTimeout(() => abortController.abort(), 10000)
+const commentOrAborted = await pkc
+  .getComment({cid: commentCid, abortSignal: abortController.signal})
+  .catch((e) => (e.code === 'ERR_GET_COMMENT_ABORTED' ? undefined : Promise.reject(e)))
 /*
 Prints:
 { ...TODO }

--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ console.log(multisubCommunityAddresses)
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | address | `string` | The `Address` of the community |
-| options.abortSignal | `AbortSignal` | Optional. Cancels the fetch instead of waiting out the `community-ipns` timeout. Rejects with `ERR_GET_COMMUNITY_ABORTED`. |
+| abortSignal | `AbortSignal` | Optional. Cancels the fetch instead of waiting out the `community-ipns` timeout. Rejects with `ERR_GET_COMMUNITY_ABORTED`. |
 
 #### Returns
 
@@ -684,7 +684,7 @@ console.log(community)
 const abortController = new AbortController()
 setTimeout(() => abortController.abort(), 10000)
 const communityOrAborted = await pkc
-  .getCommunity({address: communityAddress}, {abortSignal: abortController.signal})
+  .getCommunity({address: communityAddress, abortSignal: abortController.signal})
   .catch((e) => (e.code === 'ERR_GET_COMMUNITY_ABORTED' ? undefined : Promise.reject(e)))
 
 let currentPostCid = community.lastPostCid

--- a/src/community/rpc-remote-community.ts
+++ b/src/community/rpc-remote-community.ts
@@ -352,14 +352,21 @@ export class RpcRemoteCommunity extends RemoteCommunity {
 
         if (this._updatingRpcCommunityInstanceWithListeners) {
             await this._cleanupMirroringUpdatingCommunity();
-        } else if (this._updateRpcSubscriptionId) {
-            try {
-                await this._pkc._pkcRpcClient!.unsubscribe(this._updateRpcSubscriptionId);
-            } catch (e) {
-                log.error("Failed to unsubscribe from communityUpdate", e);
+        } else {
+            if (this._updateRpcSubscriptionId) {
+                try {
+                    await this._pkc._pkcRpcClient!.unsubscribe(this._updateRpcSubscriptionId);
+                } catch (e) {
+                    log.error("Failed to unsubscribe from communityUpdate", e);
+                }
+                this._updateRpcSubscriptionId = undefined;
+                log.trace(`Stopped the update of remote community (${this.address}) via RPC`);
             }
-            this._updateRpcSubscriptionId = undefined;
-            log.trace(`Stopped the update of remote community (${this.address}) via RPC`);
+            // Untracked even without a subscription id. _createAndSubscribeToNewUpdatingCommunity
+            // tracks the instance BEFORE _initRpcUpdateSubscription assigns that id, so a subscribe
+            // that fails or is cancelled used to leave a stopped instance sitting in
+            // _updatingCommunities for findUpdatingCommunity to hand out (issue #277). untrack() is
+            // identity-keyed and a no-op for an instance that was never tracked.
             untrackUpdatingCommunity(this._pkc, this);
         }
         this._setRpcClientStateWithEmission("stopped");

--- a/src/community/schema.ts
+++ b/src/community/schema.ts
@@ -453,7 +453,9 @@ export const CommunityIpfsReservedFields = difference(
         "publishingState",
         "updatingState",
         "started",
-        "exports"
+        "exports",
+        // getCommunity() argument, never part of a record (issue #275)
+        "abortSignal"
     ],
     keys(CommunityIpfsSchema.shape)
 );

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -20,6 +20,7 @@ export enum messages {
     ERR_FETCH_OVER_IPNS_OVER_PUBSUB_RETURNED_UNDEFINED = "libp2p Fetch over IPNS-Over-Pubsub returned undefined when requested from a peer",
     ERR_FAILED_TO_DIAL_ANY_PEERS_PROVIDING_CID = "Failed to dial and connect to any peers providing a CID",
     ERR_GET_COMMUNITY_TIMED_OUT = "pkc.getCommunity({address}) timed out",
+    ERR_GET_COMMUNITY_ABORTED = "Aborted while waiting for the community record to load",
     ERR_TIMEOUT_WAITING_FOR_PUBSUB_TOPIC_PEERS = "Timeout waiting for propagation of pubsub topic peers",
     ERR_PUBSUB_TOPIC_PEER_WAIT_ABORTED = "Aborted while waiting for a peer to subscribe to a pubsub topic",
     ERR_IPNS_DIRECT_FETCH_ABORTED = "Aborted while fetching an IPNS record directly from subscribers/providers",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -22,6 +22,7 @@ export enum messages {
     ERR_GET_COMMUNITY_TIMED_OUT = "pkc.getCommunity({address}) timed out",
     ERR_GET_COMMUNITY_ABORTED = "Aborted while waiting for the community record to load",
     ERR_COMMUNITY_STOPPED_WHILE_LOADING = "The community instance was stopped while its record was being loaded",
+    ERR_GET_COMMENT_ABORTED = "Aborted while waiting for the comment record to load",
     ERR_TIMEOUT_WAITING_FOR_PUBSUB_TOPIC_PEERS = "Timeout waiting for propagation of pubsub topic peers",
     ERR_PUBSUB_TOPIC_PEER_WAIT_ABORTED = "Aborted while waiting for a peer to subscribe to a pubsub topic",
     ERR_IPNS_DIRECT_FETCH_ABORTED = "Aborted while fetching an IPNS record directly from subscribers/providers",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -21,6 +21,7 @@ export enum messages {
     ERR_FAILED_TO_DIAL_ANY_PEERS_PROVIDING_CID = "Failed to dial and connect to any peers providing a CID",
     ERR_GET_COMMUNITY_TIMED_OUT = "pkc.getCommunity({address}) timed out",
     ERR_GET_COMMUNITY_ABORTED = "Aborted while waiting for the community record to load",
+    ERR_COMMUNITY_STOPPED_WHILE_LOADING = "The community instance was stopped while its record was being loaded",
     ERR_TIMEOUT_WAITING_FOR_PUBSUB_TOPIC_PEERS = "Timeout waiting for propagation of pubsub topic peers",
     ERR_PUBSUB_TOPIC_PEER_WAIT_ABORTED = "Aborted while waiting for a peer to subscribe to a pubsub topic",
     ERR_IPNS_DIRECT_FETCH_ABORTED = "Aborted while fetching an IPNS record directly from subscribers/providers",

--- a/src/pkc/pkc-with-rpc-client.ts
+++ b/src/pkc/pkc-with-rpc-client.ts
@@ -73,11 +73,11 @@ export class PKCWithRpcClient extends PKC {
         return this.createComment({ ...parsedArgs, raw: { ...(parsedArgs as CommentJson)?.raw, comment: commentIpfs } });
     }
 
-    override async getCommunity(getCommunityArgs: GetCommunityArgs) {
+    override async getCommunity(getCommunityArgs: GetCommunityArgs, options?: { abortSignal?: AbortSignal }) {
         if (!getCommunityArgs.address && !getCommunityArgs.name && !getCommunityArgs.publicKey) {
             throw new Error("At least one of address, name, or publicKey must be provided");
         }
-        return super.getCommunity(getCommunityArgs);
+        return super.getCommunity(getCommunityArgs, options);
     }
 
     override async createCommunity(

--- a/src/pkc/pkc-with-rpc-client.ts
+++ b/src/pkc/pkc-with-rpc-client.ts
@@ -8,6 +8,7 @@ import { RpcRemoteCommunity } from "../community/rpc-remote-community.js";
 import type { RpcLocalCommunityJson, RpcLocalCommunityUpdateResultType, RpcRemoteCommunityJson } from "../community/types.js";
 import { z } from "zod";
 import { PKCError } from "../pkc-error.js";
+import { rejectWhenCommunityStopsOrAborts, throwIfAbortSignalAborted } from "../util.js";
 import type { AuthorNameRpcParam, CidRpcParam } from "../clients/rpc-client/types.js";
 import { parseRpcAuthorNameParam, parseRpcCidParam, parseRpcFetchCidParam } from "../clients/rpc-client/rpc-schema-util.js";
 import { listStartedCommunities } from "./tracked-instance-registry-util.js";
@@ -81,9 +82,11 @@ export class PKCWithRpcClient extends PKC {
     }
 
     override async createCommunity(
-        options: z.infer<typeof CreateRpcCommunityFunctionArgumentSchema> | RpcRemoteCommunityJson | RpcLocalCommunityJson = {}
+        options: z.infer<typeof CreateRpcCommunityFunctionArgumentSchema> | RpcRemoteCommunityJson | RpcLocalCommunityJson = {},
+        opts?: { abortSignal?: AbortSignal }
     ): Promise<RpcLocalCommunity | RpcRemoteCommunity> {
         const log = Logger("pkc-js:pkc-with-rpc-client:createCommunity");
+        throwIfAbortSignalAborted(opts?.abortSignal);
 
         // No need to parse if it's a jsonified instance
         const parsedRpcOptions =
@@ -127,9 +130,28 @@ export class PKCWithRpcClient extends PKC {
                 const updatePromise = new Promise((resolve) => community.once("update", resolve));
                 let error: PKCError | Error | undefined;
                 const errorPromise = new Promise((resolve) => community.once("error", (err) => resolve((error = err))));
-                await community._createAndSubscribeToNewUpdatingCommunity(community);
-                await community.update();
-                await Promise.race([updatePromise, errorPromise]);
+                // Every wait below is unbounded: the subscribe call may never be answered, and the
+                // server may never push an update for a community it hosts. Without something to
+                // lose to, an aborting caller (and pkc.destroy(), which cannot reach into this
+                // function) is left with a promise that never settles — issue #277. The instance is
+                // tracked in _updatingCommunities before the first wait, so a third-party stop()
+                // reaches it too, and that is the second way out.
+                const cancellation = rejectWhenCommunityStopsOrAborts({
+                    community,
+                    abortSignal: this._combineWithDestroyAbortSignal(opts?.abortSignal)
+                });
+                try {
+                    await Promise.race([community._createAndSubscribeToNewUpdatingCommunity(community), cancellation.promise]);
+                    await Promise.race([community.update(), cancellation.promise]);
+                    await Promise.race([updatePromise, errorPromise, cancellation.promise]);
+                } catch (e) {
+                    // stop() is a no-op on an instance that is already stopped, which is exactly the
+                    // case when we lost to a stop rather than to an abort.
+                    await community.stop().catch((stopErr) => log.error("Failed to stop a cancelled community instance", stopErr));
+                    throw e;
+                } finally {
+                    cancellation.cleanup();
+                }
                 await community.stop();
                 if (error) throw error;
                 await community._attachExportsSubscription();

--- a/src/pkc/pkc-with-rpc-client.ts
+++ b/src/pkc/pkc-with-rpc-client.ts
@@ -1,6 +1,6 @@
 import Logger from "../logger.js";
 import { PKC } from "./pkc.js";
-import type { InputPKCOptions, GetCommunityArgs } from "../types.js";
+import type { InputPKCOptions, GetCommunityArgs, GetCommentArgs } from "../types.js";
 import { parseCreateRpcCommunityFunctionArgumentSchemaWithPKCErrorIfItFails } from "../schema/schema-util.js";
 import { CreateRpcCommunityFunctionArgumentSchema } from "../community/schema.js";
 import { RpcLocalCommunity } from "../community/rpc-local-community.js";
@@ -8,11 +8,12 @@ import { RpcRemoteCommunity } from "../community/rpc-remote-community.js";
 import type { RpcLocalCommunityJson, RpcLocalCommunityUpdateResultType, RpcRemoteCommunityJson } from "../community/types.js";
 import { z } from "zod";
 import { PKCError } from "../pkc-error.js";
-import { rejectWhenCommunityStopsOrAborts, throwIfAbortSignalAborted } from "../util.js";
+import { rejectWhenAbortSignalFires, rejectWhenCommunityStopsOrAborts, throwIfAbortSignalAborted } from "../util.js";
 import type { AuthorNameRpcParam, CidRpcParam } from "../clients/rpc-client/types.js";
 import { parseRpcAuthorNameParam, parseRpcCidParam, parseRpcFetchCidParam } from "../clients/rpc-client/rpc-schema-util.js";
 import { listStartedCommunities } from "./tracked-instance-registry-util.js";
 import { CommentJson } from "../publications/comment/types.js";
+import type PKCRpcClient from "../clients/rpc-client/pkc-rpc-client.js";
 
 // This is a helper class for separating RPC-client logic from main PKC
 // Not meant to be used with end users
@@ -68,9 +69,22 @@ export class PKCWithRpcClient extends PKC {
         await this._pkcRpcClient.destroy();
     }
 
-    override async getComment(commentCid: CidRpcParam) {
-        const parsedArgs = parseRpcCidParam(commentCid);
-        const commentIpfs = await this._pkcRpcClient.getComment(parsedArgs);
+    // The RPC call below has no cancellation of its own, so an aborting caller (and pkc.destroy(),
+    // which cannot reach into this function) would be left waiting on it. Racing the combined signal
+    // gives them a way out, matching the direct path in PKC.getComment (issue #278).
+    override async getComment(getCommentArgs: GetCommentArgs) {
+        const { abortSignal, ...cidArgs } = getCommentArgs;
+        const parsedArgs = parseRpcCidParam(cidArgs);
+        const cancellation = rejectWhenAbortSignalFires({
+            abortSignal: this._combineWithDestroyAbortSignal(abortSignal),
+            error: () => new PKCError("ERR_GET_COMMENT_ABORTED", { getCommentArgs: parsedArgs, abortReason: abortSignal?.reason })
+        });
+        let commentIpfs: Awaited<ReturnType<PKCRpcClient["getComment"]>>;
+        try {
+            commentIpfs = await Promise.race([this._pkcRpcClient.getComment(parsedArgs), cancellation.promise]);
+        } finally {
+            cancellation.cleanup();
+        }
         return this.createComment({ ...parsedArgs, raw: { ...(parsedArgs as CommentJson)?.raw, comment: commentIpfs } });
     }
 

--- a/src/pkc/pkc-with-rpc-client.ts
+++ b/src/pkc/pkc-with-rpc-client.ts
@@ -73,11 +73,11 @@ export class PKCWithRpcClient extends PKC {
         return this.createComment({ ...parsedArgs, raw: { ...(parsedArgs as CommentJson)?.raw, comment: commentIpfs } });
     }
 
-    override async getCommunity(getCommunityArgs: GetCommunityArgs, options?: { abortSignal?: AbortSignal }) {
+    override async getCommunity(getCommunityArgs: GetCommunityArgs) {
         if (!getCommunityArgs.address && !getCommunityArgs.name && !getCommunityArgs.publicKey) {
             throw new Error("At least one of address, name, or publicKey must be provided");
         }
-        return super.getCommunity(getCommunityArgs, options);
+        return super.getCommunity(getCommunityArgs);
     }
 
     override async createCommunity(

--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -464,15 +464,23 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         hideClassPrivateProps(this);
     }
 
-    async getCommunity(getCommunityArgs: GetCommunityArgs) {
+    // `options.abortSignal` unwinds the IPNS wait below immediately instead of blocking for
+    // `_timeouts["community-ipns"]`, and rejects with ERR_GET_COMMUNITY_ABORTED. It is a second
+    // parameter rather than a key on `getCommunityArgs` because that object is forwarded verbatim to
+    // createCommunity(), whose schemas are `.strict()`, and because it is the RPC-facing shape (#275).
+    async getCommunity(getCommunityArgs: GetCommunityArgs, options?: { abortSignal?: AbortSignal }) {
         if (!getCommunityArgs.address && !getCommunityArgs.name && !getCommunityArgs.publicKey) {
             throw new Error("At least one of address, name, or publicKey must be provided");
         }
+        // Same code as an abort mid-fetch, so callers have one thing to check regardless of when the
+        // signal fired, and we skip creating an instance we would only stop again.
+        if (options?.abortSignal?.aborted)
+            throw new PKCError("ERR_GET_COMMUNITY_ABORTED", { getCommunityArgs, abortReason: options.abortSignal.reason });
         const community = await this.createCommunity(getCommunityArgs);
 
         if (typeof community.createdAt === "number") return <RpcLocalCommunity | LocalCommunity>community; // It's a local community, and already has been loaded, no need to wait
         const timeoutMs = this._timeouts["community-ipns"];
-        await waitForUpdateInCommunityInstanceWithErrorAndTimeout(community, timeoutMs);
+        await waitForUpdateInCommunityInstanceWithErrorAndTimeout(community, timeoutMs, options?.abortSignal);
 
         return community;
     }

--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -31,7 +31,8 @@ import {
     isStringDomain,
     removeUndefinedValuesRecursively,
     timestamp,
-    resolveWhenPredicateIsTrue
+    resolveWhenPredicateIsTrue,
+    throwIfAbortSignalAborted
 } from "../util.js";
 import Vote from "../publications/vote/vote.js";
 import { createSigner, verifyCommentPubsubMessage } from "../signer/index.js";
@@ -475,7 +476,7 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         // Same code as an abort mid-fetch, so callers have one thing to check regardless of when the
         // signal fired, and we skip creating an instance we would only stop again.
         if (abortSignal?.aborted) throw new PKCError("ERR_GET_COMMUNITY_ABORTED", { communityIdentifier, abortReason: abortSignal.reason });
-        const community = await this.createCommunity(communityIdentifier);
+        const community = await this.createCommunity(communityIdentifier, { abortSignal });
 
         if (typeof community.createdAt === "number") return <RpcLocalCommunity | LocalCommunity>community; // It's a local community, and already has been loaded, no need to wait
         const timeoutMs = this._timeouts["community-ipns"];
@@ -823,10 +824,16 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         else return this._createRemoteCommunityInstance(jsonfied);
     }
 
+    // `opts.abortSignal` is a second parameter rather than a key on `options`, because `options` is
+    // zod-parsed by `.strict()` schemas that would reject the extra key. It only has teeth on the
+    // RPC path, whose local-community branch parks on waits with no timeout (issue #277); here it
+    // just refuses to start work the caller has already given up on.
     async createCommunity(
-        options: z.infer<typeof CreateCommunityFunctionArgumentsSchema> | CommunityJson = {}
+        options: z.infer<typeof CreateCommunityFunctionArgumentsSchema> | CommunityJson = {},
+        opts?: { abortSignal?: AbortSignal }
     ): Promise<RemoteCommunity | RpcRemoteCommunity | RpcLocalCommunity | LocalCommunity> {
         const log = Logger("pkc-js:pkc:createCommunity");
+        throwIfAbortSignalAborted(opts?.abortSignal);
         if ("clients" in options) return this._createCommunityInstanceFromJsonifiedCommunity(<CommunityJson>options);
         const parsedOptions = <z.infer<typeof CreateCommunityFunctionArgumentsSchema>>options;
         log.trace("Received options: ", parsedOptions);
@@ -1203,8 +1210,22 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     }
 
     _getDestroyAbortSignal(): AbortSignal {
-        if (!this._destroyAbortController) this._destroyAbortController = new AbortController();
+        if (!this._destroyAbortController) {
+            this._destroyAbortController = new AbortController();
+            // destroy() aborts with `?.`, so nothing happens there if no caller had asked for the
+            // signal yet. Without this, the first caller to ask afterwards is handed a live signal
+            // for a pkc that is already torn down, and waits on it forever (issue #277).
+            if (this.destroyed) this._destroyAbortController.abort(new PKCError("ERR_PKC_IS_DESTROYED"));
+        }
         return this._destroyAbortController.signal;
+    }
+
+    // Folds teardown into a caller's signal, so work nobody explicitly cancelled still stops when the
+    // pkc is destroyed. Returns the destroy signal untouched when there is nothing to combine, which
+    // keeps AbortSignal.any() (and the listener it registers on both sources) off the common path.
+    _combineWithDestroyAbortSignal(abortSignal?: AbortSignal): AbortSignal {
+        const destroySignal = this._getDestroyAbortSignal();
+        return abortSignal ? AbortSignal.any([abortSignal, destroySignal]) : destroySignal;
     }
 
     async destroy() {

--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -19,7 +19,8 @@ import type {
     AuthorPubsubType,
     PKCMemCaches,
     CreatePublicationOptions,
-    GetCommunityArgs
+    GetCommunityArgs,
+    GetCommentArgs
 } from "../types.js";
 import { Comment } from "../publications/comment/comment.js";
 import {
@@ -485,9 +486,18 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         return community;
     }
 
-    async getComment(cid: CidRpcParam): Promise<Comment> {
+    // `abortSignal` unwinds the CommentIpfs wait below immediately instead of blocking for
+    // `_timeouts["comment-ipfs"]`, and rejects with ERR_GET_COMMENT_ABORTED (issue #278). It has to
+    // be split off before the rest reaches createComment(), which would otherwise carry the signal
+    // onto the instance — the same reason `abortSignal` is a reserved comment field.
+    async getComment(getCommentArgs: GetCommentArgs): Promise<Comment> {
         const log = Logger("pkc-js:pkc:getComment");
-        const parsedGetCommentArgs = parseRpcCidParam(cid);
+        const { abortSignal, ...cidArgs } = getCommentArgs;
+        const parsedGetCommentArgs = parseRpcCidParam(cidArgs);
+        // Same code as an abort mid-fetch, so callers have one thing to check regardless of when the
+        // signal fired, and we skip creating an instance we would only stop again.
+        if (abortSignal?.aborted)
+            throw new PKCError("ERR_GET_COMMENT_ABORTED", { getCommentArgs: parsedGetCommentArgs, abortReason: abortSignal.reason });
         // getComment is interested in loading CommentIpfs only
         const comment = await this.createComment(parsedGetCommentArgs);
 
@@ -496,9 +506,32 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         const errorListener = (err: Error) => (lastUpdateError = err);
         comment.on("error", errorListener);
 
+        // Rejects the race below on abort. Reported as ERR_GET_COMMENT_ABORTED rather than as the
+        // timeout, so callers can tell a slow network from a cancellation.
+        let abortError: PKCError | undefined;
+        let abortReject: ((err: PKCError) => void) | undefined;
+        const abortListener = () => {
+            abortError = new PKCError("ERR_GET_COMMENT_ABORTED", {
+                getCommentArgs: parsedGetCommentArgs,
+                abortReason: abortSignal?.reason,
+                lastUpdateError
+            });
+            abortReject?.(abortError);
+        };
+        const abortPromise = new Promise<never>((_, reject) => {
+            abortReject = reject;
+        });
+        // pTimeout attaches its own handler, but only once we hand it the race below. Give it one up
+        // front so an abort landing before that never surfaces as an unhandled rejection.
+        void abortPromise.catch(() => {});
+        // The signal outlives this call (a caller's long-lived stop signal), so the listener is
+        // removed in the `finally` on every outcome. `{ once: true }` alone only detaches it when
+        // abort fires, which leaks one listener per call (issues #145, #146).
+        abortSignal?.addEventListener("abort", abortListener);
+
         const commentTimeout = this._timeouts["comment-ipfs"];
         try {
-            await pTimeout(comment._attemptInfintelyToLoadCommentIpfs(), {
+            await pTimeout(Promise.race([comment._attemptInfintelyToLoadCommentIpfs(), abortPromise]), {
                 milliseconds: commentTimeout,
                 message:
                     lastUpdateError ||
@@ -507,9 +540,13 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
             if (!comment.signature) throw Error("Failed to load CommentIpfs");
             return comment;
         } catch (e) {
+            // Abort wins over whatever else the comment happened to emit: the caller cancelled on
+            // purpose, so reporting a stale retriable error instead would be misleading.
+            if (abortError) throw abortError;
             if (lastUpdateError) throw lastUpdateError;
             throw e;
         } finally {
+            abortSignal?.removeEventListener("abort", abortListener);
             comment.removeListener("error", errorListener);
             await comment.stop();
         }

--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -464,23 +464,22 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         hideClassPrivateProps(this);
     }
 
-    // `options.abortSignal` unwinds the IPNS wait below immediately instead of blocking for
-    // `_timeouts["community-ipns"]`, and rejects with ERR_GET_COMMUNITY_ABORTED. It is a second
-    // parameter rather than a key on `getCommunityArgs` because that object is forwarded verbatim to
-    // createCommunity(), whose schemas are `.strict()`, and because it is the RPC-facing shape (#275).
-    async getCommunity(getCommunityArgs: GetCommunityArgs, options?: { abortSignal?: AbortSignal }) {
-        if (!getCommunityArgs.address && !getCommunityArgs.name && !getCommunityArgs.publicKey) {
+    // `abortSignal` unwinds the IPNS wait below immediately instead of blocking for
+    // `_timeouts["community-ipns"]`, and rejects with ERR_GET_COMMUNITY_ABORTED (issue #275). It has
+    // to be split off before the rest reaches createCommunity(), whose schemas are `.strict()`.
+    async getCommunity(getCommunityArgs: GetCommunityArgs) {
+        const { abortSignal, ...communityIdentifier } = getCommunityArgs;
+        if (!communityIdentifier.address && !communityIdentifier.name && !communityIdentifier.publicKey) {
             throw new Error("At least one of address, name, or publicKey must be provided");
         }
         // Same code as an abort mid-fetch, so callers have one thing to check regardless of when the
         // signal fired, and we skip creating an instance we would only stop again.
-        if (options?.abortSignal?.aborted)
-            throw new PKCError("ERR_GET_COMMUNITY_ABORTED", { getCommunityArgs, abortReason: options.abortSignal.reason });
-        const community = await this.createCommunity(getCommunityArgs);
+        if (abortSignal?.aborted) throw new PKCError("ERR_GET_COMMUNITY_ABORTED", { communityIdentifier, abortReason: abortSignal.reason });
+        const community = await this.createCommunity(communityIdentifier);
 
         if (typeof community.createdAt === "number") return <RpcLocalCommunity | LocalCommunity>community; // It's a local community, and already has been loaded, no need to wait
         const timeoutMs = this._timeouts["community-ipns"];
-        await waitForUpdateInCommunityInstanceWithErrorAndTimeout(community, timeoutMs, options?.abortSignal);
+        await waitForUpdateInCommunityInstanceWithErrorAndTimeout({ community, timeoutMs, abortSignal });
 
         return community;
     }

--- a/src/publications/comment/schema.ts
+++ b/src/publications/comment/schema.ts
@@ -309,7 +309,11 @@ const additionalCommentReservedFields = [
     "publishingState",
     "updatingState",
     "rowid",
-    "nameResolved"
+    "nameResolved",
+    // Runtime-only, accepted by pkc.getComment({cid, abortSignal}) and stripped before the rest
+    // reaches createComment. Reserved so a record arriving on the wire carrying that key is rejected
+    // rather than carried onto the instance (issue #278).
+    "abortSignal"
 ] as const;
 
 type AdditionalCommentReservedField = (typeof additionalCommentReservedFields)[number];

--- a/src/publications/publication-client-manager.ts
+++ b/src/publications/publication-client-manager.ts
@@ -169,10 +169,15 @@ export class PublicationClientsManager extends PKCClientsManager {
             findStartedCommunity(this._pkc, { publicKey: this._publication.communityPublicKey, name: this._publication.communityName });
         const community =
             directCommunityInstance ||
-            (await this._pkc.createCommunity({
-                name: this._publication.communityName,
-                publicKey: this._publication.communityPublicKey
-            }));
+            // Under RPC, createCommunity() parks on unbounded waits for a community the server hosts,
+            // so stop() has to reach this call too, not just the IPNS wait below (issue #277).
+            (await this._pkc.createCommunity(
+                {
+                    name: this._publication.communityName,
+                    publicKey: this._publication.communityPublicKey
+                },
+                { abortSignal: this._publication._getCommunityFetchAbortSignal() }
+            ));
 
         this._communityForUpdating = {
             community: community,

--- a/src/publications/publication-client-manager.ts
+++ b/src/publications/publication-client-manager.ts
@@ -346,7 +346,13 @@ export class PublicationClientsManager extends PKCClientsManager {
         if (!updatingCommunityInstance.community.raw.communityIpfs) {
             const timeoutMs = this._pkc._timeouts["community-ipns"];
             try {
-                await waitForUpdateInCommunityInstanceWithErrorAndTimeout(updatingCommunityInstance.community, timeoutMs);
+                // The publication's stop/destroy signal, so stop() cancels this fetch rather than
+                // leaving the caller blocked for the whole community-ipns timeout (issue #275).
+                await waitForUpdateInCommunityInstanceWithErrorAndTimeout(
+                    updatingCommunityInstance.community,
+                    timeoutMs,
+                    this._publication._getCommunityFetchAbortSignal()
+                );
                 communityIpfs = updatingCommunityInstance.community.raw.communityIpfs!;
             } catch (e) {
                 await this.cleanUpUpdatingCommunityInstance();

--- a/src/publications/publication-client-manager.ts
+++ b/src/publications/publication-client-manager.ts
@@ -348,11 +348,11 @@ export class PublicationClientsManager extends PKCClientsManager {
             try {
                 // The publication's stop/destroy signal, so stop() cancels this fetch rather than
                 // leaving the caller blocked for the whole community-ipns timeout (issue #275).
-                await waitForUpdateInCommunityInstanceWithErrorAndTimeout(
-                    updatingCommunityInstance.community,
+                await waitForUpdateInCommunityInstanceWithErrorAndTimeout({
+                    community: updatingCommunityInstance.community,
                     timeoutMs,
-                    this._publication._getCommunityFetchAbortSignal()
-                );
+                    abortSignal: this._publication._getCommunityFetchAbortSignal()
+                });
                 communityIpfs = updatingCommunityInstance.community.raw.communityIpfs!;
             } catch (e) {
                 await this.cleanUpUpdatingCommunityInstance();

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -793,10 +793,11 @@ class Publication extends TypedEmitter<PublicationEvents> {
                 // Held on the publication so stop() can drain it. Without that the refresh outlives
                 // the PKC and goes on creating community instances after teardown (issue #270).
                 const refresh = this._pkc
-                    .getCommunity(
-                        { publicKey: this.communityPublicKey, name: this.communityName },
-                        { abortSignal: this._getCommunityFetchAbortSignal() }
-                    )
+                    .getCommunity({
+                        publicKey: this.communityPublicKey,
+                        name: this.communityName,
+                        abortSignal: this._getCommunityFetchAbortSignal()
+                    })
                     .catch((e) => {
                         // Cancelling the refresh is what stop() asked for, so it is not an error.
                         if (e?.code === "ERR_GET_COMMUNITY_ABORTED")

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -118,6 +118,11 @@ class Publication extends TypedEmitter<PublicationEvents> {
     // In-flight stale-cache community refresh fired by _fetchCommunityForPublishing. Deliberately
     // not awaited by the publish path, so stop() drains it (issue #270).
     _backgroundCommunityRefresh?: Promise<unknown>;
+    // Aborted by stop(), so a community fetch that is already in flight unwinds immediately instead
+    // of blocking the caller for the whole community-ipns timeout (issue #275). Combined once with
+    // pkc's destroy signal; recreated per publish() so a stopped publication can be published again.
+    private _communityFetchAbortController?: AbortController;
+    private _communityFetchAbortSignal?: AbortSignal;
 
     _challengeExchanges: Record<
         string, // challengeRequestId stringified
@@ -739,6 +744,24 @@ class Publication extends TypedEmitter<PublicationEvents> {
         return getPKCAddressFromPublicKeySync(encryptionPublicKey);
     }
 
+    // Fires when this publication is stopped or its pkc is destroyed. Built once and cached rather
+    // than composed per call: AbortSignal.any() registers on both sources every time it is called.
+    _getCommunityFetchAbortSignal(): AbortSignal {
+        if (!this._communityFetchAbortSignal) {
+            this._communityFetchAbortController = new AbortController();
+            this._communityFetchAbortSignal = AbortSignal.any([
+                this._communityFetchAbortController.signal,
+                this._pkc._getDestroyAbortSignal()
+            ]);
+        }
+        return this._communityFetchAbortSignal;
+    }
+
+    private _resetCommunityFetchAbortSignal() {
+        this._communityFetchAbortController = undefined;
+        this._communityFetchAbortSignal = undefined;
+    }
+
     _getCommunityCache(): NonNullable<Publication["_community"]> | undefined {
         const cached = this._pkc._memCaches.communityForPublishing.get(this.communityAddress, { allowStale: true });
         if (cached) return cached;
@@ -770,8 +793,16 @@ class Publication extends TypedEmitter<PublicationEvents> {
                 // Held on the publication so stop() can drain it. Without that the refresh outlives
                 // the PKC and goes on creating community instances after teardown (issue #270).
                 const refresh = this._pkc
-                    .getCommunity({ publicKey: this.communityPublicKey, name: this.communityName })
-                    .catch((e) => log.error("Failed to update cache of community", this.communityAddress, e))
+                    .getCommunity(
+                        { publicKey: this.communityPublicKey, name: this.communityName },
+                        { abortSignal: this._getCommunityFetchAbortSignal() }
+                    )
+                    .catch((e) => {
+                        // Cancelling the refresh is what stop() asked for, so it is not an error.
+                        if (e?.code === "ERR_GET_COMMUNITY_ABORTED")
+                            log("Stopped the background refresh of the community cache", this.communityAddress);
+                        else log.error("Failed to update cache of community", this.communityAddress, e);
+                    })
                     .finally(() => {
                         if (this._backgroundCommunityRefresh === refresh) this._backgroundCommunityRefresh = undefined;
                     });
@@ -782,6 +813,12 @@ class Publication extends TypedEmitter<PublicationEvents> {
     }
 
     async stop() {
+        // Abort first, so the drain below unwinds an in-flight fetch instead of waiting it out. Only
+        // stop() does this, never the success funnel: a refresh fired to warm a stale cache should
+        // still finish after a publish succeeds.
+        this._communityFetchAbortController?.abort(
+            new PKCError("ERR_GET_COMMUNITY_ABORTED", { publicationType: this.getType(), communityAddress: this.communityAddress })
+        );
         try {
             await this._postSucessOrFailurePublishing();
         } finally {
@@ -1285,6 +1322,9 @@ class Publication extends TypedEmitter<PublicationEvents> {
 
     async publish() {
         this._validatePublicationFields();
+        // A previous stop() left the signal aborted, which would cancel this attempt's community
+        // fetch before it started.
+        if (this._getCommunityFetchAbortSignal().aborted) this._resetCommunityFetchAbortSignal();
         // Track before the first await so pkc.destroy() can stop us no matter how far the exchange
         // has progressed. Untracked in _postSucessOrFailurePublishing once the exchange ends, or in
         // the catch below if publish never got that far.

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,14 @@ export type NameResolver = z.infer<typeof NameResolverSchema>;
 export type InputPKCOptions = z.input<typeof PKCUserOptionsSchema>;
 export type ParsedPKCOptions = z.output<typeof PKCParsedOptionsSchema>;
 
-export type GetCommunityArgs = { address?: string; name?: CommunityIpfsType["name"]; publicKey?: string };
+export type GetCommunityArgs = {
+    address?: string;
+    name?: CommunityIpfsType["name"];
+    publicKey?: string;
+    // Cancels the IPNS wait instead of blocking for _timeouts["community-ipns"]. Stripped before the
+    // rest is forwarded to createCommunity(), whose schemas are .strict() (issue #275).
+    abortSignal?: AbortSignal;
+};
 
 export type AuthorPubsubType = z.infer<typeof AuthorPubsubSchema>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,7 @@ import { LRUCache } from "lru-cache";
 import type { CommunityIpfsType } from "./community/types.js";
 import type { PageIpfs } from "./pages/types.js";
 import type { CommentIpfsType } from "./publications/comment/types.js";
+import type { CidRpcParam } from "./clients/rpc-client/types.js";
 
 export type ProtocolVersion = z.infer<typeof ProtocolVersionSchema>;
 export type ChainTicker = z.infer<typeof ChainTickerSchema>;
@@ -33,6 +34,13 @@ export type GetCommunityArgs = {
     publicKey?: string;
     // Cancels the IPNS wait instead of blocking for _timeouts["community-ipns"]. Stripped before the
     // rest is forwarded to createCommunity(), whose schemas are .strict() (issue #275).
+    abortSignal?: AbortSignal;
+};
+
+// `abortSignal` cancels the CommentIpfs wait instead of blocking for _timeouts["comment-ipfs"].
+// Stripped before the rest reaches createComment(), whose schemas would otherwise carry it onto the
+// instance (issue #278). The rest of the shape is CidRpcParam, which is `.loose()`.
+export type GetCommentArgs = CidRpcParam & {
     abortSignal?: AbortSignal;
 };
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -608,6 +608,31 @@ export async function resolveWhenPredicateIsTrue(options: {
     });
 }
 
+// Loses a race the moment `abortSignal` fires. For waits that have no timeout and no cancellation of
+// their own, so an aborting caller (or pkc.destroy()) has something for the wait to lose to.
+//
+// Returns a `cleanup` the caller MUST run on every outcome — the signal outlives the wait (a
+// publication's stop signal, pkc's destroy signal), so relying on `{ once: true }` would leak one
+// listener per call (issues #145, #146).
+export function rejectWhenAbortSignalFires(opts: { abortSignal?: AbortSignal; error: () => PKCError }): {
+    promise: Promise<never>;
+    cleanup: () => void;
+} {
+    const { abortSignal, error } = opts;
+    let rejectPromise: ((err: PKCError) => void) | undefined;
+    const promise = new Promise<never>((_, reject) => {
+        rejectPromise = reject;
+    });
+    // A caller that throws before racing this would otherwise turn a pre-aborted signal into an
+    // unhandled rejection. Racing attaches its own handler, so nothing is swallowed.
+    void promise.catch(() => {});
+    const onAbort = () => rejectPromise?.(error());
+    abortSignal?.addEventListener("abort", onAbort);
+    const cleanup = () => abortSignal?.removeEventListener("abort", onAbort);
+    if (abortSignal?.aborted) onAbort();
+    return { promise, cleanup };
+}
+
 // Loses a race when the caller cancels or when `community` is stopped out from under us. Both are
 // ways a community load stops being wanted while it is parked on a wait that has no timeout of its
 // own, e.g. the RPC-local branch of PKCWithRpcClient.createCommunity() (issue #277). pkc.destroy()

--- a/src/util.ts
+++ b/src/util.ts
@@ -613,11 +613,12 @@ export async function resolveWhenPredicateIsTrue(options: {
 // stopping the community itself: the instance may be shared (see `findUpdatingCommunity` and
 // `_numOfListenersForUpdatingInstance`), and only the `!wasUpdating` branch there knows whether we
 // own it. See issue #275.
-export async function waitForUpdateInCommunityInstanceWithErrorAndTimeout(
-    community: RemoteCommunity,
-    timeoutMs: number,
-    abortSignal?: AbortSignal
-) {
+export async function waitForUpdateInCommunityInstanceWithErrorAndTimeout(opts: {
+    community: RemoteCommunity;
+    timeoutMs: number;
+    abortSignal?: AbortSignal;
+}) {
+    const { community, timeoutMs, abortSignal } = opts;
     const wasUpdating = community.state === "updating";
     const updatingStates: RemoteCommunity["updatingState"][] = [];
     const updatingStateChangeListener = (state: RemoteCommunity["updatingState"]) => updatingStates.push(state);

--- a/src/util.ts
+++ b/src/util.ts
@@ -608,7 +608,16 @@ export async function resolveWhenPredicateIsTrue(options: {
     });
 }
 
-export async function waitForUpdateInCommunityInstanceWithErrorAndTimeout(community: RemoteCommunity, timeoutMs: number) {
+// `abortSignal` is a fourth way the race below can lose, alongside update / non-retriable error /
+// timeout. Deliberately routed through the same `finally` as every other outcome rather than
+// stopping the community itself: the instance may be shared (see `findUpdatingCommunity` and
+// `_numOfListenersForUpdatingInstance`), and only the `!wasUpdating` branch there knows whether we
+// own it. See issue #275.
+export async function waitForUpdateInCommunityInstanceWithErrorAndTimeout(
+    community: RemoteCommunity,
+    timeoutMs: number,
+    abortSignal?: AbortSignal
+) {
     const wasUpdating = community.state === "updating";
     const updatingStates: RemoteCommunity["updatingState"][] = [];
     const updatingStateChangeListener = (state: RemoteCommunity["updatingState"]) => updatingStates.push(state);
@@ -643,10 +652,39 @@ export async function waitForUpdateInCommunityInstanceWithErrorAndTimeout(commun
         }
     };
     community.on("error", errorListener);
+    // Rejects the race on abort. Reported as ERR_GET_COMMUNITY_ABORTED rather than reusing
+    // ERR_GET_COMMUNITY_TIMED_OUT so callers can tell a slow network from a cancellation.
+    let abortError: PKCError | undefined;
+    let abortReject: ((err: PKCError) => void) | undefined;
+    const abortListener = () => {
+        abortError = new PKCError("ERR_GET_COMMUNITY_ABORTED", {
+            communityAddress: community.address,
+            abortReason: abortSignal?.reason,
+            updatingStates,
+            errors
+        });
+        abortReject?.(abortError);
+    };
+    const abortPromise = new Promise<never>((_, reject) => {
+        abortReject = reject;
+    });
+    // The paths that throw `abortError` directly never hand `abortPromise` to the race, so give it a
+    // handler up front or a pre-aborted signal turns into an unhandled rejection. The race attaches
+    // its own handler, so this does not swallow anything.
+    void abortPromise.catch(() => {});
+    // The signal outlives this call (a publication's stop signal, pkc's destroy signal), so the
+    // listener is removed in the `finally` below on every outcome. `{ once: true }` alone only
+    // detaches it when abort fires, which leaks one listener per call (issues #145, #146).
+    if (abortSignal) {
+        if (abortSignal.aborted) abortListener();
+        else abortSignal.addEventListener("abort", abortListener);
+    }
     try {
+        if (abortError) throw abortError;
         if (community.state !== "started") await community.update();
+        if (abortError) throw abortError; // abort may have landed while update() was in flight
         if (criticalError) throw criticalError; // Non-retriable error may have fired synchronously during update (e.g. RPC emitAllPendingMessages replay)
-        await pTimeout(Promise.race([updatePromise, nonRetriableErrorPromise]), {
+        await pTimeout(Promise.race([updatePromise, nonRetriableErrorPromise, abortPromise]), {
             milliseconds: timeoutMs,
             message:
                 criticalError ||
@@ -661,6 +699,9 @@ export async function waitForUpdateInCommunityInstanceWithErrorAndTimeout(commun
         });
         if (criticalError) throw criticalError;
     } catch (e) {
+        // Abort wins over whatever else the community happened to emit: the caller cancelled on
+        // purpose, so reporting a stale retriable error instead would be misleading.
+        if (abortError) throw abortError;
         if (criticalError) throw criticalError;
         if (errors.length > 0) throw errors.at(-1);
         const updatingCommunity = findUpdatingCommunity(community._pkc, { publicKey: community.publicKey, name: community.name });
@@ -668,6 +709,7 @@ export async function waitForUpdateInCommunityInstanceWithErrorAndTimeout(commun
             throw updatingCommunity._clientsManager._ipnsLoadingOperation.mainError();
         throw e;
     } finally {
+        abortSignal?.removeEventListener("abort", abortListener);
         if (updateListener) community.removeListener("update", updateListener);
         community.removeListener("error", errorListener);
         community.removeListener("updatingstatechange", updatingStateChangeListener);

--- a/src/util.ts
+++ b/src/util.ts
@@ -608,6 +608,44 @@ export async function resolveWhenPredicateIsTrue(options: {
     });
 }
 
+// Loses a race when the caller cancels or when `community` is stopped out from under us. Both are
+// ways a community load stops being wanted while it is parked on a wait that has no timeout of its
+// own, e.g. the RPC-local branch of PKCWithRpcClient.createCommunity() (issue #277). pkc.destroy()
+// takes both routes: it fires the destroy signal first, then stops every tracked updating community.
+//
+// Returns a `cleanup` the caller MUST run on every outcome — the signal outlives the load (a
+// publication's stop signal, pkc's destroy signal), so relying on `{ once: true }` would leak one
+// listener per call (issues #145, #146).
+export function rejectWhenCommunityStopsOrAborts(opts: { community: RemoteCommunity; abortSignal?: AbortSignal }): {
+    promise: Promise<never>;
+    cleanup: () => void;
+} {
+    const { community, abortSignal } = opts;
+    let rejectPromise: ((err: PKCError) => void) | undefined;
+    const promise = new Promise<never>((_, reject) => {
+        rejectPromise = reject;
+    });
+    // A caller that throws before racing this would otherwise turn a pre-aborted signal into an
+    // unhandled rejection. Racing attaches its own handler, so nothing is swallowed.
+    void promise.catch(() => {});
+    const onAbort = () =>
+        rejectPromise?.(
+            new PKCError("ERR_GET_COMMUNITY_ABORTED", { communityAddress: community.address, abortReason: abortSignal?.reason })
+        );
+    const onStateChange = (newState: RemoteCommunity["state"]) => {
+        if (newState === "stopped")
+            rejectPromise?.(new PKCError("ERR_COMMUNITY_STOPPED_WHILE_LOADING", { communityAddress: community.address }));
+    };
+    community.on("statechange", onStateChange);
+    abortSignal?.addEventListener("abort", onAbort);
+    const cleanup = () => {
+        community.removeListener("statechange", onStateChange);
+        abortSignal?.removeEventListener("abort", onAbort);
+    };
+    if (abortSignal?.aborted) onAbort();
+    return { promise, cleanup };
+}
+
 // `abortSignal` is a fourth way the race below can lose, alongside update / non-retriable error /
 // timeout. Deliberately routed through the same `finally` as every other outcome rather than
 // stopping the community itself: the instance may be shared (see `findUpdatingCommunity` and

--- a/test/node-and-browser/community/getcommunity.abort.test.ts
+++ b/test/node-and-browser/community/getcommunity.abort.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { describe, it, beforeAll, afterAll, expect, vi } from "vitest";
 import { getAvailablePKCConfigsToTestAgainst } from "../../../dist/node/test/test-util.js";
 import { CommunityIpfsReservedFields } from "../../../dist/node/community/schema.js";
 import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
 import type { PKCError } from "../../../dist/node/pkc-error.js";
 import type { RemoteCommunity } from "../../../dist/node/community/remote-community.js";
+import { findUpdatingCommunity } from "../../../dist/node/pkc/tracked-instance-registry-util.js";
 
 // pkc.getCommunity() on a community whose IPNS record never resolves blocks for the whole
 // _timeouts["community-ipns"] (5 minutes by default). These tests pin that an abortSignal unwinds it
@@ -27,23 +28,25 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
         it("rejects with ERR_GET_COMMUNITY_ABORTED when the signal fires mid-fetch", async () => {
             const abortController = new AbortController();
-            const startedAt = Date.now();
             const getCommunityPromise = pkc.getCommunity({
                 address: unresolvableCommunityAddress,
                 abortSignal: abortController.signal
             });
-            const timer = setTimeout(() => abortController.abort(), 1000);
+            // Abort only once the fetch is genuinely in flight, so this exercises the cancellation
+            // path rather than the pre-aborted one covered below.
+            await vi.waitFor(() => expect(pkc._updatingCommunities.size()).to.equal(1), { timeout: 30000, interval: 20 });
 
+            const abortedAt = Date.now();
+            abortController.abort();
             const error = await getCommunityPromise.then(
                 (): PKCError | undefined => undefined,
                 (e): PKCError | undefined => e as PKCError
             );
-            clearTimeout(timer);
 
             expect(error).to.be.an("Error");
             expect(error?.code).to.equal("ERR_GET_COMMUNITY_ABORTED");
-            // The point of the signal: we come back on abort, not on the timeout.
-            expect(Date.now() - startedAt).to.be.lessThan(30000);
+            // The point of the signal: we come back on abort, not on the community-ipns timeout.
+            expect(Date.now() - abortedAt).to.be.lessThan(30000);
         });
 
         it("rejects immediately when the signal is already aborted", async () => {
@@ -64,9 +67,9 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
                 address: unresolvableCommunityAddress,
                 abortSignal: abortController.signal
             });
-            const timer = setTimeout(() => abortController.abort(), 1000);
+            await vi.waitFor(() => expect(pkc._updatingCommunities.size()).to.equal(1), { timeout: 30000, interval: 20 });
+            abortController.abort();
             await getCommunityPromise.catch(() => {});
-            clearTimeout(timer);
 
             // getCommunity() owns the instance it created, so abort has to leave the registry as
             // empty as a successful one-shot fetch would.
@@ -88,12 +91,20 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
                     address: unresolvableCommunityAddress,
                     abortSignal: abortController.signal
                 });
-                const timer = setTimeout(() => abortController.abort(), 1000);
+                // getCommunity() does not create a second registry entry here, both instances mirror
+                // the one tracked instance, so wait for its listener count to include ours.
+                await vi.waitFor(
+                    () =>
+                        expect(
+                            findUpdatingCommunity(pkc, { publicKey: unresolvableCommunityAddress })?._numOfListenersForUpdatingInstance
+                        ).to.equal(2),
+                    { timeout: 30000, interval: 20 }
+                );
+                abortController.abort();
                 const error = await getCommunityPromise.then(
                     (): PKCError | undefined => undefined,
                     (e): PKCError | undefined => e as PKCError
                 );
-                clearTimeout(timer);
 
                 expect(error?.code).to.equal("ERR_GET_COMMUNITY_ABORTED");
                 expect(community.state).to.equal("updating");

--- a/test/node-and-browser/community/getcommunity.abort.test.ts
+++ b/test/node-and-browser/community/getcommunity.abort.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { getAvailablePKCConfigsToTestAgainst } from "../../../dist/node/test/test-util.js";
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { PKCError } from "../../../dist/node/pkc-error.js";
+import type { RemoteCommunity } from "../../../dist/node/community/remote-community.js";
+
+// pkc.getCommunity() on a community whose IPNS record never resolves blocks for the whole
+// _timeouts["community-ipns"] (5 minutes by default). These tests pin that an abortSignal unwinds it
+// immediately, reports it distinctly from a timeout, and leaves no community instance running
+// behind (issue #275).
+getAvailablePKCConfigsToTestAgainst().map((config) => {
+    describe(`pkc.getCommunity abortSignal - ${config.name}`, () => {
+        let pkc: PKCType;
+        let unresolvableCommunityAddress: string;
+
+        beforeAll(async () => {
+            pkc = await config.pkcInstancePromise();
+            // A signer whose key was never imported into any IPNS node, so nothing ever resolves for
+            // it and getCommunity() keeps retrying until the community-ipns timeout.
+            unresolvableCommunityAddress = (await pkc.createSigner()).address;
+        });
+
+        afterAll(async () => {
+            await pkc.destroy();
+        });
+
+        it("rejects with ERR_GET_COMMUNITY_ABORTED when the signal fires mid-fetch", async () => {
+            const abortController = new AbortController();
+            const startedAt = Date.now();
+            const getCommunityPromise = pkc.getCommunity(
+                { address: unresolvableCommunityAddress },
+                { abortSignal: abortController.signal }
+            );
+            const timer = setTimeout(() => abortController.abort(), 1000);
+
+            const error = await getCommunityPromise.then(
+                (): PKCError | undefined => undefined,
+                (e): PKCError | undefined => e as PKCError
+            );
+            clearTimeout(timer);
+
+            expect(error).to.be.an("Error");
+            expect(error?.code).to.equal("ERR_GET_COMMUNITY_ABORTED");
+            // The point of the signal: we come back on abort, not on the timeout.
+            expect(Date.now() - startedAt).to.be.lessThan(30000);
+        });
+
+        it("rejects immediately when the signal is already aborted", async () => {
+            const startedAt = Date.now();
+            const error = await pkc.getCommunity({ address: unresolvableCommunityAddress }, { abortSignal: AbortSignal.abort() }).then(
+                (): PKCError | undefined => undefined,
+                (e): PKCError | undefined => e as PKCError
+            );
+
+            expect(error?.code).to.equal("ERR_GET_COMMUNITY_ABORTED");
+            expect(Date.now() - startedAt).to.be.lessThan(30000);
+            expect(pkc._updatingCommunities.size()).to.equal(0);
+        });
+
+        it("stops the community instance it created when aborted", async () => {
+            const abortController = new AbortController();
+            const getCommunityPromise = pkc.getCommunity(
+                { address: unresolvableCommunityAddress },
+                { abortSignal: abortController.signal }
+            );
+            const timer = setTimeout(() => abortController.abort(), 1000);
+            await getCommunityPromise.catch(() => {});
+            clearTimeout(timer);
+
+            // getCommunity() owns the instance it created, so abort has to leave the registry as
+            // empty as a successful one-shot fetch would.
+            expect(pkc._updatingCommunities.size()).to.equal(0);
+        });
+
+        it("does not stop a community instance that somebody else is updating", async () => {
+            // getCommunity() attaches to the already-updating instance rather than resolving IPNS
+            // itself, so an unconditional stop() on abort would tear down a community the caller
+            // below is still using.
+            const community = <RemoteCommunity>await pkc.createCommunity({ address: unresolvableCommunityAddress });
+            community.on("error", () => {});
+            await community.update();
+            expect(pkc._updatingCommunities.size()).to.equal(1);
+
+            try {
+                const abortController = new AbortController();
+                const getCommunityPromise = pkc.getCommunity(
+                    { address: unresolvableCommunityAddress },
+                    { abortSignal: abortController.signal }
+                );
+                const timer = setTimeout(() => abortController.abort(), 1000);
+                const error = await getCommunityPromise.then(
+                    (): PKCError | undefined => undefined,
+                    (e): PKCError | undefined => e as PKCError
+                );
+                clearTimeout(timer);
+
+                expect(error?.code).to.equal("ERR_GET_COMMUNITY_ABORTED");
+                expect(community.state).to.equal("updating");
+                expect(pkc._updatingCommunities.size()).to.equal(1);
+            } finally {
+                await community.stop();
+            }
+        });
+    });
+});

--- a/test/node-and-browser/community/getcommunity.abort.test.ts
+++ b/test/node-and-browser/community/getcommunity.abort.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import { getAvailablePKCConfigsToTestAgainst } from "../../../dist/node/test/test-util.js";
+import { CommunityIpfsReservedFields } from "../../../dist/node/community/schema.js";
 import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
 import type { PKCError } from "../../../dist/node/pkc-error.js";
 import type { RemoteCommunity } from "../../../dist/node/community/remote-community.js";
@@ -27,10 +28,10 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
         it("rejects with ERR_GET_COMMUNITY_ABORTED when the signal fires mid-fetch", async () => {
             const abortController = new AbortController();
             const startedAt = Date.now();
-            const getCommunityPromise = pkc.getCommunity(
-                { address: unresolvableCommunityAddress },
-                { abortSignal: abortController.signal }
-            );
+            const getCommunityPromise = pkc.getCommunity({
+                address: unresolvableCommunityAddress,
+                abortSignal: abortController.signal
+            });
             const timer = setTimeout(() => abortController.abort(), 1000);
 
             const error = await getCommunityPromise.then(
@@ -47,7 +48,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
         it("rejects immediately when the signal is already aborted", async () => {
             const startedAt = Date.now();
-            const error = await pkc.getCommunity({ address: unresolvableCommunityAddress }, { abortSignal: AbortSignal.abort() }).then(
+            const error = await pkc.getCommunity({ address: unresolvableCommunityAddress, abortSignal: AbortSignal.abort() }).then(
                 (): PKCError | undefined => undefined,
                 (e): PKCError | undefined => e as PKCError
             );
@@ -59,10 +60,10 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
         it("stops the community instance it created when aborted", async () => {
             const abortController = new AbortController();
-            const getCommunityPromise = pkc.getCommunity(
-                { address: unresolvableCommunityAddress },
-                { abortSignal: abortController.signal }
-            );
+            const getCommunityPromise = pkc.getCommunity({
+                address: unresolvableCommunityAddress,
+                abortSignal: abortController.signal
+            });
             const timer = setTimeout(() => abortController.abort(), 1000);
             await getCommunityPromise.catch(() => {});
             clearTimeout(timer);
@@ -83,10 +84,10 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
             try {
                 const abortController = new AbortController();
-                const getCommunityPromise = pkc.getCommunity(
-                    { address: unresolvableCommunityAddress },
-                    { abortSignal: abortController.signal }
-                );
+                const getCommunityPromise = pkc.getCommunity({
+                    address: unresolvableCommunityAddress,
+                    abortSignal: abortController.signal
+                });
                 const timer = setTimeout(() => abortController.abort(), 1000);
                 const error = await getCommunityPromise.then(
                     (): PKCError | undefined => undefined,
@@ -101,5 +102,14 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
                 await community.stop();
             }
         });
+    });
+});
+
+// abortSignal lives on getCommunity()'s argument object, which is the same shape a caller can hand
+// createCommunity(), so a record arriving on the wire with that key has to be rejected rather than
+// carried onto the instance.
+describe("abortSignal is a reserved community field", () => {
+    it("is included in CommunityIpfsReservedFields", () => {
+        expect(CommunityIpfsReservedFields).to.include("abortSignal");
     });
 });

--- a/test/node-and-browser/publications/comment/getcomment.abort.test.ts
+++ b/test/node-and-browser/publications/comment/getcomment.abort.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, beforeAll, afterAll, expect, vi } from "vitest";
+import { getAvailablePKCConfigsToTestAgainst, isRpcFlagOn, resolveWhenConditionIsTrue } from "../../../../dist/node/test/test-util.js";
+import signers from "../../../fixtures/signers.js";
+import { calculateIpfsCidV0 } from "../../../../dist/node/util.js";
+import { CommentIpfsReservedFields, CommentPubsubMessageReservedFields } from "../../../../dist/node/publications/comment/schema.js";
+import type { PKC } from "../../../../dist/node/pkc/pkc.js";
+import type { Comment } from "../../../../dist/node/publications/comment/comment.js";
+import type { RemoteCommunity } from "../../../../dist/node/community/remote-community.js";
+import type { PKCError } from "../../../../dist/node/pkc-error.js";
+
+// pkc.getComment() on a cid that nothing on the network has blocks for the whole
+// _timeouts["comment-ifps"]. These tests pin that an abortSignal unwinds it immediately, reports it
+// distinctly from a timeout, and leaves no comment instance running behind (issue #278).
+getAvailablePKCConfigsToTestAgainst().map((config) => {
+    describe(`pkc.getComment abortSignal - ${config.name}`, () => {
+        let pkc: PKC;
+        let unloadableCid: string;
+
+        beforeAll(async () => {
+            pkc = await config.pkcInstancePromise();
+            // A cid derived from content that was never added to any node, so the retry loop inside
+            // getComment keeps going until the comment-ipfs timeout.
+            unloadableCid = await calculateIpfsCidV0("getcomment-abort-" + Math.random());
+        });
+
+        afterAll(async () => {
+            await pkc.destroy();
+        });
+
+        it("rejects with ERR_GET_COMMENT_ABORTED when the signal fires mid-fetch", async () => {
+            const abortController = new AbortController();
+            // The two paths park in different places, so each needs its own proof that the fetch is
+            // genuinely in flight before aborting — otherwise this silently degrades into the
+            // pre-aborted case covered below. Directly, getComment retries inside a Comment instance
+            // it does not expose, so spy on createComment for a handle on it (spyOn with no
+            // implementation calls through). Under RPC there is no local instance at all: getComment
+            // is parked on the RPC call itself, so wait for that call to have been issued.
+            const rpcGetCommentSpy = isRpcFlagOn() ? vi.spyOn(pkc._pkcRpcClient!, "getComment") : undefined;
+            const createCommentSpy = isRpcFlagOn() ? undefined : vi.spyOn(pkc, "createComment");
+            try {
+                const getCommentPromise = pkc.getComment({ cid: unloadableCid, abortSignal: abortController.signal });
+                const inFlightSpy = rpcGetCommentSpy ?? createCommentSpy!;
+                await vi.waitFor(() => expect(inFlightSpy.mock.calls.length).to.equal(1), { timeout: 30000, interval: 20 });
+
+                let comment: Comment | undefined;
+                if (createCommentSpy) {
+                    comment = <Comment>await createCommentSpy.mock.results[0].value;
+                    await vi.waitFor(() => expect(comment!.updatingState).to.equal("fetching-ipfs"), { timeout: 30000, interval: 20 });
+                }
+
+                const abortedAt = Date.now();
+                abortController.abort();
+                const error = await getCommentPromise.then(
+                    (): PKCError | undefined => undefined,
+                    (e): PKCError | undefined => e as PKCError
+                );
+
+                expect(error).to.be.an("Error");
+                expect(error?.code).to.equal("ERR_GET_COMMENT_ABORTED");
+                // The point of the signal: we come back on abort, not on the comment-ipfs timeout.
+                expect(Date.now() - abortedAt).to.be.lessThan(30000);
+                // getComment owns the instance it created, so abort has to stop it the same way a
+                // successful or timed-out fetch would.
+                if (comment) expect(comment.state).to.equal("stopped");
+            } finally {
+                createCommentSpy?.mockRestore();
+                rpcGetCommentSpy?.mockRestore();
+            }
+        });
+
+        it("rejects immediately when the signal is already aborted", async () => {
+            const startedAt = Date.now();
+            const error = await pkc.getComment({ cid: unloadableCid, abortSignal: AbortSignal.abort() }).then(
+                (): PKCError | undefined => undefined,
+                (e): PKCError | undefined => e as PKCError
+            );
+
+            expect(error?.code).to.equal("ERR_GET_COMMENT_ABORTED");
+            expect(Date.now() - startedAt).to.be.lessThan(30000);
+            expect(pkc._updatingComments.size()).to.equal(0);
+        });
+
+        it("still loads a comment normally when a signal is given but never fires", async () => {
+            // The signal is inert unless it fires, so an unaborted one must not change the outcome.
+            const community = <RemoteCommunity>await pkc.createCommunity({ address: signers[0].address });
+            await community.update();
+            await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+            const existingCid = community.lastPostCid!;
+            await community.stop();
+            expect(existingCid).to.be.a("string");
+
+            const abortController = new AbortController();
+            const comment = await pkc.getComment({ cid: existingCid, abortSignal: abortController.signal });
+            expect(comment.cid).to.equal(existingCid);
+            expect(comment.signature).to.be.a("object");
+        });
+    });
+});
+
+// abortSignal lives on getComment()'s argument object, which is the same shape a caller can hand
+// createComment(), so a record arriving on the wire with that key has to be rejected rather than
+// carried onto the instance.
+describe("abortSignal is a reserved comment field", () => {
+    it("is included in CommentIpfsReservedFields", () => {
+        expect(CommentIpfsReservedFields).to.include("abortSignal");
+    });
+
+    it("is included in CommentPubsubMessageReservedFields", () => {
+        expect(CommentPubsubMessageReservedFields).to.include("abortSignal");
+    });
+});

--- a/test/node-and-browser/publications/stop-aborts-community-fetch.test.ts
+++ b/test/node-and-browser/publications/stop-aborts-community-fetch.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, beforeAll, afterAll, expect, vi } from "vitest";
+import { getAvailablePKCConfigsToTestAgainst, generateMockPost } from "../../../dist/node/test/test-util.js";
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { PKCError } from "../../../dist/node/pkc-error.js";
+
+// stop() and destroy() used to be unable to cancel a community fetch that was already in flight, so
+// publishing against a community whose IPNS record never resolves kept the caller blocked for the
+// whole _timeouts["community-ipns"] (5 minutes by default) after they had already stopped it.
+// Issue #275.
+getAvailablePKCConfigsToTestAgainst().map((config) => {
+    describe(`publication.stop() aborts the in-flight community fetch - ${config.name}`, () => {
+        let pkc: PKCType;
+        let unresolvableCommunityAddress: string;
+
+        beforeAll(async () => {
+            pkc = await config.pkcInstancePromise();
+            // A signer whose key was never imported into any IPNS node: nothing ever resolves for it.
+            unresolvableCommunityAddress = (await pkc.createSigner()).address;
+        });
+
+        afterAll(async () => {
+            if (!pkc.destroyed) await pkc.destroy();
+        });
+
+        it("unwinds publish() well before the community-ipns timeout", async () => {
+            const post = await generateMockPost({ communityAddress: unresolvableCommunityAddress, pkc });
+            post.on("error", () => {});
+
+            const publishOutcome = post.publish().then(
+                (): PKCError | undefined => undefined,
+                (e): PKCError | undefined => e as PKCError
+            );
+            // Only stop once the fetch is actually in flight, otherwise we would be testing the
+            // already-aborted path instead of cancellation.
+            await vi.waitFor(() => expect(post.publishingState).to.be.oneOf(["resolving-community-name", "fetching-community-ipns"]), {
+                timeout: 30000,
+                interval: 50
+            });
+
+            const stoppedAt = Date.now();
+            await post.stop();
+            const error = await publishOutcome;
+
+            expect(error?.code).to.equal("ERR_GET_COMMUNITY_ABORTED");
+            expect(Date.now() - stoppedAt).to.be.lessThan(30000);
+            expect(pkc._updatingCommunities.size()).to.equal(0);
+            expect(pkc._publishingPublications.has(post)).to.be.false;
+        });
+
+        it("unwinds publish() when the pkc is destroyed mid-fetch", async () => {
+            const localPKC = await config.pkcInstancePromise();
+            const post = await generateMockPost({ communityAddress: (await localPKC.createSigner()).address, pkc: localPKC });
+            post.on("error", () => {});
+
+            const publishOutcome = post.publish().then(
+                (): PKCError | undefined => undefined,
+                (e): PKCError | undefined => e as PKCError
+            );
+            await vi.waitFor(() => expect(post.publishingState).to.be.oneOf(["resolving-community-name", "fetching-community-ipns"]), {
+                timeout: 30000,
+                interval: 50
+            });
+
+            const destroyedAt = Date.now();
+            await localPKC.destroy();
+            const error = await publishOutcome;
+
+            expect(error).to.be.an("Error");
+            expect(Date.now() - destroyedAt).to.be.lessThan(30000);
+        });
+    });
+});

--- a/test/node/community/waitForUpdate.race.test.ts
+++ b/test/node/community/waitForUpdate.race.test.ts
@@ -31,7 +31,7 @@ describe("waitForUpdateInCommunityInstanceWithErrorAndTimeout - race condition",
         // With the fix it should throw ERR_INVALID_JSON almost immediately.
         const start = Date.now();
         await expect(
-            waitForUpdateInCommunityInstanceWithErrorAndTimeout(mockCommunity as unknown as RemoteCommunity, 5000)
+            waitForUpdateInCommunityInstanceWithErrorAndTimeout({ community: mockCommunity as unknown as RemoteCommunity, timeoutMs: 5000 })
         ).rejects.toThrow("The loaded file is not the expected json");
         const elapsed = Date.now() - start;
         // Should resolve in well under 1s, not wait for the 5s timeout
@@ -65,7 +65,10 @@ describe("waitForUpdateInCommunityInstanceWithErrorAndTimeout - race condition",
         };
 
         // Should NOT throw — the retriable error is ignored, waits for the update event
-        await waitForUpdateInCommunityInstanceWithErrorAndTimeout(mockCommunity as unknown as RemoteCommunity, 5000);
+        await waitForUpdateInCommunityInstanceWithErrorAndTimeout({
+            community: mockCommunity as unknown as RemoteCommunity,
+            timeoutMs: 5000
+        });
     });
 
     it("throws last retriable error on timeout when no non-retriable error occurs", async () => {
@@ -91,8 +94,8 @@ describe("waitForUpdateInCommunityInstanceWithErrorAndTimeout - race condition",
         };
 
         // Should throw the retriable error (not ERR_GET_COMMUNITY_TIMED_OUT)
-        await expect(waitForUpdateInCommunityInstanceWithErrorAndTimeout(mockCommunity as unknown as RemoteCommunity, 200)).rejects.toThrow(
-            "Failed to resolve IPNS through IPFS P2P"
-        );
+        await expect(
+            waitForUpdateInCommunityInstanceWithErrorAndTimeout({ community: mockCommunity as unknown as RemoteCommunity, timeoutMs: 200 })
+        ).rejects.toThrow("Failed to resolve IPNS through IPFS P2P");
     });
 });

--- a/test/node/rpc/getcommunity-abort-rpc-local.rpc.test.ts
+++ b/test/node/rpc/getcommunity-abort-rpc-local.rpc.test.ts
@@ -1,0 +1,79 @@
+// #275 follow-up: getCommunity()'s abortSignal reaches the IPNS wait in
+// waitForUpdateInCommunityInstanceWithErrorAndTimeout, but not createCommunity(), which runs first.
+// For a community the RPC server hosts, PKCWithRpcClient.createCommunity() takes the
+// isCommunityRpcLocal branch and blocks inside _createAndSubscribeToNewUpdatingCommunity ->
+// _initRpcUpdateSubscription, and then on `Promise.race([updatePromise, errorPromise])`. Neither has
+// a timeout and neither sees the signal, so a caller that aborts (or destroys the pkc) stays
+// blocked. The instance is already tracked in pkc._updatingCommunities by then, which is why
+// stopping it is a plausible way to unblock the wait.
+import { describe, it, expect, vi } from "vitest";
+import { mockRpcRemotePKC } from "../../../dist/node/test/test-util.js";
+import { itIfRpc } from "../../helpers/conditional-tests.js";
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { PKCError } from "../../../dist/node/pkc-error.js";
+
+const STILL_PENDING = "still pending" as const;
+
+// Resolves to STILL_PENDING if `promise` has not settled within `ms`, so a hang is reported as a
+// failed assertion instead of a 160s vitest timeout with no explanation.
+function settleWithin<T>(promise: Promise<T>, ms: number): Promise<T | typeof STILL_PENDING> {
+    return Promise.race([promise, new Promise<typeof STILL_PENDING>((resolve) => setTimeout(() => resolve(STILL_PENDING), ms))]);
+}
+
+describe("pkc.getCommunity abortSignal on a community the RPC server hosts", () => {
+    itIfRpc("abort unwinds getCommunity while the update subscription is still pending", async () => {
+        const pkc: PKCType = await mockRpcRemotePKC();
+        try {
+            // Created over RPC, so its address lands in pkc.communities and getCommunity() below
+            // takes the isCommunityRpcLocal branch.
+            const localCommunity = await pkc.createCommunity();
+            const communityAddress = localCommunity.address;
+
+            // Models an RPC server that accepts the subscribe and never answers it. Mocked on the
+            // client so the per-call RPC timeout (#196) does not fire and mask the hang.
+            vi.spyOn(pkc._pkcRpcClient!, "communityUpdateSubscribe").mockImplementation(() => new Promise(() => {}));
+
+            const abortController = new AbortController();
+            const getCommunityOutcome = pkc.getCommunity({ address: communityAddress, abortSignal: abortController.signal }).then(
+                (): Error | undefined => undefined,
+                (e): Error | undefined => e as Error
+            );
+            abortController.abort();
+
+            const outcome = await settleWithin(getCommunityOutcome, 10000);
+            expect(outcome, "getCommunity() ignored the abort and is still waiting on the RPC subscription").to.not.equal(STILL_PENDING);
+            expect((outcome as PKCError | undefined)?.code).to.equal("ERR_GET_COMMUNITY_ABORTED");
+            // The instance is tracked before the first wait, so cancelling has to stop it rather
+            // than leave a dead entry behind for findUpdatingCommunity to hand out.
+            expect(pkc._updatingCommunities.size()).to.equal(0);
+        } finally {
+            // destroy() is itself part of what this bug blocks, so do not let it hang the run.
+            await settleWithin(pkc.destroy(), 20000);
+        }
+    });
+
+    itIfRpc("destroy() unwinds getCommunity while the update subscription is still pending", async () => {
+        const pkc: PKCType = await mockRpcRemotePKC();
+        try {
+            const localCommunity = await pkc.createCommunity();
+            const communityAddress = localCommunity.address;
+            vi.spyOn(pkc._pkcRpcClient!, "communityUpdateSubscribe").mockImplementation(() => new Promise(() => {}));
+
+            const getCommunityOutcome = pkc.getCommunity({ address: communityAddress }).then(
+                (): Error | undefined => undefined,
+                (e): Error | undefined => e as Error
+            );
+
+            // The instance is tracked in pkc._updatingCommunities before the subscribe is awaited, so
+            // destroy() reaches it through listUpdatingCommunities and stops it. Nothing observes
+            // that stop today, which is why the caller stays blocked.
+            const destroyOutcome = await settleWithin(pkc.destroy(), 20000);
+            expect(destroyOutcome, "pkc.destroy() itself blocked on the pending subscription").to.not.equal(STILL_PENDING);
+
+            const outcome = await settleWithin(getCommunityOutcome, 10000);
+            expect(outcome, "getCommunity() is still waiting on the RPC subscription after destroy()").to.not.equal(STILL_PENDING);
+        } finally {
+            if (!pkc.destroyed) await settleWithin(pkc.destroy(), 20000);
+        }
+    });
+});


### PR DESCRIPTION
Closes #275. Fixes #277 (found during review of this PR). Closes #278.

## Problem

`pkc.getCommunity()` and the publish-time community fetch both block for the whole `_timeouts["community-ipns"]` (5 minutes by default) with no way to cancel. Stopping a publication did not stop the fetch:

- **Cold cache (blocking)** — `publish()` -> `_fetchCommunityForPublishing()` -> `fetchCommunityForPublishingWithCacheGuard()` -> `_loadCommunityForPublishingFromNetwork()`. A `stop()` mid-fetch left `publish()` pending until the timeout.
- **Stale cache (background refresh)** — `stop()` *drained* `_backgroundCommunityRefresh` by awaiting it (#270), which is a wait-it-out rather than a cancellation.

Before the change, `publish()` against an unresolvable community was still pending 160s after `stop()` returned.

## What changed (#275)

**The signal goes into `waitForUpdateInCommunityInstanceWithErrorAndTimeout`, not into `getCommunity` alone.** That helper is where both paths wait; the cold-cache publish path reaches it through the clients manager and never touches `getCommunity`. Abort becomes a fourth way its `Promise.race` can lose, alongside update / non-retriable error / timeout.

Routing abort through the existing `finally` matters for ownership. That block already reads:

```ts
if (!wasUpdating && community.state !== "started") await community.stop();
```

The community instance can be shared (`findUpdatingCommunity`, `_numOfListenersForUpdatingInstance`), so an unconditional `stop()` on abort would tear down a community another consumer is still using. There is a test for exactly that.

**API shape.** Both entry points take a single options object, per the convention in `AGENTS.md`:

```ts
await pkc.getCommunity({address, abortSignal})
await waitForUpdateInCommunityInstanceWithErrorAndTimeout({community, timeoutMs, abortSignal})
```

`getCommunity` splits `abortSignal` off before forwarding the rest to `createCommunity`, whose schemas are `.strict()` and would reject the extra key. `abortSignal` is also added to `CommunityIpfsReservedFields`, so a record arriving on the wire carrying that key is rejected rather than carried onto the instance.

**`Publication` owns an `AbortController`**, combined once with `pkc._getDestroyAbortSignal()` via `AbortSignal.any`, read by both fetch paths. Aborted in `stop()` only, never in the success funnel `_postSucessOrFailurePublishing()` -- a refresh fired to warm a stale cache should still complete after a publish succeeds. `publish()` resets an already-aborted signal so a stopped publication can be published again. Named `_communityFetchAbortController` rather than `_stopAbortController` because `Comment` already owns one of the latter for its updating lifecycle.

**New error code `ERR_GET_COMMUNITY_ABORTED`**, distinct from `ERR_GET_COMMUNITY_TIMED_OUT`, so callers can tell a slow network from a cancellation. Also what a pre-aborted signal produces, so there is one thing to check regardless of when the signal fired.

**Listener hygiene**: the abort listener is removed in the same `finally` on every outcome rather than relying on `{ once: true }`, per the long-lived-signal leak class from #144-#148.

## The RPC-local hang (#277)

CodeRabbit flagged that the signal could not reach `createCommunity`, which runs first. Reproduced deterministically in `test/node/rpc/getcommunity-abort-rpc-local.rpc.test.ts`: for a community the RPC server hosts, `PKCWithRpcClient.createCommunity()` parked on three waits with **no timeout and no cancellation** — the `communityUpdateSubscribe` call, `community.update()`, and the update-or-error race. This predates the PR; that path has never had a timeout. It also reaches publishing, since `PublicationClientsManager._createCommunityInstanceWithStateTranslation()` creates its instance the same way.

| case | before | after |
|---|---|---|
| abort while the subscribe is pending | still pending at 10s | 38ms |
| `destroy()` while the subscribe is pending | still pending at 10s | 16ms |

New `rejectWhenCommunityStopsOrAborts()` loses a race on either an abort signal or the instance transitioning to `stopped`, and all three waits race against it. Both routes are needed: `pkc.destroy()` fires the destroy signal *and* stops every tracked updating community, while a third-party `stop()` only takes the second. `createCommunity(options, {abortSignal})` keeps the signal off the zod-parsed `.strict()` options.

**Two adjacent bugs the repro turned up**, both fixed here:

1. `_getDestroyAbortSignal()` handed out a fresh, **un-aborted** controller when first asked for after `destroy()` — `destroy()` aborts with `?.`, a no-op when nobody had requested the signal yet. Anything racing that signal waited forever.
2. `RpcRemoteCommunity.stop()` only untracked the instance when it had a `_updateRpcSubscriptionId`, but `_createAndSubscribeToNewUpdatingCommunity()` calls `trackUpdatingCommunity()` *before* that id is assigned. A subscribe that failed or was cancelled left a stopped instance in `_updatingCommunities` for `findUpdatingCommunity()` to hand out — the #129 class of problem. Caught by asserting `_updatingCommunities.size() === 0` after cancellation.

**Not addressed**: the update-or-error race still has no timeout of its own, it just has something to lose to now. A bounded timeout there is worth considering separately.

## `getComment` (#278)

The same gap existed on `pkc.getComment({cid})`, which blocked for the whole `_timeouts["comment-ipfs"]` with no way to cancel. Same shape as `getCommunity`:

```ts
await pkc.getComment({ cid, abortSignal })
```

`abortSignal` is split off before `parseRpcCidParam`, a pre-aborted signal throws before an instance is created, and the CommentIpfs retry loop is raced against it. New error code `ERR_GET_COMMENT_ABORTED`, distinct from the timeout. The listener is removed in the same `finally` as every other outcome rather than relying on `{ once: true }`.

`PKCWithRpcClient.getComment` needed it too: its RPC call has no cancellation of its own, so an aborting caller (and `pkc.destroy()`, which cannot reach into that function) would be left parked on it. It races the caller signal combined with the destroy signal, via a new `rejectWhenAbortSignalFires()` in `util.ts` — the abort-only sibling of `rejectWhenCommunityStopsOrAborts()`.

`abortSignal` is added to `additionalCommentReservedFields`, so it reaches both `CommentPubsubMessageReservedFields` and `CommentIpfsReservedFields` and a record arriving on the wire carrying that key is rejected rather than carried onto the instance.

`test/node-and-browser/publications/comment/getcomment.abort.test.ts`:
- rejects with `ERR_GET_COMMENT_ABORTED` when the signal fires mid-fetch, and the instance it created is left stopped
- rejects immediately when the signal is already aborted
- an unaborted signal does not change the outcome
- `abortSignal` is in both comment reserved-field lists

The in-flight test proves the fetch is actually in flight before aborting, in a config-aware way — a `createComment` spy on the direct path, an RPC-call spy under RPC, since the two paths park in different places — so it cannot silently degrade into the pre-aborted case.

Green under both `remote-kubo-rpc` and `remote-pkc-rpc`, plus `test/node/rpc/` (38), `getcomment.pkc.test.ts`, `createcomment.test.ts`, `getcommunity.abort.test.ts`.

## Tests

`test/node-and-browser/community/getcommunity.abort.test.ts`:
- rejects with `ERR_GET_COMMUNITY_ABORTED` when the signal fires mid-fetch
- rejects immediately when the signal is already aborted
- leaves `_updatingCommunities` empty, same as a successful one-shot fetch
- does **not** stop a community instance somebody else is updating
- `abortSignal` is in `CommunityIpfsReservedFields`

`test/node-and-browser/publications/stop-aborts-community-fetch.test.ts`:
- `stop()` unwinds `publish()` well before the community-ipns timeout, publication unregistered, no community left updating
- `pkc.destroy()` mid-fetch unwinds it too

`test/node/rpc/getcommunity-abort-rpc-local.rpc.test.ts` — the #277 repro, both cases above.

The in-flight tests poll for the fetch actually being in flight (registry size, or the tracked instance's listener count) rather than sleeping, so they exercise the cancellation path rather than possibly the pre-aborted one.

Green: `test/node/rpc/` (38), `test/node/pkc/` (168), RPC dir + abort suites (48), community + publish suites (52), `waitForUpdate.race.test.ts`, `publication-registry.test.ts`, `stop.community.test.ts`, `update.community.test.ts`, `publishingstate.comment.test.ts`.

Caveat: the whole `test/node-and-browser/community/` directory under `remote-pkc-rpc` is red locally, but it is red on `master` too and the failing test moves between runs (key-migration once, then `pages.posts`, matching the master baseline exactly). Both pass in isolation on both trees — the known stale-test-server instability, not this change.

README documents the new parameter.
