### PR TITLE
feat(challenges): add validateChallengeSettings and core optionInputs validation (#283)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Before working on certain areas, read the relevant protocol doc to avoid mistake
 | `comment.crosspost`, embedded records, `features.noCrossposts` | `docs/protocol/crossposts.md` |
 | Challenge/response, `src/pubsub-messages/`, encryption | `docs/protocol/challenge-flow.md` |
 | `settings.challenges`, challenge options, sensitive config | `docs/protocol/challenge-settings.md` |
+| Writing a challenge package, `optionInputs`, `validateChallengeSettings` | `docs/protocol/challenge-authoring.md` |
 | Data storage, IPFS CIDs, IPNS, mutability questions | `docs/protocol/data-permanence.md` |
 | DB migration, `extraProps`, CID reconstruction, `deriveCommentIpfsFromCommentTableRow` | `docs/protocol/db-community-address-migration.md` |
 

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -14,6 +14,7 @@ Concise protocol reference for AI agents and contributors. Each doc covers one d
 | [crossposts.md](crossposts.md) | `comment.crosspost`, the embedded record, tier-1 vs tier-2 verification, `features.noCrossposts` |
 | [challenge-flow.md](challenge-flow.md) | 4-message encrypted challenge exchange |
 | [challenge-settings.md](challenge-settings.md) | Private (`settings.challenges`) vs public (`challenges`) boundary, sensitive options |
+| [challenge-authoring.md](challenge-authoring.md) | For challenge package authors: core `optionInputs` validation, the `validateChallengeSettings` hook, publication obligations |
 | [data-permanence.md](data-permanence.md) | What is permanent (IPFS CIDs) vs ephemeral (regenerated) |
 | [db-community-address-migration.md](db-community-address-migration.md) | DB v37 migration: subplebbitAddress → communityPublicKey/communityName, CID preservation |
 | [data-path-migration.md](data-path-migration.md) | Directory layout migration for downstream apps: `.plebbit/` → `.pkc/`, `subplebbits/` → `communities/` |

--- a/docs/protocol/challenge-authoring.md
+++ b/docs/protocol/challenge-authoring.md
@@ -1,0 +1,117 @@
+# Challenge Authoring
+
+For authors of challenge packages: what pkc-js validates on your behalf, what your challenge has to
+validate for itself, and where each of those runs.
+
+## The two layers
+
+A community owner's challenge configuration lives in `community.settings.challenges[i]`, a
+`CommunityChallengeSetting`. It is checked in two layers before it takes effect.
+
+| Layer | Who runs it | What it catches |
+|---|---|---|
+| Core `optionInputs` validation | pkc-js, for every challenge | Mechanical mistakes the challenge file's own `optionInputs` already describe |
+| `validateChallengeSettings` | Your challenge, optional | Semantic mistakes only your challenge can recognize |
+
+### Layer 1: what core validates for you
+
+Core compares `options` and `publicOptions` against the `optionInputs` your `ChallengeFileFactory`
+returned. You write no code for any of this.
+
+| Check | Error code |
+|---|---|
+| An `options` key that no `optionInputs` entry declares | `ERR_CHALLENGE_OPTION_NOT_DECLARED_IN_OPTION_INPUTS` |
+| A missing option whose `optionInputs` entry has `required: true` | `ERR_CHALLENGE_REQUIRED_OPTION_MISSING` |
+| A `publicOptions` entry that no `optionInputs` entry declares | `ERR_CHALLENGE_PUBLIC_OPTION_NOT_DECLARED_IN_OPTION_INPUTS` |
+
+An undeclared key can only be a typo. Nothing reads it and nothing publishes it, so it is dead config by
+definition, and silently accepting it is how `anwser` instead of `answer` ends up rejecting every author
+with no signal to the owner.
+
+`required` means present, nothing more. An option counts as missing only when the key is absent; a key set
+to `""` satisfies the check. Whether an empty value is meaningful for your challenge is your business, so
+reject one in your `validateChallengeSettings` hook if it is not.
+
+`optionInputs` is optional. A challenge file that declares none makes no promise about which options it
+reads, so the two declared-key checks are skipped for it rather than rejecting everything it was given. If
+you want core to catch typos for your challenge, declare your options.
+
+### Layer 2: `validateChallengeSettings`
+
+```ts
+validateChallengeSettings?: (args: { challengeSettings: CommunityChallengeSetting }) => void
+```
+
+Add it to what your `ChallengeFileFactory` returns. Four rules:
+
+-   **Optional.** A challenge with nothing semantic to check omits it. Layer 1 runs regardless.
+-   **Sync, and no network.** It runs on every community start, so an async validator that hit a third party
+    would turn that third party's outage into a startup problem. An API key check belongs in your
+    `getChallenge()` failure path, where an outage degrades one publish instead of a boot.
+-   **Rejection is a throw.** Throw anything, including a plain `new Error("matches is not valid JSON")`. No
+    pkc-js import is needed. Core wraps it in a `PKCError` with code
+    `ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED`, the original as `cause`, and your message in
+    `details.validationError` (the part that survives RPC serialization, so write it for an owner to read).
+-   **You get the whole `challengeSettings`.** Reject any field in it, `exclude` included.
+
+Keep the factory itself cheap and non-throwing. The factory runs on load as well as on edit (start, DB
+migration, community creation), so a factory that threw on invalid options would fail community startup
+rather than the offending edit, and an owner who persisted a bad config would end up with a community that
+will not boot. That separation is the whole reason this hook exists.
+
+## Where validation runs
+
+Both layers run at the same four points, with the same error codes on each. A consumer filtering on the
+code cares about what is wrong, not about which path noticed.
+
+| Path | Behavior |
+|---|---|
+| `community.edit()` | Rejected before anything is persisted. Failures are collected across every challenge and thrown as one `PKCError` with code `ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED_FOR_CHALLENGES`, whose `details.failures` is `{challengeIndex, challengeName, error}[]`, so an owner editing several challenges learns every failure at once |
+| Community creation | Throws the same aggregated error. Nothing is persisted yet, so a throw is safe |
+| `community.start()` | Emits one `error` event per invalid challenge, each carrying `{challengeIndex, challengeName, communityAddress}` in `details`. The community still starts, and the errors are re-emitted on every start until the config is fixed |
+| DB migration | Silent. Surfacing config errors in the middle of a schema migration the owner did not initiate is the worst possible moment, and start catches the same problem seconds later |
+
+Start never throws by design. A config that was persisted before a check existed, or one that a stricter
+version of your challenge now rejects, must not take an owner's community down.
+
+## Publication obligations
+
+`publicOptions` (see [challenge-settings.md](challenge-settings.md)) lets the **owner** choose which of
+your options are written into the published community record. Your hook is where you constrain that
+choice, because a hook throw is a veto the owner cannot override.
+
+-   **Forbid publication of a secret.** An option is a secret when publishing it breaks the challenge, not
+    merely when it is private. `question.answer` is the only built-in case: published, anyone can pass the
+    challenge. Throw if it appears in `publicOptions`.
+-   **Require publication when clients need to read it.** A challenge that rejects publications for a reason
+    the author cannot see in advance rejects every author. If your challenge only works when a UI can read a
+    rule up front, throw when that option is _not_ in `publicOptions`.
+-   **Stay silent otherwise.** Most options are private by default but legitimately publishable. A blacklist
+    is moderation policy, and publishing it is transparency rather than a leak. That is the owner's call.
+
+Because the hook is optional, these are obligations on you as a package author, not guarantees core can
+enforce.
+
+## Built-in challenges
+
+| Challenge | What its hook validates |
+|---|---|
+| `question` | Refuses `answer` in `publicOptions` |
+| `publication-match` | `matches` parses as JSON, is an array of `{propertyName, regexp}`, and every `regexp` compiles. No opinion on publication |
+| `blacklist`, `whitelist` | Every comma separated `urls` entry parses with `new URL()` and uses `http:` or `https:`, since `fetch` is the only consumer and anything else fails silently forever. Every comma separated `addresses` entry is non-empty |
+| `text-math`, `fail` | No hook |
+
+## Upgrade note
+
+Communities carrying config that has been quietly broken all along (a typo'd key, a missing required
+option) begin emitting `error` events at boot once these checks ship. That is the intended outcome, but it
+looks like a new bug to whoever sees it first.
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `src/community/schema.ts` | `ChallengeFileSchema` (where `validateChallengeSettings` is declared), `ChallengeOptionInputSchema`, `CommunityChallengeSettingSchema` |
+| `src/runtime/node/community/challenges/validate-challenge-settings.ts` | Both layers, and the aggregation used by the edit and creation paths |
+| `src/runtime/node/community/challenges/pkc-js-challenges/` | Built-in challenges and their hooks |
+| `src/errors.ts` | The `ERR_CHALLENGE_*` codes listed above |

--- a/docs/protocol/challenge-settings.md
+++ b/docs/protocol/challenge-settings.md
@@ -65,7 +65,7 @@ The one exception is opt-in and owner-driven: the owner names individual options
 - The field is omitted entirely, not emitted as `{}`, when nothing qualifies. A record from an owner who opted into nothing is byte-identical to one produced before `publicOptions` existed.
 - Values stay `string`, matching the `options` contract. A structured ruleset ships as a JSON string, exactly as `publication-match` already does with its `matches` option.
 
-Publication is the owner's decision, not the challenge developer's. A challenge package that must forbid or require publication of one of its options enforces that in its own validator rather than by owning the switch.
+Publication is the owner's decision, not the challenge developer's. A challenge package that must forbid or require publication of one of its options enforces that in its `validateChallengeSettings` hook rather than by owning the switch. See [challenge-authoring.md](challenge-authoring.md).
 
 ## Sensitive Options by Built-in Challenge
 
@@ -73,13 +73,15 @@ Two different things get called "sensitive", and `publicOptions` forces them apa
 
 ### Secrets: publishing breaks the challenge
 
+The challenge's own `validateChallengeSettings` hook must forbid publication of these.
+
 | Challenge | Option | Why publishing breaks it |
 |-----------|--------|--------------------------|
 | `question` | `answer` | Anyone reading the record could answer the challenge, so it stops filtering anything |
 
 ### Private by default: publishing is a legitimate owner choice
 
-Not published unless the owner names the option, but naming it is a policy decision rather than a leak.
+Not published unless the owner names the option, but naming it is a policy decision rather than a leak, so the challenge's hook stays silent about them.
 
 | Challenge | Option | What publishing it means |
 |-----------|--------|--------------------------|
@@ -103,5 +105,6 @@ All built-in challenges also accept an `error` option (custom error message), no
 |------|---------|
 | `src/community/schema.ts` | Both `CommunityChallengeSettingSchema` and `CommunityChallengeSchema` |
 | `src/runtime/node/community/challenges/index.ts` | `getCommunityChallengeFromCommunityChallengeSettings()` transformation and `derivePublicOptions()` |
+| `src/runtime/node/community/challenges/validate-challenge-settings.ts` | Validation of a settings entry against the challenge file, see [challenge-authoring.md](challenge-authoring.md) |
 | `src/runtime/node/community/challenges/pkc-js-challenges/` | Built-in challenge implementations with their `optionInputs` |
 | `src/runtime/node/community/local-community.ts` | Where `this.challenges` is populated from `this.settings.challenges` |

--- a/src/community/schema.ts
+++ b/src/community/schema.ts
@@ -203,7 +203,17 @@ export const ChallengeFileSchema = z.looseObject({
     getChallenge: z.function({
         input: [GetChallengeArgsSchema],
         output: z.promise(ResultOfGetChallengeSchema)
-    })
+    }),
+    // Optional semantic validation of the owner's challengeSettings, for the checks only the challenge can
+    // make (does `matches` parse as JSON, does every regexp compile). Core already enforces the mechanical
+    // things optionInputs describes, so a challenge with nothing semantic to check omits this.
+    // Sync and no network: it runs on every community start, so an async validator hitting a third party
+    // would turn that third party's outage into a startup problem. Rejection is a throw of anything at all,
+    // so a package needs no pkc-js import; core wraps it in a PKCError with code
+    // ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED. See docs/protocol/challenge-authoring.md.
+    validateChallengeSettings: z
+        .function({ input: [z.object({ challengeSettings: CommunityChallengeSettingSchema })], output: z.void() })
+        .optional()
 });
 
 export const CommunityChallengeSchema = z.looseObject({

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -413,5 +413,14 @@ export enum messages {
     ERR_CHALLENGE_RESULT_OVERRIDES_COMMENT_SIGNED_FIELD = "A challenge result attempted to set comment.<field> that is in CommentSignedPropertyNames (would invalidate the author's signature on CommentIpfs)",
     ERR_CHALLENGE_RESULT_OVERRIDES_RESERVED_COMMENT_UPDATE_FIELD = "A challenge result attempted to set commentUpdate.<field> that is in CommentUpdateChallengeReservedFieldNames (community-computed field)",
     ERR_CHALLENGE_RESULT_OVERRIDES_NON_COMMUNITY_AUTHOR_KEY = "A challenge result attempted to set commentUpdate.author.<field> with a key other than 'community' — challenges may only extend commentUpdate.author.community",
-    ERR_CHALLENGE_RESULT_OVERRIDES_RESERVED_COMMUNITY_AUTHOR_FIELD = "A challenge result attempted to set commentUpdate.author.community.<field> that is in CommunityAuthorChallengeReservedFieldNames (community-computed or mod-settable field)"
+    ERR_CHALLENGE_RESULT_OVERRIDES_RESERVED_COMMUNITY_AUTHOR_FIELD = "A challenge result attempted to set commentUpdate.author.community.<field> that is in CommunityAuthorChallengeReservedFieldNames (community-computed or mod-settable field)",
+
+    // Validation of settings.challenges[i] against the challenge file. Emitted by the same codes on every
+    // path (edit, creation, start), because a consumer filtering on the code cares about what is wrong,
+    // not about which path noticed. See docs/protocol/challenge-authoring.md.
+    ERR_CHALLENGE_OPTION_NOT_DECLARED_IN_OPTION_INPUTS = "settings.challenges[i].options has a key that no optionInputs entry of the challenge declares, so it is never read",
+    ERR_CHALLENGE_REQUIRED_OPTION_MISSING = "settings.challenges[i].options is missing an option whose optionInputs entry is required",
+    ERR_CHALLENGE_PUBLIC_OPTION_NOT_DECLARED_IN_OPTION_INPUTS = "settings.challenges[i].publicOptions names an option that no optionInputs entry of the challenge declares",
+    ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED = "The challenge's validateChallengeSettings hook rejected settings.challenges[i]",
+    ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED_FOR_CHALLENGES = "One or more challenges in settings.challenges failed validation"
 }

--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -967,7 +967,9 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
             ...(pkc.settings?.challenges || {}) // user-defined override
         };
         const challenges = mapValues(allChallengeFactories, (challengeFactory) =>
-            omit(challengeFactory({ challengeSettings: {} }), ["getChallenge"])
+            // both dropped keys are functions: they cannot be serialized, and both only ever run
+            // community-side on the node that owns the community
+            omit(challengeFactory({ challengeSettings: {} }), ["getChallenge", "validateChallengeSettings"])
         );
 
         return <PKCWsServerSettingsSerialized>{ pkcOptions, challenges };

--- a/src/rpc/src/schema.ts
+++ b/src/rpc/src/schema.ts
@@ -46,6 +46,8 @@ export const PKCWsServerSettingsSerializedSchema = z.object({
     pkcOptions: PKCParsedOptionsSchema.loose(),
     challenges: z.record(
         z.string(),
-        ChallengeFileSchema.omit({ getChallenge: true }) // to avoid throwing because of recursive dependency
+        // getChallenge is omitted to avoid throwing because of a recursive dependency; validateChallengeSettings
+        // is omitted because it is a function that cannot cross the wire and only ever runs community-side.
+        ChallengeFileSchema.omit({ getChallenge: true, validateChallengeSettings: true })
     )
 });

--- a/src/runtime/node/community/challenges/index.ts
+++ b/src/runtime/node/community/challenges/index.ts
@@ -87,7 +87,7 @@ type ChallengeVerificationFailure = {
 } & Pick<ChallengeResultAggregate, "aggregatedReason">;
 
 // Use structural typing for the pkc param to avoid circular import issues
-type PKCWithSettingsChallenges = {
+export type PKCWithSettingsChallenges = {
     settings?: { challenges?: Record<string, ChallengeFileFactoryInput> };
 };
 
@@ -843,16 +843,17 @@ const derivePublicOptions = (communityChallengeSettings: CommunityChallengeSetti
     return isEmpty(published) ? undefined : published;
 };
 
-// get the data to be published publicly to community.challenges
-const getCommunityChallengeFromCommunityChallengeSettings = async ({
+// Load the ChallengeFile a settings entry points at, by path or by registered name. The factory is
+// expected to stay cheap and non-throwing: it runs on every community start and DB migration, not only on
+// edit, so a factory that threw on bad options would take startup down rather than fail the offending
+// edit. Rejecting bad options is validateChallengeSettings' job. See docs/protocol/challenge-authoring.md.
+const loadChallengeFileFromCommunityChallengeSettings = async ({
     communityChallengeSettings,
     pkc
 }: {
     communityChallengeSettings: CommunityChallengeSetting;
     pkc?: PKCWithSettingsChallenges;
-}): Promise<{ communityChallenge: CommunityChallenge }> => {
-    communityChallengeSettings = CommunityChallengeSettingSchema.parse(communityChallengeSettings);
-
+}): Promise<ChallengeFile> => {
     // if the challenge is an external file, fetch it and override the communityChallengeSettings values
     let challengeFile: ChallengeFile | undefined = undefined;
     if (communityChallengeSettings.path) {
@@ -879,6 +880,19 @@ const getCommunityChallengeFromCommunityChallengeSettings = async ({
         challengeFile = ChallengeFileSchema.parse(ChallengeFileFactory({ challengeSettings: communityChallengeSettings }));
     }
     if (!challengeFile) throw Error("Failed to load challenge file");
+    return challengeFile;
+};
+
+// get the data to be published publicly to community.challenges
+const getCommunityChallengeFromCommunityChallengeSettings = async ({
+    communityChallengeSettings,
+    pkc
+}: {
+    communityChallengeSettings: CommunityChallengeSetting;
+    pkc?: PKCWithSettingsChallenges;
+}): Promise<{ communityChallenge: CommunityChallenge }> => {
+    communityChallengeSettings = CommunityChallengeSettingSchema.parse(communityChallengeSettings);
+    const challengeFile = await loadChallengeFileFromCommunityChallengeSettings({ communityChallengeSettings, pkc });
     const { challenge, type } = challengeFile;
     return {
         communityChallenge: {
@@ -898,5 +912,6 @@ export {
     getPendingChallengesOrChallengeVerification,
     getChallengeVerificationFromChallengeAnswers,
     getChallengeVerification,
-    getCommunityChallengeFromCommunityChallengeSettings
+    getCommunityChallengeFromCommunityChallengeSettings,
+    loadChallengeFileFromCommunityChallengeSettings
 };

--- a/src/runtime/node/community/challenges/pkc-js-challenges/address-list-validation.ts
+++ b/src/runtime/node/community/challenges/pkc-js-challenges/address-list-validation.ts
@@ -1,0 +1,29 @@
+import type { CommunityChallengeSetting } from "../../../../../community/types.js";
+
+// Shared by the blacklist and whitelist challenges, which take the same `addresses` and `urls` options in
+// the same comma separated form.
+
+const splitCommaSeparated = (value: string): string[] => value.split(",").map((entry) => entry.trim());
+
+// The only consumer of `urls` is fetch(), so anything that is not a parseable http(s) URL is a guaranteed
+// silent failure: fetchAndUpdateUrlSet swallows every error, and the remote list simply never loads.
+export function validateAddressListOptions({ challengeSettings }: { challengeSettings: CommunityChallengeSetting }): void {
+    const { addresses, urls } = challengeSettings.options ?? {};
+
+    if (addresses)
+        for (const [index, address] of splitCommaSeparated(addresses).entries())
+            if (!address) throw new Error(`addresses entry ${index} is empty, check for a stray or trailing comma`);
+
+    if (urls)
+        for (const [index, url] of splitCommaSeparated(urls).entries()) {
+            if (!url) throw new Error(`urls entry ${index} is empty, check for a stray or trailing comma`);
+            let parsed: URL;
+            try {
+                parsed = new URL(url);
+            } catch {
+                throw new Error(`urls entry ${index} ('${url}') is not a valid URL`);
+            }
+            if (parsed.protocol !== "http:" && parsed.protocol !== "https:")
+                throw new Error(`urls entry ${index} ('${url}') must use http: or https:, it is fetched over HTTP`);
+        }
+}

--- a/src/runtime/node/community/challenges/pkc-js-challenges/blacklist.ts
+++ b/src/runtime/node/community/challenges/pkc-js-challenges/blacklist.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../../../../community/types.js";
 import { derivePublicationFromChallengeRequest } from "../../../../../util.js";
 import { getCommunityAddressFromRecord } from "../../../../../publications/publication-community.js";
+import { validateAddressListOptions } from "./address-list-validation.js";
 
 const optionInputs = <NonNullable<ChallengeFileInput["optionInputs"]>>[
     {
@@ -146,7 +147,7 @@ const getChallenge = async ({ challengeSettings, challengeRequestMessage }: GetC
 };
 
 function ChallengeFileFactory({ challengeSettings }: { challengeSettings: CommunityChallengeSetting }): ChallengeFileInput {
-    return { getChallenge, optionInputs, type, description };
+    return { getChallenge, optionInputs, type, description, validateChallengeSettings: validateAddressListOptions };
 }
 
 export default ChallengeFileFactory;

--- a/src/runtime/node/community/challenges/pkc-js-challenges/publication-match.ts
+++ b/src/runtime/node/community/challenges/pkc-js-challenges/publication-match.ts
@@ -158,9 +158,39 @@ const getChallenge = async ({ challengeSettings, challengeRequestMessage }: GetC
         };
 };
 
+// getChallenge parses `matches` per publication and turns a bad value into a per-author failure, which
+// means a typo in the owner's config surfaces as every author being rejected rather than as a failed edit.
+// Checking it here moves that to configuration time. No opinion on publication: advertising the patterns so
+// a UI can validate before the author burns an attempt is a legitimate owner choice.
+const validateChallengeSettings = ({ challengeSettings }: { challengeSettings: CommunityChallengeSetting }): void => {
+    const matchesStr = challengeSettings.options?.matches;
+    if (!matchesStr) return;
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(matchesStr);
+    } catch (e) {
+        throw new Error(`matches is not valid JSON: ${(e as Error).message}`);
+    }
+    if (!Array.isArray(parsed)) throw new Error("matches must be a JSON array of {propertyName, regexp} objects");
+
+    for (const [index, match] of parsed.entries()) {
+        if (typeof match !== "object" || match === null || Array.isArray(match))
+            throw new Error(`matches[${index}] must be an object with propertyName and regexp`);
+        const { propertyName, regexp } = <Partial<Match>>match;
+        if (typeof propertyName !== "string" || !propertyName) throw new Error(`matches[${index}].propertyName must be a non-empty string`);
+        if (typeof regexp !== "string" || !regexp) throw new Error(`matches[${index}].regexp must be a non-empty string`);
+        try {
+            new RegExp(regexp);
+        } catch (e) {
+            throw new Error(`matches[${index}].regexp ('${regexp}') is not a valid regular expression: ${(e as Error).message}`);
+        }
+    }
+};
+
 function ChallengeFileFactory({ challengeSettings }: { challengeSettings: CommunityChallengeSetting }): ChallengeFileInput {
     const description = challengeSettings?.options?.description || defaultDescription;
-    return { getChallenge, optionInputs, type, description };
+    return { getChallenge, optionInputs, type, description, validateChallengeSettings };
 }
 
 export default ChallengeFileFactory;

--- a/src/runtime/node/community/challenges/pkc-js-challenges/question.ts
+++ b/src/runtime/node/community/challenges/pkc-js-challenges/question.ts
@@ -74,13 +74,21 @@ const getChallenge = async ({
     };
 };
 
+// `answer` is a secret rather than merely private: publishing it lets anyone read the record and answer the
+// challenge, so the challenge stops filtering anything. That is never a legitimate owner choice, so it is a
+// veto rather than a warning. See docs/protocol/challenge-authoring.md.
+const validateChallengeSettings = ({ challengeSettings }: { challengeSettings: CommunityChallengeSetting }): void => {
+    if (challengeSettings.publicOptions?.includes("answer"))
+        throw new Error("answer cannot be listed in publicOptions: publishing the answer means anyone can pass the challenge");
+};
+
 function ChallengeFileFactory({ challengeSettings }: { challengeSettings: CommunityChallengeSetting }): ChallengeFileInput {
     // some challenges can prepublish the challenge so that it can be preanswered
     // in the challengeRequestMessage
     const question = challengeSettings?.options?.question;
     const challenge = question;
 
-    return { getChallenge, optionInputs, type, challenge, description };
+    return { getChallenge, optionInputs, type, challenge, description, validateChallengeSettings };
 }
 
 export default ChallengeFileFactory;

--- a/src/runtime/node/community/challenges/pkc-js-challenges/whitelist.ts
+++ b/src/runtime/node/community/challenges/pkc-js-challenges/whitelist.ts
@@ -7,6 +7,7 @@ import type {
 } from "../../../../../community/types.js";
 import { derivePublicationFromChallengeRequest } from "../../../../../util.js";
 import { getCommunityAddressFromRecord } from "../../../../../publications/publication-community.js";
+import { validateAddressListOptions } from "./address-list-validation.js";
 
 const optionInputs = <NonNullable<ChallengeFileInput["optionInputs"]>>[
     {
@@ -146,7 +147,7 @@ const getChallenge = async ({ challengeSettings, challengeRequestMessage }: GetC
 };
 
 function ChallengeFileFactory({ challengeSettings }: { challengeSettings: CommunityChallengeSetting }): ChallengeFileInput {
-    return { getChallenge, optionInputs, type, description };
+    return { getChallenge, optionInputs, type, description, validateChallengeSettings: validateAddressListOptions };
 }
 
 export default ChallengeFileFactory;

--- a/src/runtime/node/community/challenges/validate-challenge-settings.ts
+++ b/src/runtime/node/community/challenges/validate-challenge-settings.ts
@@ -1,0 +1,134 @@
+import { PKCError } from "../../../../pkc-error.js";
+import { loadChallengeFileFromCommunityChallengeSettings } from "./index.js";
+import type { ChallengeFile, CommunityChallengeSetting } from "../../../../community/types.js";
+import type { PKCWithSettingsChallenges } from "./index.js";
+
+// One challenge's rejection, as it appears in the aggregated edit-path throw and in the per-challenge
+// start-path error events. `challengeName` is settings.challenges[i].name, or its `path` for a challenge
+// loaded from disk, so an owner can tell which entry is broken without counting array indices.
+export interface ChallengeSettingsValidationFailure {
+    challengeIndex: number;
+    challengeName: string;
+    error: PKCError;
+}
+
+const describeChallenge = (communityChallengeSettings: CommunityChallengeSetting): string =>
+    communityChallengeSettings.name || communityChallengeSettings.path || "unknown challenge";
+
+// `required` means present, nothing more. An option set to "" is deliberately accepted: whether an empty
+// value is meaningful is the challenge's own business, and its validateChallengeSettings hook is where to
+// reject one.
+const isOptionSet = (value: string | undefined): boolean => value !== undefined && value !== null;
+
+// Generic validation of a settings entry against the challenge file's own optionInputs. No challenge code
+// is involved: every one of these checks is mechanical, and each would otherwise be reimplemented by every
+// package. Returns the first failure, or undefined when the entry is valid.
+//
+// optionInputs is optional. A challenge file that declares none makes no promises about which options it
+// reads, so the declared-key checks are skipped for it rather than rejecting every option it was given.
+export function validateChallengeSettingsAgainstChallengeFile({
+    challengeSettings,
+    challengeFile,
+    challengeIndex
+}: {
+    challengeSettings: CommunityChallengeSetting;
+    challengeFile: ChallengeFile;
+    challengeIndex: number;
+}): PKCError | undefined {
+    const challengeName = describeChallenge(challengeSettings);
+    const baseDetails = { challengeIndex, challengeName };
+    const { optionInputs } = challengeFile;
+
+    if (optionInputs) {
+        const declaredOptions = new Set(optionInputs.map((optionInput) => optionInput.option));
+
+        // An undeclared key can only be a typo: nothing reads it, and it is never published either, so it
+        // is dead config by definition. Silently ignoring it is how `anwser` instead of `answer` ends up
+        // rejecting every author with no signal to the owner.
+        for (const optionName of Object.keys(challengeSettings.options ?? {}))
+            if (!declaredOptions.has(optionName))
+                return new PKCError("ERR_CHALLENGE_OPTION_NOT_DECLARED_IN_OPTION_INPUTS", {
+                    ...baseDetails,
+                    offendingOption: optionName,
+                    declaredOptions: [...declaredOptions]
+                });
+
+        // This is what finally makes ChallengeOptionInputSchema's `required` comment true.
+        for (const optionInput of optionInputs)
+            if (optionInput.required && !isOptionSet(challengeSettings.options?.[optionInput.option]))
+                return new PKCError("ERR_CHALLENGE_REQUIRED_OPTION_MISSING", {
+                    ...baseDetails,
+                    missingOption: optionInput.option
+                });
+
+        for (const optionName of challengeSettings.publicOptions ?? [])
+            if (!declaredOptions.has(optionName))
+                return new PKCError("ERR_CHALLENGE_PUBLIC_OPTION_NOT_DECLARED_IN_OPTION_INPUTS", {
+                    ...baseDetails,
+                    offendingOption: optionName,
+                    declaredOptions: [...declaredOptions]
+                });
+    }
+
+    // The challenge's own semantic validation, for what core cannot know. It may throw anything, so no
+    // pkc-js import is needed on the package side. We keep the original as `cause` for a local consumer,
+    // and copy its message into details.validationError, which is the part that survives RPC serialization.
+    if (challengeFile.validateChallengeSettings)
+        try {
+            challengeFile.validateChallengeSettings({ challengeSettings });
+        } catch (e) {
+            const wrapped = new PKCError("ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED", {
+                ...baseDetails,
+                validationError: e instanceof Error ? e.message : String(e)
+            });
+            // Object.assign rather than `wrapped.cause = e` because the build targets ES2021, whose Error
+            // type predates the standard `cause` property. It is still there at runtime on every Node we support.
+            Object.assign(wrapped, { cause: e });
+            return wrapped;
+        }
+
+    return undefined;
+}
+
+// Validate every entry of settings.challenges and collect the failures rather than stopping at the first,
+// so an owner editing several challenges learns about all of them at once instead of one edit at a time.
+// Loading a challenge file is itself allowed to throw (a bad `path`, an unregistered `name`); that is a
+// different failure from an invalid setting, so it propagates instead of being collected.
+export async function collectChallengeSettingsValidationFailures({
+    challengeSettings,
+    pkc
+}: {
+    challengeSettings: CommunityChallengeSetting[];
+    pkc?: PKCWithSettingsChallenges;
+}): Promise<ChallengeSettingsValidationFailure[]> {
+    const failures: ChallengeSettingsValidationFailure[] = [];
+    for (const [challengeIndex, communityChallengeSettings] of challengeSettings.entries()) {
+        const challengeFile = await loadChallengeFileFromCommunityChallengeSettings({ communityChallengeSettings, pkc });
+        const error = validateChallengeSettingsAgainstChallengeFile({
+            challengeSettings: communityChallengeSettings,
+            challengeFile,
+            challengeIndex
+        });
+        if (error) failures.push({ challengeIndex, challengeName: describeChallenge(communityChallengeSettings), error });
+    }
+    return failures;
+}
+
+// The edit and creation paths reject the whole write: nothing is persisted yet on either, so one
+// aggregated throw carrying every failure is safe and is the most useful thing for an owner-facing UI.
+export async function throwIfChallengeSettingsAreInvalid({
+    challengeSettings,
+    pkc,
+    communityAddress
+}: {
+    challengeSettings: CommunityChallengeSetting[];
+    pkc?: PKCWithSettingsChallenges;
+    communityAddress?: string;
+}): Promise<void> {
+    const failures = await collectChallengeSettingsValidationFailures({ challengeSettings, pkc });
+    if (failures.length)
+        throw new PKCError("ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED_FOR_CHALLENGES", {
+            communityAddress,
+            failures: failures.map(({ challengeIndex, challengeName, error }) => ({ challengeIndex, challengeName, error }))
+        });
+}

--- a/src/runtime/node/community/local-community/db-state.ts
+++ b/src/runtime/node/community/local-community/db-state.ts
@@ -11,6 +11,7 @@ import { SignerWithPublicKeyAddress } from "../../../../signer/index.js";
 import { getIpfsKeyFromPrivateKey, getPublicKeyFromPrivateKey } from "../../../../signer/util.js";
 import { findCommunityInRegistry, findStartedCommunity } from "../../../../pkc/tracked-instance-registry-util.js";
 import { getCommunityChallengeFromCommunityChallengeSettings } from "../challenges/index.js";
+import { throwIfChallengeSettingsAreInvalid } from "../challenges/validate-challenge-settings.js";
 import type {
     CommunityIpfsType,
     CreateNewLocalCommunityParsedOptions,
@@ -272,6 +273,14 @@ export async function createNewLocalCommunityDb(community: LocalCommunity) {
     if (typeof community.settings?.purgeDisapprovedCommentsOlderThan !== "number") {
         community.settings = { ...community.settings, purgeDisapprovedCommentsOlderThan: 1.21e6 }; // two weeks
     }
+
+    // Creation can throw: nothing has been persisted yet, so refusing to create the community is safe and
+    // leaves the owner with no broken config on disk.
+    await throwIfChallengeSettingsAreInvalid({
+        challengeSettings: community.settings.challenges!,
+        pkc: community._pkc,
+        communityAddress: community.address
+    });
 
     community.challenges = await Promise.all(
         community.settings.challenges!.map(

--- a/src/runtime/node/community/local-community/editing.ts
+++ b/src/runtime/node/community/local-community/editing.ts
@@ -12,6 +12,7 @@ import {
     trackStartedCommunity
 } from "../../../../pkc/tracked-instance-registry-util.js";
 import { getCommunityChallengeFromCommunityChallengeSettings } from "../challenges/index.js";
+import { throwIfChallengeSettingsAreInvalid } from "../challenges/validate-challenge-settings.js";
 import type {
     CommunityEditOptions,
     CommunityIpfsType,
@@ -65,6 +66,13 @@ export async function parseChallengesToEdit(
     community: LocalCommunity,
     newChallengeSettings: NonNullable<NonNullable<CommunityEditOptions["settings"]>["challenges"]>
 ): Promise<NonNullable<Pick<InternalCommunityRecordAfterFirstUpdateType, "challenges" | "_usingDefaultChallenge">>> {
+    // A dedicated pass first, before anything below is derived or persisted, so an invalid edit is rejected
+    // whole. Failures are aggregated across every challenge rather than thrown one at a time.
+    await throwIfChallengeSettingsAreInvalid({
+        challengeSettings: newChallengeSettings,
+        pkc: community._pkc,
+        communityAddress: community.address
+    });
     return {
         challenges: await Promise.all(
             newChallengeSettings.map(

--- a/src/runtime/node/community/local-community/lifecycle.ts
+++ b/src/runtime/node/community/local-community/lifecycle.ts
@@ -6,6 +6,7 @@ import env from "../../../../version.js";
 import { pubsubTopicToDhtKey, removeMfsFilesSafely, sleepUntilTimeoutOrAbort } from "../../../../util.js";
 import { moveCommunityDbToDeletedDirectory } from "../../util.js";
 import { getCommunityChallengeFromCommunityChallengeSettings } from "../challenges/index.js";
+import { collectChallengeSettingsValidationFailures } from "../challenges/validate-challenge-settings.js";
 import {
     findCommunityInRegistry,
     findStartedCommunity,
@@ -108,6 +109,29 @@ export async function initBeforeStarting(community: LocalCommunity) {
     await community._dbHandler.initDbIfNeeded();
 }
 
+// Report every invalid persisted challenge as its own `error` event, one per challenge, and keep going.
+// Loading a challenge file can itself throw (a `path` that no longer exists, a `name` this node does not
+// have registered); that is a startup problem in its own right and is reported the same way rather than
+// swallowed, since the caller only asked us to look at the config.
+async function emitChallengeSettingsValidationErrors(community: LocalCommunity, log: Logger) {
+    let failures: Awaited<ReturnType<typeof collectChallengeSettingsValidationFailures>>;
+    try {
+        failures = await collectChallengeSettingsValidationFailures({
+            challengeSettings: community.settings?.challenges ?? [],
+            pkc: community._pkc
+        });
+    } catch (e) {
+        log.error("Failed to validate settings.challenges on start", community.address, e);
+        community.emit("error", e as PKCError);
+        return;
+    }
+    for (const { error, challengeIndex, challengeName } of failures) {
+        error.details = { ...error.details, challengeIndex, challengeName, communityAddress: community.address };
+        log.error("Invalid challenge settings on start", community.address, error);
+        community.emit("error", error);
+    }
+}
+
 export async function start(community: LocalCommunity) {
     const log = Logger("pkc-js:local-community:start");
     if (community.state === "updating")
@@ -174,6 +198,12 @@ export async function start(community: LocalCommunity) {
                         .communityChallenge
             )
         ); // make sure community.challenges is using latest props from settings.challenges
+
+        // Start only reports; it never throws. A config that was persisted before these checks existed, or
+        // one that a stricter challenge version now rejects, must not take startup down. It is re-emitted
+        // on every start until the owner fixes it, because a suppressed error is how a misconfiguration
+        // gets forgotten.
+        await emitChallengeSettingsValidationErrors(community, log);
     } catch (e) {
         await community.stop(); // Make sure to reset the community state
         //@ts-expect-error

--- a/test/node/community/challenges/validate-challenge-settings.community.test.ts
+++ b/test/node/community/challenges/validate-challenge-settings.community.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mockPKC, resolveWhenConditionIsTrue } from "../../../../dist/node/test/test-util.js";
+import { updateDbInternalState } from "../../../../dist/node/runtime/node/community/local-community/db-state.js";
+import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
+import type { PKC as PKCType } from "../../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+import type { RpcLocalCommunity } from "../../../../dist/node/community/rpc-local-community.js";
+import type { CommunityChallengeSetting } from "../../../../dist/node/community/types.js";
+import type { PKCError } from "../../../../dist/node/pkc-error.js";
+
+// settings.challenges[i] is validated in two layers: core checks the mechanical things optionInputs
+// describes (undeclared keys, missing required options, undeclared publicOptions entries), and the
+// challenge's own optional validateChallengeSettings hook checks what only it can know. Both run on the
+// edit, creation and start paths, with the same error codes on each. See
+// docs/protocol/challenge-authoring.md.
+
+const failuresOf = (e: unknown): { challengeIndex: number; challengeName: string; error: { code: string; details: any } }[] => {
+    const details = (e as PKCError).details;
+    expect(details, `error carried no details: ${e}`).to.be.an("object");
+    expect(details.failures, `error carried no failures: ${JSON.stringify(details)}`).to.be.an("array");
+    return details.failures;
+};
+
+describe.concurrent(`validateChallengeSettings and core optionInputs validation`, async () => {
+    let pkc: PKCType;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+    });
+
+    afterAll(async () => {
+        await pkc.destroy();
+    });
+
+    describe(`edit() rejects the whole edit and aggregates every failure`, async () => {
+        it(`rejects an options key that no optionInputs entry declares`, async () => {
+            const community = (await pkc.createCommunity({})) as LocalCommunity | RpcLocalCommunity;
+            const before = community.settings!.challenges;
+            // 'anwser' is a typo for 'answer': nothing would ever read it, and every author would be
+            // rejected from then on with no signal to the owner
+            const challenges: CommunityChallengeSetting[] = [{ name: "question", options: { question: "q?", anwser: "a" } }];
+
+            let thrown: unknown;
+            try {
+                await community.edit({ settings: { challenges } });
+            } catch (e) {
+                thrown = e;
+            }
+            expect(thrown, "edit() should have thrown").to.exist;
+            expect((thrown as PKCError).code).to.equal("ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED_FOR_CHALLENGES");
+
+            const failures = failuresOf(thrown);
+            expect(failures).to.have.length(1);
+            expect(failures[0].challengeIndex).to.equal(0);
+            expect(failures[0].challengeName).to.equal("question");
+            expect(failures[0].error.code).to.equal("ERR_CHALLENGE_OPTION_NOT_DECLARED_IN_OPTION_INPUTS");
+            expect(failures[0].error.details.offendingOption).to.equal("anwser");
+
+            // nothing was persisted: the settings are untouched
+            expect(community.settings!.challenges).to.deep.equal(before);
+            await community.delete();
+        });
+
+        it(`rejects a missing option whose optionInputs entry is required`, async () => {
+            const community = (await pkc.createCommunity({})) as LocalCommunity | RpcLocalCommunity;
+            // question's 'answer' optionInput carries required: true
+            const challenges: CommunityChallengeSetting[] = [{ name: "question", options: { question: "q?" } }];
+
+            let thrown: unknown;
+            try {
+                await community.edit({ settings: { challenges } });
+            } catch (e) {
+                thrown = e;
+            }
+            const failures = failuresOf(thrown);
+            expect(failures[0].error.code).to.equal("ERR_CHALLENGE_REQUIRED_OPTION_MISSING");
+            expect(failures[0].error.details.missingOption).to.equal("answer");
+            await community.delete();
+        });
+
+        // `required` means present, nothing more: whether "" is meaningful is the challenge's own business
+        it(`accepts a required option that is present but empty`, async () => {
+            const community = (await pkc.createCommunity({})) as LocalCommunity | RpcLocalCommunity;
+            const challenges: CommunityChallengeSetting[] = [{ name: "question", options: { question: "q?", answer: "" } }];
+            await community.edit({ settings: { challenges } });
+            expect(community.settings!.challenges).to.deep.equal(challenges);
+            await community.delete();
+        });
+
+        it(`rejects a publicOptions entry that no optionInputs entry declares`, async () => {
+            const community = (await pkc.createCommunity({})) as LocalCommunity | RpcLocalCommunity;
+            const challenges: CommunityChallengeSetting[] = [
+                { name: "question", options: { question: "q?", answer: "a" }, publicOptions: ["quesion"] }
+            ];
+
+            let thrown: unknown;
+            try {
+                await community.edit({ settings: { challenges } });
+            } catch (e) {
+                thrown = e;
+            }
+            const failures = failuresOf(thrown);
+            expect(failures[0].error.code).to.equal("ERR_CHALLENGE_PUBLIC_OPTION_NOT_DECLARED_IN_OPTION_INPUTS");
+            expect(failures[0].error.details.offendingOption).to.equal("quesion");
+            await community.delete();
+        });
+
+        it(`reports every invalid challenge at once instead of one per edit`, async () => {
+            const community = (await pkc.createCommunity({})) as LocalCommunity | RpcLocalCommunity;
+            const challenges: CommunityChallengeSetting[] = [
+                { name: "question", options: { question: "q?", answer: "a" } }, // valid
+                { name: "question", options: { question: "q?" } }, // missing required answer
+                { name: "publication-match", options: { matches: "[{" } }, // hook: unparseable JSON
+                { name: "blacklist", options: { urls: "not a url" } } // hook: unfetchable url
+            ];
+
+            let thrown: unknown;
+            try {
+                await community.edit({ settings: { challenges } });
+            } catch (e) {
+                thrown = e;
+            }
+            const failures = failuresOf(thrown);
+            expect(failures.map((f) => f.challengeIndex)).to.deep.equal([1, 2, 3]);
+            expect(failures.map((f) => f.challengeName)).to.deep.equal(["question", "publication-match", "blacklist"]);
+            expect(failures.map((f) => f.error.code)).to.deep.equal([
+                "ERR_CHALLENGE_REQUIRED_OPTION_MISSING",
+                "ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED",
+                "ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED"
+            ]);
+            // the challenge's own message is preserved, so an owner-facing UI can show what is wrong
+            expect(failures[1].error.details.validationError).to.include("matches is not valid JSON");
+            expect(failures[2].error.details.validationError).to.include("not a valid URL");
+            await community.delete();
+        });
+
+        it(`accepts a valid edit that exercises every built-in hook`, async () => {
+            const community = (await pkc.createCommunity({})) as LocalCommunity | RpcLocalCommunity;
+            const challenges: CommunityChallengeSetting[] = [
+                { name: "question", options: { question: "q?", answer: "a" }, publicOptions: ["question"] },
+                { name: "publication-match", options: { matches: `[{"propertyName":"author.address","regexp":"\\\\.bso$"}]` } },
+                { name: "blacklist", options: { addresses: "a.bso,b.bso", urls: "https://example.com/list.json" } },
+                { name: "whitelist", options: { addresses: "c.bso", urls: "http://example.com/list.json" } },
+                { name: "text-math", options: { difficulty: "2" } },
+                { name: "fail", options: { error: "no" } }
+            ];
+            await community.edit({ settings: { challenges } });
+            expect(community.settings!.challenges).to.deep.equal(challenges);
+            await community.delete();
+        });
+    });
+
+    describe(`built-in hooks`, async () => {
+        const expectHookRejection = async (challenge: CommunityChallengeSetting, expectedMessage: string) => {
+            const community = (await pkc.createCommunity({})) as LocalCommunity | RpcLocalCommunity;
+            let thrown: unknown;
+            try {
+                await community.edit({ settings: { challenges: [challenge] } });
+            } catch (e) {
+                thrown = e;
+            }
+            const failures = failuresOf(thrown);
+            expect(failures[0].error.code).to.equal("ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED");
+            expect(failures[0].error.details.validationError).to.include(expectedMessage);
+            await community.delete();
+        };
+
+        // the answer is a secret rather than merely private: publishing it means anyone can pass
+        it(`question refuses to publish its answer`, async () =>
+            expectHookRejection(
+                { name: "question", options: { question: "q?", answer: "a" }, publicOptions: ["answer"] },
+                "answer cannot be listed in publicOptions"
+            ));
+
+        it(`publication-match rejects a regexp that does not compile`, async () =>
+            expectHookRejection(
+                { name: "publication-match", options: { matches: `[{"propertyName":"content","regexp":"["}]` } },
+                "is not a valid regular expression"
+            ));
+
+        it(`publication-match rejects matches that is not an array of objects`, async () =>
+            expectHookRejection({ name: "publication-match", options: { matches: `{"propertyName":"content"}` } }, "must be a JSON array"));
+
+        it(`blacklist rejects a urls entry that fetch could never load`, async () =>
+            expectHookRejection({ name: "blacklist", options: { urls: "ftp://example.com/list.json" } }, "must use http: or https:"));
+
+        it(`whitelist rejects an empty addresses entry`, async () =>
+            expectHookRejection({ name: "whitelist", options: { addresses: "a.bso,,b.bso" } }, "is empty"));
+    });
+
+    describe(`the load paths`, async () => {
+        it(`creation throws, since nothing has been persisted yet`, async () => {
+            let thrown: unknown;
+            try {
+                await pkc.createCommunity({
+                    settings: { challenges: [{ name: "question", options: { question: "q?", anwser: "a" } }] }
+                });
+            } catch (e) {
+                thrown = e;
+            }
+            expect(thrown, "createCommunity() should have thrown").to.exist;
+            expect((thrown as PKCError).code).to.equal("ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED_FOR_CHALLENGES");
+            expect(failuresOf(thrown)[0].error.code).to.equal("ERR_CHALLENGE_OPTION_NOT_DECLARED_IN_OPTION_INPUTS");
+        });
+
+        // Planting an already-broken persisted config means writing the community's internal DB state
+        // directly, which an RPC client has no access to. The RPC side of this (that the start-time error
+        // events reach an RpcLocalCommunity subscriber) is covered in
+        // test/node/pkc/pkc-settings-challenges-rpc.test.ts.
+        describeSkipIfRpc(`start-time reporting`, async () => {
+            // A config persisted before these checks existed, or one a stricter challenge version now
+            // rejects, must never take startup down: start reports and keeps going.
+            it(`start emits one error event per invalid challenge and still starts the community`, async () => {
+                const community = (await pkc.createCommunity({})) as LocalCommunity;
+
+                // write the broken config the way an older release could have, bypassing the edit-path check
+                const broken: CommunityChallengeSetting[] = [
+                    { name: "question", options: { question: "q?" } },
+                    { name: "publication-match", options: { matches: "[{" } }
+                ];
+                community.settings = { ...community.settings, challenges: broken };
+                // _usingDefaultChallenge must go false too: start() regenerates the default challenge over
+                // whatever is persisted while it is true, which would quietly undo the planted config
+                community._usingDefaultChallenge = false;
+                await updateDbInternalState(community, { settings: community.settings, _usingDefaultChallenge: false });
+
+                const errors: PKCError[] = [];
+                community.on("error", (e) => errors.push(e as PKCError));
+
+                await community.start();
+                await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => errors.length >= 2 });
+
+                // the community started anyway
+                expect(community.started).to.be.true;
+                expect(community.state).to.equal("started");
+
+                const validationErrors = errors.filter((e) => e.code?.startsWith("ERR_CHALLENGE_"));
+                expect(validationErrors.map((e) => e.code)).to.include.members([
+                    "ERR_CHALLENGE_REQUIRED_OPTION_MISSING",
+                    "ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED"
+                ]);
+                for (const e of validationErrors) {
+                    expect(e.details.communityAddress).to.equal(community.address);
+                    expect(e.details.challengeIndex).to.be.a("number");
+                    expect(e.details.challengeName).to.equal(e.details.challengeIndex === 0 ? "question" : "publication-match");
+                }
+                await community.delete();
+            });
+        });
+    });
+});

--- a/test/node/pkc/pkc-settings-challenges-rpc.test.ts
+++ b/test/node/pkc/pkc-settings-challenges-rpc.test.ts
@@ -14,6 +14,9 @@ import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
 import type { RpcLocalCommunity } from "../../../dist/node/community/rpc-local-community.js";
 import type { ChallengeVerificationMessageType } from "../../../dist/node/pubsub-messages/types.js";
 import type { PKCWsServerSettingsSerialized } from "../../../dist/node/rpc/src/types.js";
+import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
+import type { PKCError } from "../../../dist/node/pkc-error.js";
+import { updateDbInternalState } from "../../../dist/node/runtime/node/community/local-community/db-state.js";
 import type {
     ChallengeFileInput,
     ChallengeInput,
@@ -296,6 +299,99 @@ describe("pkc.settings.challenges over RPC", () => {
         expect(challenges["runtime-added"].description).to.equal("A custom challenge asking about the sky color.");
 
         await clientPKC.destroy();
+    });
+
+    // The owner-facing configuration UI is the consumer these checks exist to serve, and it usually talks to
+    // the community over RPC, so the payload has to survive serialization rather than only being correct
+    // in-process. See docs/protocol/challenge-authoring.md.
+    describe(`challenge settings validation over RPC`, () => {
+        const connectClient = async () => {
+            const clientPKC = await PKC({ pkcRpcClientsOptions: [RPC_URL], dataPath: undefined, httpRoutersOptions: [] });
+            clientPKC.on("error", () => {}); // Prevent uncaught errors from WebSocket reconnection
+            return clientPKC;
+        };
+
+        it(`the aggregated edit failure arrives intact on an RpcLocalCommunity`, async () => {
+            // drop the "question" override an earlier test installed, so the built-in optionInputs apply
+            serverPKC.settings.challenges = { "sky-color": customSkyChallenge };
+            const clientPKC = await connectClient();
+            const community = (await clientPKC.createCommunity({})) as RpcLocalCommunity;
+
+            let thrown: unknown;
+            try {
+                await community.edit({
+                    settings: {
+                        challenges: [
+                            { name: "question", options: { question: "q?", answer: "a" } }, // valid
+                            { name: "question", options: { question: "q?" } }, // missing required answer
+                            { name: "publication-match", options: { matches: "[{" } } // hook: unparseable JSON
+                        ]
+                    }
+                });
+            } catch (e) {
+                thrown = e;
+            }
+            expect(thrown, "edit() over RPC should have thrown").to.exist;
+            expect((thrown as PKCError).code).to.equal("ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED_FOR_CHALLENGES");
+
+            const failures = (thrown as PKCError).details.failures;
+            expect(failures, `no failures in ${JSON.stringify((thrown as PKCError).details)}`).to.be.an("array");
+            expect(failures).to.have.length(2);
+            expect(failures.map((f: any) => f.challengeIndex)).to.deep.equal([1, 2]);
+            expect(failures.map((f: any) => f.challengeName)).to.deep.equal(["question", "publication-match"]);
+            expect(failures.map((f: any) => f.error.code)).to.deep.equal([
+                "ERR_CHALLENGE_REQUIRED_OPTION_MISSING",
+                "ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED"
+            ]);
+            // the per-failure details survive too, so a UI can point at the offending field
+            expect(failures[0].error.details.missingOption).to.equal("answer");
+            expect(failures[1].error.details.validationError).to.include("matches is not valid JSON");
+
+            await community.delete();
+            await clientPKC.destroy();
+        });
+
+        it(`start-time validation errors reach an RPC subscriber and the community still starts`, async () => {
+            serverPKC.settings.challenges = { "sky-color": customSkyChallenge };
+            // plant an already-broken persisted config server-side, the way a release predating these
+            // checks could have left one behind
+            const serverCommunity = (await serverPKC.createCommunity({})) as LocalCommunity;
+            const broken: CommunityChallengeSetting[] = [
+                { name: "question", options: { question: "q?" } },
+                { name: "publication-match", options: { matches: "[{" } }
+            ];
+            serverCommunity.settings = { ...serverCommunity.settings, challenges: broken };
+            // _usingDefaultChallenge must go false too: start() regenerates the default challenge over
+            // whatever is persisted while it is true, which would quietly undo the planted config
+            serverCommunity._usingDefaultChallenge = false;
+            await updateDbInternalState(serverCommunity, { settings: serverCommunity.settings, _usingDefaultChallenge: false });
+            serverCommunity._dbHandler.destoryConnection();
+
+            const clientPKC = await connectClient();
+            const community = (await clientPKC.createCommunity({ address: serverCommunity.address })) as RpcLocalCommunity;
+            const errors: PKCError[] = [];
+            community.on("error", (e) => errors.push(e as PKCError));
+
+            await community.start();
+            await resolveWhenConditionIsTrue({
+                toUpdate: community,
+                predicate: async () => errors.filter((e) => e.code?.startsWith("ERR_CHALLENGE_")).length >= 2
+            });
+
+            expect(community.state).to.equal("started");
+            const validationErrors = errors.filter((e) => e.code?.startsWith("ERR_CHALLENGE_"));
+            expect(validationErrors.map((e) => e.code)).to.include.members([
+                "ERR_CHALLENGE_REQUIRED_OPTION_MISSING",
+                "ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED"
+            ]);
+            for (const e of validationErrors) {
+                expect(e.details.communityAddress).to.equal(serverCommunity.address);
+                expect(e.details.challengeName).to.equal(e.details.challengeIndex === 0 ? "question" : "publication-match");
+            }
+
+            await community.delete();
+            await clientPKC.destroy();
+        });
     });
 
     it(`RPC client can create a community with custom challenge and publish to it`, async () => {


### PR DESCRIPTION
Closes #283. **Stacked on #287 (#282) — review that first; this PR's diff is only correct against that base.**

## What

Two layers guard `settings.challenges[i]`.

**Layer 1, core, no challenge code involved.** `options` and `publicOptions` are checked against the challenge file's own `optionInputs`:

| Check | Code |
|---|---|
| An `options` key that no `optionInputs` entry declares | `ERR_CHALLENGE_OPTION_NOT_DECLARED_IN_OPTION_INPUTS` |
| A missing option whose `optionInputs` entry has `required: true` | `ERR_CHALLENGE_REQUIRED_OPTION_MISSING` |
| A `publicOptions` entry that no `optionInputs` entry declares | `ERR_CHALLENGE_PUBLIC_OPTION_NOT_DECLARED_IN_OPTION_INPUTS` |

A challenge file that declares no `optionInputs` makes no promise about which options it reads, so the two declared-key checks are skipped for it rather than rejecting everything it was given.

**Layer 2, the optional `validateChallengeSettings` hook**, for what only the challenge can know. Sync, no network (it runs on every start). It may throw anything, so a package needs no pkc-js import; core wraps it in `ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED` keeping the original as `cause` and its message in `details.validationError`, which is the part that survives RPC serialization.

The factory stays cheap and non-throwing, which is the whole point: it runs on load as well as on edit, so a factory that threw on bad options would fail startup instead of the offending edit.

## Where it runs

| Path | Behavior |
|---|---|
| `edit()` | Dedicated pass before `parseChallengesToEdit()`. Failures aggregated across every challenge into one `ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED_FOR_CHALLENGES` carrying `{challengeIndex, challengeName, error}[]` |
| Creation | Same aggregated throw; nothing persisted yet |
| Start | One `error` event per invalid challenge, carrying `communityAddress`. The community still starts, and it re-emits on every start until fixed |
| DB migration | Silent |

Same codes on every path, no `_ON_LOAD` variants.

## Built-in hooks

- `question` refuses `answer` in `publicOptions` (a secret, not merely private).
- `publication-match` checks `matches` parses as JSON, is an array of `{propertyName, regexp}`, and every `regexp` compiles. No opinion on publication.
- `blacklist` / `whitelist` check every `urls` entry parses with `new URL()` and uses `http:`/`https:` (`fetch` is the only consumer, so anything else fails silently forever) and that `addresses` entries are non-empty. Shared in a new `address-list-validation.ts` rather than duplicated.
- `text-math`, `fail`: none.

## Judgment call worth a look

An option counts as missing when the key is absent **or** the value is `""`. A UI that renders an `optionInputs` entry the owner never filled in sends `""` rather than omitting the key, and an empty required option is exactly as broken as an absent one. Easy to narrow to absent-only if that is wrong.

## Upgrade note for the release

Communities carrying config that has been quietly broken all along (a typo'd key, a missing required option) start emitting `error` events at boot. That is the intended outcome, but it will look like a new bug to whoever sees it first.

## Docs

New `docs/protocol/challenge-authoring.md` for package authors, plus the `docs/protocol/README.md` index entry and an AGENTS.md router row. `challenge-settings.md` splits its sensitive-options table into secrets (the hook must forbid publication) and private-by-default (the owner's choice).

## Tests

- `test/node/community/challenges/validate-challenge-settings.community.test.ts`: the aggregated edit throw, each core check, each built-in hook, the creation throw, and the start-time emits with an error listener attached before `start()`.
- `test/node/pkc/pkc-settings-challenges-rpc.test.ts`: the aggregated payload arrives intact on an `RpcLocalCommunity`, and start-time error events reach RPC subscribers. The owner-facing UI is the consumer this exists to serve, so it is verified rather than assumed.

All green locally under `local-kubo-rpc` and `local-kubo-rpc,remote-pkc-rpc`, with the same regression sweep as #287.