### PR TITLE
fix(community): scope the process-wide started-community registry by dataPath

### DIFF
--- a/src/pkc/tracked-instance-registry-util.ts
+++ b/src/pkc/tracked-instance-registry-util.ts
@@ -16,7 +16,6 @@ type CommunityLookup = {
 };
 
 type CommunityWithAliases = {
-    address?: string;
     name?: string;
     publicKey?: string;
     signer?: { address?: string } | undefined;
@@ -67,15 +66,39 @@ function persistAliases<T extends object>(target: T, aliases: string[]): string[
     return [...aliasHistory];
 }
 
-export function getCommunityRegistryAliases(community: CommunityWithAliases): string[] {
-    const aliases = dedupeAliases([community.address, community.name, community.publicKey, community.signer?.address]);
+// Aliases are scoped to the dataPath they belong to when one is given. processStartedCommunities is
+// a module-level registry shared by every PKC instance in the process, and the registry matches on
+// ANY alias, so without a scope two LocalCommunity instances backed by different dataPaths but
+// sharing an address resolve to each other: one then adopts the other's posts/updateCid through a
+// signer it does not hold, and every publish after that fails signature validation (issue #238).
+// The scope is a prefix rather than an extra alias on purpose — a bare dataPath alias would instead
+// make every community *within* one dataPath collide.
+// A registry that is already scoped by construction (the per-PKC pkc._updatingCommunities and
+// pkc._startedCommunities) passes no dataPath and is left unprefixed.
+const REGISTRY_SCOPE_SEPARATOR = "\u0000";
+
+function scopeAliasesToDataPath(aliases: string[], dataPath: string | undefined): string[] {
+    if (dataPath === undefined) return aliases;
+    return aliases.map((alias) => `${dataPath}${REGISTRY_SCOPE_SEPARATOR}${alias}`);
+}
+
+export function getCommunityRegistryAliases(community: CommunityWithAliases, dataPath?: string): string[] {
+    // community.address is deliberately absent: setAddress keeps it equal to `name || publicKey`, so
+    // it is never an identity name/publicKey does not already carry. signer.address is NOT
+    // redundant — communityIdentityPublicKey() is `anchor?.publicKey ?? signer.address`, so on a
+    // delegated community publicKey is the anchor while signer.address is the minter that signs its
+    // records, and both have to resolve to the instance.
+    const aliases = dedupeAliases([community.name, community.publicKey, community.signer?.address]);
     if (aliases.length === 0) throw new PKCError("ERR_COMMUNITY_REGISTRY_LOOKUP_HAS_NO_ALIASES", { community });
 
-    return dedupeAliases(
-        aliases.flatMap((alias) => {
-            if (isEthAliasDomain(alias)) return getEquivalentCommunityAliases(alias);
-            return [alias];
-        })
+    return scopeAliasesToDataPath(
+        dedupeAliases(
+            aliases.flatMap((alias) => {
+                if (isEthAliasDomain(alias)) return getEquivalentCommunityAliases(alias);
+                return [alias];
+            })
+        ),
+        dataPath
     );
 }
 
@@ -83,8 +106,12 @@ export function getCommentRegistryAliases(comment: CommentLookup): string[] {
     return dedupeAliases([comment.cid]);
 }
 
-export function syncCommunityRegistryEntry<T extends CommunityWithAliases>(registry: TrackedInstanceRegistry<T>, community: T): T {
-    return registry.track({ value: community, aliases: persistAliases(community, getCommunityRegistryAliases(community)) });
+export function syncCommunityRegistryEntry<T extends CommunityWithAliases>(
+    registry: TrackedInstanceRegistry<T>,
+    community: T,
+    dataPath?: string
+): T {
+    return registry.track({ value: community, aliases: persistAliases(community, getCommunityRegistryAliases(community, dataPath)) });
 }
 
 export function syncCommentRegistryEntry<T extends CommentLookup>(registry: TrackedInstanceRegistry<T>, comment: T): T {
@@ -93,9 +120,10 @@ export function syncCommentRegistryEntry<T extends CommentLookup>(registry: Trac
 
 export function findCommunityInRegistry<T extends CommunityWithAliases>(
     registry: TrackedInstanceRegistry<T>,
-    lookup: CommunityLookup
+    lookup: CommunityLookup,
+    dataPath?: string
 ): T | undefined {
-    return registry.findByAliases(getCommunityRegistryAliases(lookup));
+    return registry.findByAliases(getCommunityRegistryAliases(lookup, dataPath));
 }
 
 export function findCommentInRegistry<T extends CommentLookup>(registry: TrackedInstanceRegistry<T>, lookup: CommentLookup): T | undefined {

--- a/src/pkc/tracked-instance-registry-util.ts
+++ b/src/pkc/tracked-instance-registry-util.ts
@@ -27,8 +27,14 @@ type CommentLookup = {
 
 const trackedAliasHistorySymbol = Symbol("trackedAliasHistory");
 
+// One history per (object, registry). A single Set shared by every registry let the per-PKC
+// registries (unscoped) and processStartedCommunities (dataPath-scoped) feed each other's aliases:
+// the process registry ended up holding bare aliases that matched across dataPaths, defeating the
+// #238 scope. The history holds UNSCOPED aliases and the scope is applied on every sync, so a
+// community re-tracked under a new dataPath (RPC setSettings swaps community._pkc) drops the old
+// scope while a renamed community stays reachable by its old name within the same scope.
 type TrackedAliasHistoryHolder = object & {
-    [trackedAliasHistorySymbol]?: Set<string>;
+    [trackedAliasHistorySymbol]?: WeakMap<object, Set<string>>;
 };
 
 function isEthAliasDomain(address: string): boolean {
@@ -47,21 +53,27 @@ function dedupeAliases(aliases: (string | undefined)[]): string[] {
     return [...new Set(aliases.filter((alias): alias is string => typeof alias === "string" && alias.length > 0))];
 }
 
-function getTrackedAliasHistory(target: object): Set<string> {
+function getTrackedAliasHistory(target: object, registry: object): Set<string> {
     const holder = target as TrackedAliasHistoryHolder;
     if (!holder[trackedAliasHistorySymbol]) {
         Object.defineProperty(holder, trackedAliasHistorySymbol, {
-            value: new Set<string>(),
+            value: new WeakMap<object, Set<string>>(),
             enumerable: false,
             configurable: false,
             writable: false
         });
     }
-    return holder[trackedAliasHistorySymbol]!;
+    const histories = holder[trackedAliasHistorySymbol]!;
+    let history = histories.get(registry);
+    if (!history) {
+        history = new Set<string>();
+        histories.set(registry, history);
+    }
+    return history;
 }
 
-function persistAliases<T extends object>(target: T, aliases: string[]): string[] {
-    const aliasHistory = getTrackedAliasHistory(target);
+function persistAliases<T extends object>(target: T, registry: object, aliases: string[]): string[] {
+    const aliasHistory = getTrackedAliasHistory(target, registry);
     aliases.forEach((alias) => aliasHistory.add(alias));
     return [...aliasHistory];
 }
@@ -111,11 +123,14 @@ export function syncCommunityRegistryEntry<T extends CommunityWithAliases>(
     community: T,
     dataPath?: string
 ): T {
-    return registry.track({ value: community, aliases: persistAliases(community, getCommunityRegistryAliases(community, dataPath)) });
+    return registry.track({
+        value: community,
+        aliases: scopeAliasesToDataPath(persistAliases(community, registry, getCommunityRegistryAliases(community)), dataPath)
+    });
 }
 
 export function syncCommentRegistryEntry<T extends CommentLookup>(registry: TrackedInstanceRegistry<T>, comment: T): T {
-    return registry.track({ value: comment, aliases: persistAliases(comment, getCommentRegistryAliases(comment)) });
+    return registry.track({ value: comment, aliases: persistAliases(comment, registry, getCommentRegistryAliases(comment)) });
 }
 
 export function findCommunityInRegistry<T extends CommunityWithAliases>(

--- a/src/runtime/node/community/local-community/db-state.ts
+++ b/src/runtime/node/community/local-community/db-state.ts
@@ -9,7 +9,7 @@ import { parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails } from "../../
 import { deriveDbPosts, resolveDbPostsCidRefs, importSignerIntoKuboNode } from "../../util.js";
 import { SignerWithPublicKeyAddress } from "../../../../signer/index.js";
 import { getIpfsKeyFromPrivateKey, getPublicKeyFromPrivateKey } from "../../../../signer/util.js";
-import { findCommunityInRegistry, findStartedCommunity } from "../../../../pkc/tracked-instance-registry-util.js";
+import { findStartedCommunity } from "../../../../pkc/tracked-instance-registry-util.js";
 import { getCommunityChallengeFromCommunityChallengeSettings } from "../challenges/index.js";
 import type {
     CommunityIpfsType,
@@ -20,9 +20,8 @@ import type {
 import type { DbPostsFormat } from "../../../../publications/comment/types.js";
 import type { LocalCommunity } from "../local-community.js";
 import { generateDefaultChallenges, isDefaultChallengeStructure } from "./defaults.js";
-import { processStartedCommunities } from "./registry.js";
+import { findProcessStartedCommunity, processStartedCommunities, syncProcessStartedCommunity } from "./registry.js";
 import { CommunitySignedPropertyNames } from "../../../../community/schema.js";
-import { syncCommunityRegistryEntry } from "../../../../pkc/tracked-instance-registry-util.js";
 import { DbHandler } from "../db-handler.js";
 import { getHighestAcceptedAnchorSequence } from "./anchor-publishing.js";
 import { PageGenerator } from "../page-generator.js";
@@ -149,11 +148,7 @@ export async function updateInstancePropsWithStartedCommunityOrDb(community: Loc
     const log = Logger("pkc-js:local-community:_updateInstancePropsWithStartedCommunityOrDb");
     const startedCommunity = <LocalCommunity | undefined>(
         (findStartedCommunity(community._pkc, { publicKey: community.publicKey, name: community.name }) ||
-            findCommunityInRegistry(
-                processStartedCommunities,
-                { publicKey: community.publicKey, name: community.name },
-                community._pkc.dataPath
-            ))
+            findProcessStartedCommunity(community))
     );
     if (startedCommunity) {
         log("Loading local community", community.address, "from started community instance");
@@ -368,7 +363,7 @@ export async function initInternalCommunityAfterFirstUpdateNoMerge(
     if (Array.isArray(newProps._cidsToUnPin)) newProps._cidsToUnPin.forEach((cid) => community._cidsToUnPin.add(cid));
     if (Array.isArray(newProps._mfsPathsToRemove)) newProps._mfsPathsToRemove.forEach((path) => community._mfsPathsToRemove.add(path));
     community._updateIpnsPubsubPropsIfNeeded(newProps);
-    if (processStartedCommunities.has(community)) syncCommunityRegistryEntry(processStartedCommunities, community, community._pkc.dataPath);
+    if (processStartedCommunities.has(community)) syncProcessStartedCommunity(community);
     if (community.updateCid) community.raw.localCommunity = community.toJSONInternalRpcAfterFirstUpdate();
 }
 
@@ -389,7 +384,7 @@ export async function initInternalCommunityBeforeFirstUpdateNoMerge(
     // LocalCommunity's override always derives these from signer.address, so the explicit
     // minter-based assignment that used to follow this call is no longer needed here.
     community._updateIpnsPubsubPropsIfNeeded(newProps);
-    if (processStartedCommunities.has(community)) syncCommunityRegistryEntry(processStartedCommunities, community, community._pkc.dataPath);
+    if (processStartedCommunities.has(community)) syncProcessStartedCommunity(community);
     community.raw.localCommunity = community.toJSONInternalRpcBeforeFirstUpdate();
 }
 

--- a/src/runtime/node/community/local-community/db-state.ts
+++ b/src/runtime/node/community/local-community/db-state.ts
@@ -149,7 +149,11 @@ export async function updateInstancePropsWithStartedCommunityOrDb(community: Loc
     const log = Logger("pkc-js:local-community:_updateInstancePropsWithStartedCommunityOrDb");
     const startedCommunity = <LocalCommunity | undefined>(
         (findStartedCommunity(community._pkc, { publicKey: community.publicKey, name: community.name }) ||
-            findCommunityInRegistry(processStartedCommunities, { publicKey: community.publicKey, name: community.name }))
+            findCommunityInRegistry(
+                processStartedCommunities,
+                { publicKey: community.publicKey, name: community.name },
+                community._pkc.dataPath
+            ))
     );
     if (startedCommunity) {
         log("Loading local community", community.address, "from started community instance");
@@ -364,7 +368,7 @@ export async function initInternalCommunityAfterFirstUpdateNoMerge(
     if (Array.isArray(newProps._cidsToUnPin)) newProps._cidsToUnPin.forEach((cid) => community._cidsToUnPin.add(cid));
     if (Array.isArray(newProps._mfsPathsToRemove)) newProps._mfsPathsToRemove.forEach((path) => community._mfsPathsToRemove.add(path));
     community._updateIpnsPubsubPropsIfNeeded(newProps);
-    if (processStartedCommunities.has(community)) syncCommunityRegistryEntry(processStartedCommunities, community);
+    if (processStartedCommunities.has(community)) syncCommunityRegistryEntry(processStartedCommunities, community, community._pkc.dataPath);
     if (community.updateCid) community.raw.localCommunity = community.toJSONInternalRpcAfterFirstUpdate();
 }
 
@@ -385,7 +389,7 @@ export async function initInternalCommunityBeforeFirstUpdateNoMerge(
     // LocalCommunity's override always derives these from signer.address, so the explicit
     // minter-based assignment that used to follow this call is no longer needed here.
     community._updateIpnsPubsubPropsIfNeeded(newProps);
-    if (processStartedCommunities.has(community)) syncCommunityRegistryEntry(processStartedCommunities, community);
+    if (processStartedCommunities.has(community)) syncCommunityRegistryEntry(processStartedCommunities, community, community._pkc.dataPath);
     community.raw.localCommunity = community.toJSONInternalRpcBeforeFirstUpdate();
 }
 

--- a/src/runtime/node/community/local-community/editing.ts
+++ b/src/runtime/node/community/local-community/editing.ts
@@ -140,7 +140,7 @@ export async function editPropsOnStartedCommunity(
     community.emit("update", community);
     if (community.address !== oldAddress) {
         trackStartedCommunity(community._pkc, community);
-        syncCommunityRegistryEntry(processStartedCommunities, community);
+        syncCommunityRegistryEntry(processStartedCommunities, community, community._pkc.dataPath);
     }
     return community;
 }
@@ -186,7 +186,11 @@ export async function edit(community: LocalCommunity, newCommunityOptions: Commu
 
     const startedCommunity = <LocalCommunity | undefined>(
         (findStartedCommunity(community._pkc, { publicKey: community.publicKey, name: community.name }) ||
-            findCommunityInRegistry(processStartedCommunities, { publicKey: community.publicKey, name: community.name }))
+            findCommunityInRegistry(
+                processStartedCommunities,
+                { publicKey: community.publicKey, name: community.name },
+                community._pkc.dataPath
+            ))
     );
     if (startedCommunity && community.state !== "started") {
         // sceneario 1

--- a/src/runtime/node/community/local-community/editing.ts
+++ b/src/runtime/node/community/local-community/editing.ts
@@ -5,12 +5,7 @@ import { sha256 } from "js-sha256";
 import { areEquivalentCommunityAddresses, doesDomainAddressHaveCapitalLetter, isStringDomain } from "../../../../util.js";
 import { PKCError } from "../../../../pkc-error.js";
 import { parseCommunityEditOptionsSchemaWithPKCErrorIfItFails } from "../../../../schema/schema-util.js";
-import {
-    findCommunityInRegistry,
-    findStartedCommunity,
-    syncCommunityRegistryEntry,
-    trackStartedCommunity
-} from "../../../../pkc/tracked-instance-registry-util.js";
+import { findStartedCommunity, trackStartedCommunity } from "../../../../pkc/tracked-instance-registry-util.js";
 import { getCommunityChallengeFromCommunityChallengeSettings } from "../challenges/index.js";
 import type {
     CommunityEditOptions,
@@ -20,7 +15,7 @@ import type {
 } from "../../../../community/types.js";
 import type { LocalCommunity } from "../local-community.js";
 import { isDefaultChallengeStructure } from "./defaults.js";
-import { processStartedCommunities } from "./registry.js";
+import { findProcessStartedCommunity, processStartedCommunities, syncProcessStartedCommunity } from "./registry.js";
 import { updateDbInternalState, updateInstancePropsWithStartedCommunityOrDb } from "./db-state.js";
 
 export async function movePostUpdatesFolderToNewAddress(community: LocalCommunity, oldAddress: string, newAddress: string) {
@@ -140,7 +135,7 @@ export async function editPropsOnStartedCommunity(
     community.emit("update", community);
     if (community.address !== oldAddress) {
         trackStartedCommunity(community._pkc, community);
-        syncCommunityRegistryEntry(processStartedCommunities, community, community._pkc.dataPath);
+        syncProcessStartedCommunity(community);
     }
     return community;
 }
@@ -186,11 +181,7 @@ export async function edit(community: LocalCommunity, newCommunityOptions: Commu
 
     const startedCommunity = <LocalCommunity | undefined>(
         (findStartedCommunity(community._pkc, { publicKey: community.publicKey, name: community.name }) ||
-            findCommunityInRegistry(
-                processStartedCommunities,
-                { publicKey: community.publicKey, name: community.name },
-                community._pkc.dataPath
-            ))
+            findProcessStartedCommunity(community))
     );
     if (startedCommunity && community.state !== "started") {
         // sceneario 1

--- a/src/runtime/node/community/local-community/lifecycle.ts
+++ b/src/runtime/node/community/local-community/lifecycle.ts
@@ -7,17 +7,15 @@ import { pubsubTopicToDhtKey, removeMfsFilesSafely, sleepUntilTimeoutOrAbort } f
 import { moveCommunityDbToDeletedDirectory } from "../../util.js";
 import { getCommunityChallengeFromCommunityChallengeSettings } from "../challenges/index.js";
 import {
-    findCommunityInRegistry,
     findStartedCommunity,
     findUpdatingCommunity,
-    syncCommunityRegistryEntry,
     trackStartedCommunity,
     trackUpdatingCommunity,
     untrackStartedCommunity,
     untrackUpdatingCommunity
 } from "../../../../pkc/tracked-instance-registry-util.js";
 import { LocalCommunity } from "../local-community.js";
-import { processStartedCommunities } from "./registry.js";
+import { findProcessStartedCommunity, processStartedCommunities, syncProcessStartedCommunity } from "./registry.js";
 import { communityChallengePubsubTopic } from "./comment-updates.js";
 import { providePubsubTopicRoutingCidsIfNeeded } from "./pubsub.js";
 import { reprovideOnAddressChangeIfDue } from "./reprovide-on-address-change.js";
@@ -124,11 +122,7 @@ export async function start(community: LocalCommunity) {
     if (
         community.started ||
         findStartedCommunity(community._pkc, { publicKey: community.publicKey, name: community.name }) ||
-        findCommunityInRegistry(
-            processStartedCommunities,
-            { publicKey: community.publicKey, name: community.name },
-            community._pkc.dataPath
-        )
+        findProcessStartedCommunity(community)
     )
         throw new PKCError("ERR_COMMUNITY_ALREADY_STARTED", { address: community.address });
     try {
@@ -148,7 +142,7 @@ export async function start(community: LocalCommunity) {
         await community._updateStartedValue();
         await community._dbHandler.lockCommunityStart(); // Will throw if community is locked already
         trackStartedCommunity(community._pkc, community);
-        syncCommunityRegistryEntry(processStartedCommunities, community, community._pkc.dataPath);
+        syncProcessStartedCommunity(community);
         await community._updateStartedValue();
         await community._dbHandler.initDbIfNeeded();
         await community._dbHandler.createOrMigrateTablesIfNeeded();
@@ -320,11 +314,7 @@ export async function updateOnce(community: LocalCommunity) {
     await community._updateStartedValue();
     const startedCommunity = <LocalCommunity | undefined>(
         (findStartedCommunity(community._pkc, { publicKey: community.publicKey, name: community.name }) ||
-            findCommunityInRegistry(
-                processStartedCommunities,
-                { publicKey: community.publicKey, name: community.name },
-                community._pkc.dataPath
-            ))
+            findProcessStartedCommunity(community))
     );
     if (community._mirroredStartedOrUpdatingCommunity)
         return; // we're already mirroring a started or updating community
@@ -479,11 +469,7 @@ export async function deleteCommunity(community: LocalCommunity) {
 
     const startedCommunity = <LocalCommunity | undefined>(
         (findStartedCommunity(community._pkc, { publicKey: community.publicKey, name: community.name }) ||
-            findCommunityInRegistry(
-                processStartedCommunities,
-                { publicKey: community.publicKey, name: community.name },
-                community._pkc.dataPath
-            ))
+            findProcessStartedCommunity(community))
     );
     if (startedCommunity && startedCommunity !== community) {
         await startedCommunity.delete();

--- a/src/runtime/node/community/local-community/lifecycle.ts
+++ b/src/runtime/node/community/local-community/lifecycle.ts
@@ -124,7 +124,11 @@ export async function start(community: LocalCommunity) {
     if (
         community.started ||
         findStartedCommunity(community._pkc, { publicKey: community.publicKey, name: community.name }) ||
-        findCommunityInRegistry(processStartedCommunities, { publicKey: community.publicKey, name: community.name })
+        findCommunityInRegistry(
+            processStartedCommunities,
+            { publicKey: community.publicKey, name: community.name },
+            community._pkc.dataPath
+        )
     )
         throw new PKCError("ERR_COMMUNITY_ALREADY_STARTED", { address: community.address });
     try {
@@ -144,7 +148,7 @@ export async function start(community: LocalCommunity) {
         await community._updateStartedValue();
         await community._dbHandler.lockCommunityStart(); // Will throw if community is locked already
         trackStartedCommunity(community._pkc, community);
-        syncCommunityRegistryEntry(processStartedCommunities, community);
+        syncCommunityRegistryEntry(processStartedCommunities, community, community._pkc.dataPath);
         await community._updateStartedValue();
         await community._dbHandler.initDbIfNeeded();
         await community._dbHandler.createOrMigrateTablesIfNeeded();
@@ -316,7 +320,11 @@ export async function updateOnce(community: LocalCommunity) {
     await community._updateStartedValue();
     const startedCommunity = <LocalCommunity | undefined>(
         (findStartedCommunity(community._pkc, { publicKey: community.publicKey, name: community.name }) ||
-            findCommunityInRegistry(processStartedCommunities, { publicKey: community.publicKey, name: community.name }))
+            findCommunityInRegistry(
+                processStartedCommunities,
+                { publicKey: community.publicKey, name: community.name },
+                community._pkc.dataPath
+            ))
     );
     if (community._mirroredStartedOrUpdatingCommunity)
         return; // we're already mirroring a started or updating community
@@ -471,7 +479,11 @@ export async function deleteCommunity(community: LocalCommunity) {
 
     const startedCommunity = <LocalCommunity | undefined>(
         (findStartedCommunity(community._pkc, { publicKey: community.publicKey, name: community.name }) ||
-            findCommunityInRegistry(processStartedCommunities, { publicKey: community.publicKey, name: community.name }))
+            findCommunityInRegistry(
+                processStartedCommunities,
+                { publicKey: community.publicKey, name: community.name },
+                community._pkc.dataPath
+            ))
     );
     if (startedCommunity && startedCommunity !== community) {
         await startedCommunity.delete();

--- a/src/runtime/node/community/local-community/registry.ts
+++ b/src/runtime/node/community/local-community/registry.ts
@@ -1,5 +1,54 @@
+import fs from "fs";
+import path from "path";
 import { TrackedInstanceRegistry } from "../../../../pkc/tracked-instance-registry.js";
+import { findCommunityInRegistry, syncCommunityRegistryEntry } from "../../../../pkc/tracked-instance-registry-util.js";
 import type { LocalCommunity } from "../local-community.js";
 
+// The shape the process registry needs from a community: its identity aliases plus the dataPath of
+// the PKC instance backing it. Structural on purpose so it can be exercised without a LocalCommunity.
+export type ProcessStartedCommunity = {
+    name?: string;
+    publicKey?: string;
+    signer?: { address?: string } | undefined;
+    _pkc: { dataPath?: string };
+};
+
 // A global registry on process level to track started communities
-export const processStartedCommunities = new TrackedInstanceRegistry<LocalCommunity>();
+export const processStartedCommunities = new TrackedInstanceRegistry<ProcessStartedCommunity>();
+
+// The registry scope (issue #238) is a string prefix, while the DB and lock files are opened through
+// path.join, so `/a` and `/a/`, a relative spelling, or a symlink all open the SAME database but
+// would land in different scopes. Resolve to the canonical directory: realpath when it exists, and
+// otherwise the realpath of the nearest existing ancestor plus the missing tail (start() creates the
+// dataPath, so the registry can be consulted before the directory is there).
+export function normalizeRegistryDataPath(dataPath: string | undefined): string | undefined {
+    if (dataPath === undefined) return undefined;
+    const resolved = path.resolve(dataPath);
+    let existing = resolved;
+    let tail = "";
+    while (true) {
+        try {
+            return path.join(fs.realpathSync.native(existing), tail);
+        } catch {
+            const parent = path.dirname(existing);
+            if (parent === existing) return resolved; // reached the filesystem root without a realpath
+            tail = path.join(path.basename(existing), tail);
+            existing = parent;
+        }
+    }
+}
+
+function getLookup(community: ProcessStartedCommunity) {
+    return { publicKey: community.publicKey, name: community.name };
+}
+
+// Every process-registry access goes through these so the dataPath scope can never be forgotten.
+export function findProcessStartedCommunity(community: ProcessStartedCommunity): LocalCommunity | undefined {
+    return <LocalCommunity | undefined>(
+        findCommunityInRegistry(processStartedCommunities, getLookup(community), normalizeRegistryDataPath(community._pkc.dataPath))
+    );
+}
+
+export function syncProcessStartedCommunity(community: ProcessStartedCommunity): void {
+    syncCommunityRegistryEntry(processStartedCommunities, community, normalizeRegistryDataPath(community._pkc.dataPath));
+}

--- a/test/node/pkc/registry-datapath-scope.test.ts
+++ b/test/node/pkc/registry-datapath-scope.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { TrackedInstanceRegistry } from "../../../dist/node/pkc/tracked-instance-registry.js";
+import {
+    findCommunityInRegistry,
+    getCommunityRegistryAliases,
+    syncCommunityRegistryEntry
+} from "../../../dist/node/pkc/tracked-instance-registry-util.js";
+
+// Issue #238: processStartedCommunities is a module-level registry shared by every PKC instance in
+// the process, and its aliases carried no dataPath. Two LocalCommunity instances backed by
+// different dataPaths but sharing an address therefore resolved to each other, and
+// updateInstancePropsWithStartedCommunityOrDb copied one instance's state into a community whose
+// signer is a different key — every later publish then failed signature validation.
+//
+// The registry itself is address-blind, so these tests exercise the alias layer directly: that is
+// where the scoping lives, and it is what every processStartedCommunities call site now feeds.
+
+type TestCommunity = { name?: string; publicKey?: string; signer?: { address?: string } };
+
+const PUBLIC_KEY = "12D3KooWFfvHKtestpublickeyfor238scope";
+const OTHER_PUBLIC_KEY = "12D3KooWN5rLmtestpublickeyfor238scope";
+const DATA_PATH_A = "/tmp/pkc-238-scope-a";
+const DATA_PATH_B = "/tmp/pkc-238-scope-b";
+
+describe("community registry aliases are scoped by dataPath (issue #238)", () => {
+    it("a same-address community in another dataPath is not found", () => {
+        const registry = new TrackedInstanceRegistry<TestCommunity>();
+        const communityInA: TestCommunity = { publicKey: PUBLIC_KEY };
+        syncCommunityRegistryEntry(registry, communityInA, DATA_PATH_A);
+
+        expect(findCommunityInRegistry(registry, { publicKey: PUBLIC_KEY }, DATA_PATH_B)).to.be.undefined;
+    });
+
+    it("the same community is still found within its own dataPath", () => {
+        const registry = new TrackedInstanceRegistry<TestCommunity>();
+        const communityInA: TestCommunity = { publicKey: PUBLIC_KEY };
+        syncCommunityRegistryEntry(registry, communityInA, DATA_PATH_A);
+
+        expect(findCommunityInRegistry(registry, { publicKey: PUBLIC_KEY }, DATA_PATH_A)).to.equal(communityInA);
+    });
+
+    it("two different communities sharing one dataPath never resolve to each other", () => {
+        // Guards the naive fix of adding dataPath as one more plain alias: the registry matches on
+        // ANY alias, so a bare dataPath alias would make every community in a dataPath collide.
+        const registry = new TrackedInstanceRegistry<TestCommunity>();
+        const first: TestCommunity = { publicKey: PUBLIC_KEY };
+        const second: TestCommunity = { publicKey: OTHER_PUBLIC_KEY };
+        syncCommunityRegistryEntry(registry, first, DATA_PATH_A);
+        syncCommunityRegistryEntry(registry, second, DATA_PATH_A);
+
+        expect(findCommunityInRegistry(registry, { publicKey: PUBLIC_KEY }, DATA_PATH_A)).to.equal(first);
+        expect(findCommunityInRegistry(registry, { publicKey: OTHER_PUBLIC_KEY }, DATA_PATH_A)).to.equal(second);
+    });
+
+    it("two same-address communities in different dataPaths coexist, each found under its own", () => {
+        const registry = new TrackedInstanceRegistry<TestCommunity>();
+        const inA: TestCommunity = { publicKey: PUBLIC_KEY };
+        const inB: TestCommunity = { publicKey: PUBLIC_KEY };
+        syncCommunityRegistryEntry(registry, inA, DATA_PATH_A);
+        syncCommunityRegistryEntry(registry, inB, DATA_PATH_B);
+
+        expect(findCommunityInRegistry(registry, { publicKey: PUBLIC_KEY }, DATA_PATH_A)).to.equal(inA);
+        expect(findCommunityInRegistry(registry, { publicKey: PUBLIC_KEY }, DATA_PATH_B)).to.equal(inB);
+    });
+
+    it("domain lookups stay scoped, including the .eth/.bso equivalence", () => {
+        const registry = new TrackedInstanceRegistry<TestCommunity>();
+        const inA: TestCommunity = { name: "scope-238.bso", publicKey: PUBLIC_KEY };
+        syncCommunityRegistryEntry(registry, inA, DATA_PATH_A);
+
+        expect(findCommunityInRegistry(registry, { name: "scope-238.bso" }, DATA_PATH_A)).to.equal(inA);
+        expect(findCommunityInRegistry(registry, { name: "scope-238.eth" }, DATA_PATH_A)).to.equal(inA);
+        expect(findCommunityInRegistry(registry, { name: "scope-238.bso" }, DATA_PATH_B)).to.be.undefined;
+        expect(findCommunityInRegistry(registry, { name: "scope-238.eth" }, DATA_PATH_B)).to.be.undefined;
+    });
+
+    it("an unscoped registry (no dataPath) keeps matching as before", () => {
+        // pkc._updatingCommunities / pkc._startedCommunities are per-PKC and already scoped by
+        // construction, so they pass no dataPath and must be unaffected.
+        const registry = new TrackedInstanceRegistry<TestCommunity>();
+        const community: TestCommunity = { publicKey: PUBLIC_KEY };
+        syncCommunityRegistryEntry(registry, community);
+
+        expect(findCommunityInRegistry(registry, { publicKey: PUBLIC_KEY })).to.equal(community);
+    });
+
+    it("address is not carried as its own alias, since it is always name or publicKey", () => {
+        const domainCommunity: TestCommunity = { name: "scope-238.bso", publicKey: PUBLIC_KEY };
+        const keyCommunity: TestCommunity = { publicKey: PUBLIC_KEY };
+
+        // Every alias a community publishes is reachable from name/publicKey/signer.address alone.
+        expect(getCommunityRegistryAliases(domainCommunity)).to.include("scope-238.bso");
+        expect(getCommunityRegistryAliases(domainCommunity)).to.include(PUBLIC_KEY);
+        expect(getCommunityRegistryAliases(keyCommunity)).to.deep.equal([PUBLIC_KEY]);
+    });
+
+    it("signer.address stays an alias, because a delegated community's identity is its anchor", () => {
+        // communityIdentityPublicKey() is `anchor?.publicKey ?? signer.address`, so on a delegated
+        // community publicKey is the anchor while signer.address is the minter that signs records.
+        // They are different keys and both have to resolve to the instance.
+        const delegated: TestCommunity = { publicKey: PUBLIC_KEY, signer: { address: OTHER_PUBLIC_KEY } };
+        const registry = new TrackedInstanceRegistry<TestCommunity>();
+        syncCommunityRegistryEntry(registry, delegated, DATA_PATH_A);
+
+        expect(findCommunityInRegistry(registry, { publicKey: PUBLIC_KEY }, DATA_PATH_A)).to.equal(delegated);
+        expect(findCommunityInRegistry(registry, { publicKey: OTHER_PUBLIC_KEY }, DATA_PATH_A)).to.equal(delegated);
+        expect(findCommunityInRegistry(registry, { publicKey: OTHER_PUBLIC_KEY }, DATA_PATH_B)).to.be.undefined;
+    });
+});

--- a/test/node/pkc/registry-datapath-scope.test.ts
+++ b/test/node/pkc/registry-datapath-scope.test.ts
@@ -1,4 +1,11 @@
 import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+import {
+    findProcessStartedCommunity,
+    processStartedCommunities,
+    syncProcessStartedCommunity
+} from "../../../dist/node/runtime/node/community/local-community/registry.js";
 import { TrackedInstanceRegistry } from "../../../dist/node/pkc/tracked-instance-registry.js";
 import {
     findCommunityInRegistry,
@@ -105,5 +112,110 @@ describe("community registry aliases are scoped by dataPath (issue #238)", () =>
         expect(findCommunityInRegistry(registry, { publicKey: PUBLIC_KEY }, DATA_PATH_A)).to.equal(delegated);
         expect(findCommunityInRegistry(registry, { publicKey: OTHER_PUBLIC_KEY }, DATA_PATH_A)).to.equal(delegated);
         expect(findCommunityInRegistry(registry, { publicKey: OTHER_PUBLIC_KEY }, DATA_PATH_B)).to.be.undefined;
+    });
+});
+
+describe("alias history is kept per registry and re-scoped on every sync", () => {
+    it("syncing into an unscoped registry first does not leak bare aliases into a scoped one", () => {
+        // lifecycle.ts start() tracks the per-PKC registry (unscoped) right before the process registry
+        // (scoped). With a single history Set per object the process registry also received the bare
+        // aliases, so an unscoped lookup (or a caller forgetting dataPath) matched across dataPaths.
+        const perPkcRegistry = new TrackedInstanceRegistry<TestCommunity>();
+        const processRegistry = new TrackedInstanceRegistry<TestCommunity>();
+        const community: TestCommunity = { publicKey: PUBLIC_KEY };
+        syncCommunityRegistryEntry(perPkcRegistry, community);
+        syncCommunityRegistryEntry(processRegistry, community, DATA_PATH_A);
+
+        expect(processRegistry.aliases()).to.not.include(PUBLIC_KEY);
+        expect(findCommunityInRegistry(processRegistry, { publicKey: PUBLIC_KEY })).to.be.undefined;
+        expect(findCommunityInRegistry(processRegistry, { publicKey: PUBLIC_KEY }, DATA_PATH_A)).to.equal(community);
+        // and the scoped aliases do not flow back into the unscoped registry either
+        expect(perPkcRegistry.aliases()).to.deep.equal([PUBLIC_KEY]);
+    });
+
+    it("a community re-tracked under a new dataPath is no longer found under the old one", () => {
+        // RPC setSettings swaps community._pkc (possibly with a new dataPath), then stop()/start()s the
+        // same object. The old scope must not survive that restart.
+        const registry = new TrackedInstanceRegistry<TestCommunity>();
+        const community: TestCommunity = { publicKey: PUBLIC_KEY };
+        syncCommunityRegistryEntry(registry, community, DATA_PATH_A);
+        registry.untrack(community);
+        syncCommunityRegistryEntry(registry, community, DATA_PATH_B);
+
+        expect(findCommunityInRegistry(registry, { publicKey: PUBLIC_KEY }, DATA_PATH_A)).to.be.undefined;
+        expect(findCommunityInRegistry(registry, { publicKey: PUBLIC_KEY }, DATA_PATH_B)).to.equal(community);
+    });
+
+    it("renamed communities stay reachable by their old name within the same dataPath (sticky aliases)", () => {
+        const registry = new TrackedInstanceRegistry<TestCommunity>();
+        const community: TestCommunity = { name: "before-238.eth", publicKey: PUBLIC_KEY };
+        syncCommunityRegistryEntry(registry, community, DATA_PATH_A);
+        community.name = "after-238.eth";
+        syncCommunityRegistryEntry(registry, community, DATA_PATH_A);
+
+        expect(findCommunityInRegistry(registry, { name: "before-238.eth" }, DATA_PATH_A)).to.equal(community);
+        expect(findCommunityInRegistry(registry, { name: "after-238.eth" }, DATA_PATH_A)).to.equal(community);
+        expect(findCommunityInRegistry(registry, { name: "before-238.eth" }, DATA_PATH_B)).to.be.undefined;
+    });
+});
+
+describe("processStartedCommunities scope normalizes the dataPath", () => {
+    it("different spellings of the same directory land in the same scope", () => {
+        const dir = path.join(process.cwd(), ".tmp", "pkc-238-scope-spellings");
+        fs.mkdirSync(dir, { recursive: true });
+        const inA = { publicKey: PUBLIC_KEY, _pkc: { dataPath: dir } };
+        syncProcessStartedCommunity(inA);
+        try {
+            expect(findProcessStartedCommunity({ publicKey: PUBLIC_KEY, _pkc: { dataPath: `${dir}/` } })).to.equal(inA);
+            expect(findProcessStartedCommunity({ publicKey: PUBLIC_KEY, _pkc: { dataPath: path.relative(process.cwd(), dir) } })).to.equal(
+                inA
+            );
+            expect(
+                findProcessStartedCommunity({ publicKey: PUBLIC_KEY, _pkc: { dataPath: path.join(dir, "..", path.basename(dir)) } })
+            ).to.equal(inA);
+        } finally {
+            processStartedCommunities.untrack(inA);
+        }
+    });
+
+    it("a symlink to the dataPath resolves to the same scope", () => {
+        const real = path.join(process.cwd(), ".tmp", "pkc-238-scope-real");
+        const link = path.join(process.cwd(), ".tmp", "pkc-238-scope-link");
+        fs.mkdirSync(real, { recursive: true });
+        fs.rmSync(link, { force: true });
+        fs.symlinkSync(real, link);
+        const inReal = { publicKey: PUBLIC_KEY, _pkc: { dataPath: real } };
+        syncProcessStartedCommunity(inReal);
+        try {
+            expect(findProcessStartedCommunity({ publicKey: PUBLIC_KEY, _pkc: { dataPath: link } })).to.equal(inReal);
+        } finally {
+            processStartedCommunities.untrack(inReal);
+            fs.rmSync(link, { force: true });
+        }
+    });
+
+    it("a dataPath that does not exist yet still scopes consistently with its later spelling", () => {
+        // start() creates the directory; the registry may be consulted before that.
+        const missing = path.join(process.cwd(), ".tmp", "pkc-238-scope-missing", "nested");
+        fs.rmSync(path.dirname(missing), { recursive: true, force: true });
+        const inMissing = { publicKey: PUBLIC_KEY, _pkc: { dataPath: missing } };
+        syncProcessStartedCommunity(inMissing);
+        try {
+            expect(findProcessStartedCommunity({ publicKey: PUBLIC_KEY, _pkc: { dataPath: `${missing}/` } })).to.equal(inMissing);
+        } finally {
+            processStartedCommunities.untrack(inMissing);
+        }
+    });
+
+    it("different directories stay in different scopes", () => {
+        const a = path.join(process.cwd(), ".tmp", "pkc-238-scope-dir-a");
+        const b = path.join(process.cwd(), ".tmp", "pkc-238-scope-dir-b");
+        const inA = { publicKey: PUBLIC_KEY, _pkc: { dataPath: a } };
+        syncProcessStartedCommunity(inA);
+        try {
+            expect(findProcessStartedCommunity({ publicKey: PUBLIC_KEY, _pkc: { dataPath: b } })).to.be.undefined;
+        } finally {
+            processStartedCommunities.untrack(inA);
+        }
     });
 });


### PR DESCRIPTION
Closes #238.

## Problem

`processStartedCommunities` (`src/runtime/node/community/local-community/registry.ts`) is a module-level `TrackedInstanceRegistry` shared by every `PKC` instance in the process, and `findByAliases` resolves a lookup on **any** matching alias. The alias set was `[address, name, publicKey, signer.address]` with nothing identifying which dataPath the instance belongs to.

Two `LocalCommunity` instances backed by different dataPaths but sharing a community address therefore resolved to each other. `updateInstancePropsWithStartedCommunityOrDb` took its

```
Loading local community <address> from started community instance
```

branch and copied the other instance's `posts`, `updateCid`, `exports` and `anchorRecordSequence` into a community whose signer is a different key. Every publish after that failed:

```
ERR_LOCAL_COMMUNITY_PRODUCED_INVALID_SIGNATURE
  validation: { valid: false, reason: 'community.posts signature is invalid' }
```

and it never recovered, since each loop iteration rebuilt from the adopted state. It surfaced as a hang rather than an error, because the failures land on the community's `error` event while whatever awaited the instance kept waiting.

## Fix

`getCommunityRegistryAliases` takes an optional `dataPath` and prefixes every alias with it.

**A prefix, not an extra alias.** Adding `dataPath` as one more plain alias would be strictly worse than the bug: the registry matches on any alias, so every community *within* a single dataPath would collide with every other. There is a test pinning that.

The per-PKC registries (`pkc._updatingCommunities`, `pkc._startedCommunities`) are already scoped by construction — one PKC, one dataPath — so they pass no dataPath and match exactly as before. All nine `processStartedCommunities` call sites in `db-state.ts`, `lifecycle.ts` and `editing.ts` pass `community._pkc.dataPath`.

## Alias set: what left and what stayed

`community.address` is **dropped**. `setAddress` keeps `address` equal to `name || publicKey` (domains land in `name`, non-domains in `publicKey`), so it never contributed an identity the other two did not already carry.

`signer.address` **stays**. It is not a duplicate of `publicKey`: `communityIdentityPublicKey()` is `anchor?.publicKey ?? signer.address`, so on a delegated community `publicKey` is the anchor while `signer.address` is the minter key that actually signs its records. Both have to resolve to the instance, and the alias history in `persistAliases` is what keeps a community reachable under a key it has since rotated away from. Removing it would be a separate behavior change for delegated communities, not part of this fix.

## Tests

New `test/node/pkc/registry-datapath-scope.test.ts`, 8 cases:

- a same-address community in another dataPath is not found (**red before the fix**: returned the other instance)
- the same community is still found within its own dataPath
- two different communities sharing one dataPath never resolve to each other (guards the naive fix)
- two same-address communities in different dataPaths coexist, each found under its own
- domain lookups stay scoped, including the `.eth`/`.bso` equivalence
- an unscoped registry (no dataPath) keeps matching as before
- `address` is not carried as its own alias
- `signer.address` stays an alias, and stays scoped

## Verification

- `npm run build` clean; `npx tsc --project test/tsconfig.json --noEmit` clean.
- New suite 8/8 (red first, against the unmodified alias logic).
- Regressions under `local-kubo-rpc`: `started-communities` + `tracked-instance-registry` + `delegated-community` -> 49/49; `start.community` + `edit.community` + `garbage.collection.community` -> 74 passed, 9 skipped; `test/node/community/local-community/` + `create.community` -> 225 passed, 1 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved community registry tracking to prevent conflicts between communities stored in different data locations.
  - Community lookups and synchronization now remain correctly scoped to their associated data path, including normalized paths and symlinks.
  - Preserved equivalent `.eth` and `.bso` aliases, alias history, and compatibility with unscoped registries.
  - Kept comment aliases isolated between registries.

- **Tests**
  - Added coverage for data-path isolation, alias matching, identity separation, renamed aliases, and path normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->