### PR TITLE
fix(community): make statsCid optional on CommunityIpfsSchema

### DIFF
--- a/src/community/schema.ts
+++ b/src/community/schema.ts
@@ -263,7 +263,7 @@ export const CommunityIpfsSchema = z
         createdAt: PKCTimestampSchema,
         updatedAt: PKCTimestampSchema,
         pubsubTopic: PubsubTopicSchema.optional(),
-        statsCid: CidStringSchema,
+        statsCid: CidStringSchema.optional(),
         protocolVersion: ProtocolVersionSchema,
         postUpdates: z.record(nonNegativeIntStringSchema, CidStringSchema).optional(),
         title: z.string().optional(),

--- a/test/node-and-browser/community/wire-format-migration.test.ts
+++ b/test/node-and-browser/community/wire-format-migration.test.ts
@@ -197,4 +197,14 @@ describe.concurrent("Wire format migration — backward compat parsing", async (
         expect(result).to.have.property("signature");
         expect(result.name).to.equal("test-sub.eth");
     });
+
+    it(`parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails accepts a record without statsCid`, () => {
+        // statsCid is optional on the wire: a community that has not generated stats yet (or chooses not to
+        // publish them) must still load instead of failing with ERR_INVALID_COMMUNITY_IPFS_SCHEMA
+        const record = clone(newFormatFixture) as Partial<CommunityIpfsType>;
+        delete record.statsCid;
+        const result = parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails(record as CommunityIpfsType);
+        expect(result).to.have.property("signature");
+        expect(result.statsCid).to.be.undefined;
+    });
 });


### PR DESCRIPTION
Closes #297

A community record without `statsCid` failed `parseCommunityIpfsSchemaPassthroughWithPKCErrorIfItFails` (`ERR_INVALID_COMMUNITY_IPFS_SCHEMA`) and never reached the `update` event, despite README documenting `statsCid?: string` and every consumer in `src/` already guarding on it.

- `src/community/schema.ts`: `statsCid: CidStringSchema.optional()`
- `test/node-and-browser/community/wire-format-migration.test.ts`: parse test for a record with `statsCid` deleted (verified red before the schema change)

Signing is unaffected: `CommunitySignedPropertyNames` only covers fields present on the record. Local communities still always publish `statsCid`.