### PR TITLE
build(ci): make the PR title releasable-commit check runnable locally

### DIFF
--- a/.github/workflows/check-pr-title-type.cjs
+++ b/.github/workflows/check-pr-title-type.cjs
@@ -8,6 +8,12 @@
 //
 // Reads the visible types straight out of config/.release-it.json so this check and the
 // changelog can never disagree about what counts as releasable.
+//
+// Runs in two modes:
+//   CI:    PR_TITLE=<title> node check-pr-title-type.cjs <file with one commit subject per line>
+//   local: node check-pr-title-type.cjs --title "<title>" [--base master]
+//          (or `npm run check:pr-title -- --title "<title>"`), which reads the commit subjects
+//          from `git log <base>..HEAD` so the check can be run before opening or pushing a PR.
 
 const fs = require("fs");
 const path = require("path");
@@ -27,17 +33,26 @@ const parseSubject = (subject) => {
     return { type: match[1].toLowerCase(), breaking: Boolean(match[3]) };
 };
 
-const title = process.env.PR_TITLE;
+const { execFileSync } = require("child_process");
+
+const argv = process.argv.slice(2);
+const argValue = (flag) => {
+    const index = argv.indexOf(flag);
+    return index === -1 ? undefined : argv[index + 1];
+};
+
+const title = argValue("--title") ?? process.env.PR_TITLE;
 if (!title) {
-    console.error("PR_TITLE is not set");
+    console.error("PR title is not set: pass --title \"<title>\" or set PR_TITLE");
     process.exit(1);
 }
 
-const commitsFile = process.argv[2];
-if (!commitsFile) {
-    console.error("usage: check-pr-title-type.cjs <file with one commit subject per line>");
-    process.exit(1);
-}
+const commitsFile = argv.find((arg) => !arg.startsWith("--") && arg !== argValue("--title") && arg !== argValue("--base"));
+const readCommitSubjects = () => {
+    if (commitsFile) return fs.readFileSync(commitsFile, "utf8");
+    const base = argValue("--base") ?? "master";
+    return execFileSync("git", ["log", "--format=%s", `${base}..HEAD`], { cwd: repoRoot, encoding: "utf8" });
+};
 
 const parsedTitle = parseSubject(title);
 if (!parsedTitle) {
@@ -56,8 +71,7 @@ if (visibleTypes.has(parsedTitle.type)) {
     process.exit(0);
 }
 
-const hiddenCommits = fs
-    .readFileSync(commitsFile, "utf8")
+const hiddenCommits = readCommitSubjects()
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,13 @@ Before working on certain areas, read the relevant protocol doc to avoid mistake
   ```
 
   If the subject does not fit, shorten it — do not split it with `;` or move detail into the title. Put the detail in the PR body.
+- The PR title type MUST NOT hide releasable commits. PRs are squash-merged, so the title becomes the only commit message release-it sees; a PR titled `chore:`/`docs:`/`test:` that contains a `fix`/`feat`/`perf`/`build`/`revert` commit ships a release with empty notes, and the `lint-pr-title` CI job (`.github/workflows/check-pr-title-type.cjs`) fails. This most often happens when a PR is opened as `chore:` and a `fix:` commit is pushed later. Before creating a PR and again before every push to an open PR, run the same check locally:
+
+  ```bash
+  npm run check:pr-title -- --title "$TITLE"
+  ```
+
+  If it fails, retitle the PR with the type of its user-visible effect (`gh pr edit <n> --title "$TITLE"`) rather than retyping the commits.
 
 ## SHOULD Rules
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "type": "module",
     "scripts": {
         "prebuild": "node config/generate-version.js",
+        "check:pr-title": "node .github/workflows/check-pr-title-type.cjs",
         "build": "npm run clean && run-s build:node build:browser verify:browser-imports build:node:bundle verify:bundle",
         "build:node": "tsc --project config/tsconfig.json",
         "build:node:bundle": "node config/build-node-bundle.js",


### PR DESCRIPTION
## Why

PR #293 (and others before it) failed `lint-pr-title` only after a `fix:` commit was pushed to a PR that had been opened as `chore:`. The releasable-commit check lives only in CI, so there was no way to catch that before pushing.

## What

- `.github/workflows/check-pr-title-type.cjs` gains a local mode: `--title "<title>" [--base master]` reads commit subjects from `git log <base>..HEAD`. CI mode (`PR_TITLE` + commits file) is unchanged.
- New npm script: `npm run check:pr-title -- --title "$TITLE"`.
- AGENTS.md rule: run it before creating a PR and before every push to an open PR; retitle the PR rather than retype commits.

Verified locally: a `chore:` title over a branch with `fix:` commits exits 1 with the same message CI prints; a `fix:` title exits 0; CI mode with a commits file still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added local pull request title validation through a new npm command.
  * Improved title validation to support both CI and local workflows, including checking recent commit messages.
* **Documentation**
  * Added guidance for using releasable pull request title types and validating titles before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->