### PR TITLE
docs(pages): document moderation visibility and pinned rules ahead of configurable page sorts

### DIFF
--- a/docs/protocol/pages.md
+++ b/docs/protocol/pages.md
@@ -57,6 +57,26 @@ Both schemas also accept `z.string().min(1)` for forward compatibility with cust
 4. Each subsequent page has its own `nextCid` for further pagination
 5. `pageCids` may be omitted if all items fit in the pre-loaded first page
 
+## Moderation Visibility
+
+Which moderated comments reach a page depends on **which page is being generated**, and the rules differ. They are currently hardcoded in the `PageOptions` each generator passes (`src/runtime/node/community/page-generator.ts`).
+
+| Page | Removed | Deleted | Pending approval | Approved `false` |
+|------|---------|---------|------------------|------------------|
+| Community posts (`generateCommunityPosts`) | excluded | excluded | excluded | excluded |
+| Post replies (`generatePostPages`) | **included** | **included** | excluded | **included** |
+| Reply replies (`generateReplyPages`) | **included** | **included** | excluded | **included** |
+
+Reply pages deliberately include removed and deleted comments so clients can render a tombstone in place, preserving thread structure. The community posts feed excludes them outright. Comments pending approval never appear in either; they live in the mod queue pages.
+
+The `active` sort applies the same exclusions to a post's **descendants** when computing its bump score, so a removed reply does not bump its post (`activeScoresCte` in `src/runtime/node/community/db-handler.ts`).
+
+> **This guarantee is scheduled to become configurable.** Under [#73](https://github.com/pkcprotocol/pkc-js/issues/73) these exclusions become per-sort operator options, defaulting to the values above. A community will be able to publish a feed that includes removed or deleted posts, for example an archive or mod-review sort. Frontends must not assume removed content is absent from a feed; check `commentUpdate.removed` / `deleted` and render accordingly.
+
+## Pinned Comments
+
+Pinned comments are sorted separately from the rest and prepended to the page, and the timeframe filter on `top*` sorts is applied **only to unpinned comments**, so a pinned post never ages out of a windowed index. This is currently a consequence of statement order in `sortAndChunkComments` rather than an explicit rule. Under [#73](https://github.com/pkcprotocol/pkc-js/issues/73) it becomes an explicit per-sort option, defaulting to the behaviour described here.
+
 ## Runtime Types
 
 In the `Comment` class at runtime, pages contain `CommentWithinRepliesPostsPageJson` objects which add runtime fields:
@@ -84,9 +104,17 @@ In the `Comment` class at runtime, pages contain `CommentWithinRepliesPostsPageJ
 - `pageCids` is optional, if all items fit in one page, it may be omitted.
 - ModQueuePages use `CommentUpdateForChallengeVerification` instead of full `CommentUpdate`.
 - Page verification: every comment in a page must belong to the correct community and have valid signatures.
+- Reply pages include removed and deleted comments; the community posts feed does not. See [Moderation Visibility](#moderation-visibility).
+- `pages` currently carries exactly one preloaded sort per record, but that is an implementation detail, not a protocol guarantee. Do not index it positionally.
 
 ## Common Mistakes
 
 - Treating page CIDs as permanent, pages are regenerated when state changes.
 - Fetching pages without verifying signatures, use `verifyPage()` from `src/signer/signatures.ts`.
+- Assuming a comment in a page is not removed or deleted. Reply pages include both by design, and the posts feed will be able to include them once [#73](https://github.com/pkcprotocol/pkc-js/issues/73) lands.
+- Assuming every community generates the same sorts. Discover them from the keys of `pages` and `pageCids` on the record, not from a hardcoded list.
+
+## Future Work
+
+- **Per-depth reply sorts.** Reply sorts are configured as a single list. Keying them by parent depth (`{ "0": [...], "*": [...] }`), plus a cutoff that stops generating reply pages below a given depth, would help deeply nested boards. Low priority: no current consumer needs it, and it is additive, so a flat list can widen to a depth-keyed map without breaking stored settings. Tracked under [#73](https://github.com/pkcprotocol/pkc-js/issues/73).
 - Confusing `pages` (pre-loaded first page) with `pageCids` (CIDs to fetch more pages).


### PR DESCRIPTION
Docs-only. Writes down three page-generation rules that are currently enforced but undocumented, all of which change or become configurable under #73, and records the implementation plan agreed in that issue.

## What changed

`docs/protocol/pages.md`, +28 lines, three new sections plus two invariants and two common mistakes.

**Moderation Visibility.** Which moderated comments reach which page differs per generator, and the rules were only discoverable by reading the `PageOptions` each one passes:

| Page | Removed | Deleted | Pending approval | Approved `false` |
|------|---------|---------|------------------|------------------|
| Community posts | excluded | excluded | excluded | excluded |
| Post replies | **included** | **included** | excluded | **included** |
| Reply replies | **included** | **included** | excluded | **included** |

Reply pages include removed and deleted comments on purpose, so clients can render a tombstone and keep thread structure. The posts feed excludes them. The `active` sort applies the same exclusions to a post's descendants when computing its bump score.

The section carries a callout that #73 turns these into per-sort operator options, so frontends must stop treating "it came from the posts feed" as "it is not removed".

**Pinned Comments.** Pinned comments are prepended and the timeframe filter on `top*` sorts applies only to unpinned comments, so a sticky never ages out of a windowed index. Currently an artifact of statement order in `sortAndChunkComments`, becoming an explicit per-sort option.

**Future Work.** Per-depth reply sorts, noted as low priority with the reasoning for why it is not being built now.

No source changes, no behaviour changes.

## Implementation plan for #73

This PR is the documentation groundwork. The design is settled in #73; the code lands in phases after it.

**Phase 1, registry and built-ins.** Introduce `PKC.pageSorts` mirroring `PKC.challenges`, and move each built-in sort into its own file, mirroring the challenge layout. Includes moving `active` out of `db-handler.ts` into its own page sort file. Acceptance: the existing active sorting tests pass unchanged, and an unset `settings.pages` still produces a byte-identical record.

**Phase 2, config and validation.** `settings.pages` schema, `preloadedPostSorts` / `preloadedReplySorts` as arrays, typed option values (`string | string[] | boolean | number`, unlike challenge options), duplicate-`sortName` and scope validation, mirroring the `validateChallengeSettings` work.

**Phase 3, generation.** Generate only the configured sorts. Generic `maxAge` filter replacing `SortProps.timeframe`. The pinned placement option. Shared preloaded size budget across the preloaded array, with per-sort degradation to `pageCids`.

**Phase 4, the package interface.** `PageSortFile` with `filter` and `scoreAll`, both sync, both taking a single object parameter. The read-only sqlite facade and `exclusionClauses`, which is what lets a package own its SQL while pkc-js keeps one definition of what "removed" means. Factory cached per community start and per settings change.

**Phase 5, failure handling.** Skip a throwing sort and publish the rest; per-cycle checks for configured-but-not-producing (error event) and changed key set (warn).

No `DB_VERSION` bump is expected: `settings` already round-trips as JSON and the whole-set scorer needs no new columns or indexes.

## Cross-repo work

Filed so the dependency order is visible. All are blocked on #73 except the two hooks blockers, which have to land alongside it:

| Repo | Issue | Why |
|---|---|---|
| bitsocial-react-hooks | #96 | `getPreloadedPageSortType` returns one sort; preloaded sorts are now an array. **Blocker.** |
| bitsocial-react-hooks | #95 | Pinned hoist branches on sort-name recognition, will override the pinned option for built-in names. **Blocker.** |
| bitsocial-react-hooks | #97 | Docs heads-up on the moderation change |
| 5chan | #1199 | Hardcodes `active` in five places; a board without it renders empty with no error |
| 5chan | #1200 | Sage is rejected at the form, so nothing reaches the wire |
| bitsocial-cli | #138 | `page-sort install` command group |
| bitsocial-web | #17 | Community settings UI for page sorts |

Refs #73


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on moderation visibility rules for posts, replies, and removed comments.
  * Documented pinned-comment sorting and descendant filtering for active sorts.
  * Added notes on common mistakes, dynamic sort discovery, and planned future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->