### PR TITLE
fix(community): await the source db removal in delete() instead of a fire-and-forget rm

### DIFF
--- a/src/runtime/node/util.ts
+++ b/src/runtime/node/util.ts
@@ -4,7 +4,6 @@ import {
     openSync,
     readSync,
     closeSync,
-    rm as rmSync,
     watch as fsWatch,
     promises as fsPromises,
     createReadStream
@@ -477,19 +476,14 @@ export async function moveCommunityDbToDeletedDirectory(communityAddress: string
         // Delete the original file
         if (os.type() === "Windows_NT") {
             await deleteOldCommunityInWindows(oldPath, pkc);
-        } else
-            rmSync(oldPath, (err) => {
-                if (err) throw err;
-            });
+        } else await fsPromises.rm(oldPath, { force: true });
     } catch (error: any) {
         error.details = { ...error.details, oldPath, newPath };
         throw error;
     }
 }
 
-export async function createKuboRpcClient(
-    kuboRpcClientOptions: KuboRpcClient["_clientOptions"]
-): Promise<KuboRpcClient["_client"]> {
+export async function createKuboRpcClient(kuboRpcClientOptions: KuboRpcClient["_clientOptions"]): Promise<KuboRpcClient["_client"]> {
     const log = Logger("pkc-js:pkc:createKuboRpcClient");
     log.trace("Creating a new kubo client on node with options", kuboRpcClientOptions);
     const { create: CreateKuboRpcClient } = await import("kubo-rpc-client");

--- a/test/node/community/delete.community.test.ts
+++ b/test/node/community/delete.community.test.ts
@@ -56,6 +56,19 @@ describe(`community.delete`, async () => {
         expect(communityFiles).to.not.include(stateLockFilename);
     });
 
+    // Under RPC the fs operations happen inside the RPC server process against its own dataPath,
+    // so this client process cannot observe the server's communities directory.
+    itSkipIfRpc(`community.delete() removes the source db from the communities dir before resolving`, async () => {
+        const freshCommunity = (await pkc.createCommunity()) as LocalCommunity;
+        const sourceDbPath = path.join(pkc.dataPath!, "communities", freshCommunity.address);
+        expect(fs.existsSync(sourceDbPath)).to.be.true;
+        await freshCommunity.delete();
+        // delete() must not resolve while the removal of the source db is still in flight: a
+        // fire-and-forget removal races with callers that clean up the dataPath right after
+        // delete() resolves, which surfaces as an uncaught ENOENT that fails the whole process.
+        expect(fs.existsSync(sourceDbPath)).to.be.false;
+    });
+
     it(`Deleting an updating community will stop the community`, async () => {
         const updatingCommunity = await pkc.createCommunity();
         await updatingCommunity.update();


### PR DESCRIPTION
## What

`community.delete()` removed the source db file with a callback-style `fs.rm` that was never awaited (and whose import was aliased as `rmSync`, hiding that it is the async callback API). An `ENOENT` or any other error thrown inside that callback becomes an uncaught exception that can kill the process after the tests already passed (previously seen as a node-local CI exit 1 with all tests green).

## Change

- Replace the fire-and-forget callback `fs.rm` with `await fsPromises.rm(oldPath, { force: true })` in `moveCommunityDbToDeletedDirectory`, and drop the misleading `rm as rmSync` import.
- Add a regression test in `test/node/community/delete.community.test.ts` asserting the source db file is gone by the time `delete()` resolves.

## Notes

Split out of #279 so that PR stays a pure `chore(deps)` bump; this fix is changelog-worthy and needs a `fix` PR title for release notes.