### PR TITLE
perf(helia): serve repeat IPNS resolves from the gossip-fed record cache, not a refetch (#301)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14390,6 +14390,9 @@
                 "@node-datachannel/win32-x64-msvc": "0.33.1"
             }
         },
+        "node_modules/node-datachannel/node_modules/@node-datachannel/android-arm64": {
+            "optional": true
+        },
         "node_modules/node-fetch": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",

--- a/src/clients/base-client-manager.ts
+++ b/src/clients/base-client-manager.ts
@@ -627,7 +627,16 @@ export class BaseClientsManager {
         throwIfAbortSignalAborted(loadOpts.abortSignal);
         // recursive: false so the resolver returns the IMMEDIATE value of each record (so we can
         // walk /ipns/ -> /ipns/ hops ourselves); see performIpnsResolve below.
-        const ipnsResolveOpts = { nocache: true, recursive: false, ...loadOpts };
+        // nocache differs by client (issue #301). The libp2p-js resolver keeps its routing-layer
+        // cache fresh from gossipsub pushes and honors the record's ttl, so letting it serve from
+        // cache is what turns the update loop's 1s cadence into pushes plus one revalidation per
+        // ttl instead of a multi-peer fetch race per community per second. Kubo keeps
+        // nocache: true (pre-existing behavior): its namesys cache is not fed by pkc's pubsub
+        // subscriptions, so serving from it could hand back records up to a full record ttl stale.
+        // Mirrors getIpfsClientWithKuboRpcClientFunctions' precedence: kubo wins when present.
+        const resolvingViaLibp2pJsClient =
+            keys(this._pkc.clients.kuboRpcClients).length === 0 && keys(this._pkc.clients.libp2pJsClients).length > 0;
+        const ipnsResolveOpts = { nocache: !resolvingViaLibp2pJsClient, recursive: false, ...loadOpts };
         const ipfsClient = this.getIpfsClientWithKuboRpcClientFunctions();
 
         const performIpnsResolve = async () => {

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -28,6 +28,7 @@ import { Libp2pJsClient } from "./libp2pjsClient.js";
 import {
     BITSWAP_SESSION_STALLED_GET_FAILOVER_MS,
     cacheIpnsRecordInPubsubLocalStore,
+    readFreshCachedIpnsRecordFromPubsubLocalStore,
     connectToPubsubPeers,
     directFetchIpnsRecordFromProviders,
     fetchBlockWithStalledSessionFailover,
@@ -367,9 +368,12 @@ export async function createLibp2pJsClientOrUseExistingOne(
         // and hands that SAME array to its resolver/publisher/republisher, so it must be mutated in
         // place: reassigning `.routers` only changes what pkc's own loops below iterate, while
         // ipnsNameResolver.resolve() keeps querying (and writing the local cache through) the
-        // original list. We drop LocalStoreIPNSRouting because pkc-js never publishes IPNS via
-        // @helia/ipns (kubo does that), so the local cache is always empty and just adds a wasted
-        // lookup. Keep HeliaIPNSRouting (HTTP delegated routing via helia.routing) and our pubsub
+        // original list. We drop LocalStoreIPNSRouting because its get() serves whatever the
+        // datastore holds with no ttl/EOL judgment of its own: the datastore is no longer empty
+        // (gossiped pushes and the issue #210 direct-fetch write land there), and cache reads must
+        // instead go through name.resolve's ttl-honoring cache gate (issue #301) so the network
+        // fallback loop below stays a NETWORK loop rather than short-circuiting on possibly-stale
+        // cache. Keep HeliaIPNSRouting (HTTP delegated routing via helia.routing) and our pubsub
         // router. Match by the router's toString() tag ("LocalStoreRouting()") rather than by
         // `constructor.name`: the class is module-private and bundlers mangle its name (in 5chan's
         // production build it becomes `dMe`), so a class-name match is a silent no-op there. The
@@ -403,8 +407,22 @@ export async function createLibp2pJsClientOrUseExistingOne(
         await (ipnsPubsubRouter as { start?: () => void | Promise<void> }).start?.();
         // The router's localStore is where gossipsub-delivered records get cached (handleRecord).
         // It's declared private but is a plain class field at runtime; the direct-fetch path below
-        // writes to it to keep the cached-record invariant (issue #210).
+        // writes to it to keep the cached-record invariant (issue #210), and the cache gate in
+        // name.resolve reads it to serve repeat resolves locally (issue #301).
         const ipnsPubsubLocalStore = (ipnsPubsubRouter as unknown as { localStore: IpnsPubsubLocalStore }).localStore;
+        // The router's message listener drops any gossiped record whose topic is not in this
+        // private Set, and upstream only populates it inside router.get() — which the direct-fetch
+        // fast path below never calls (and which, since @helia/ipns 10, skips the add when the
+        // topic is already libp2p-subscribed). name.resolve adds every IPNS topic it subscribes
+        // here as well, so pushed records actually reach handleRecord and the localStore
+        // (issue #301). Same structural-access pattern as localStore above.
+        const ipnsPubsubRouterSubscriptions = (ipnsPubsubRouter as unknown as { subscriptions: Set<string> }).subscriptions;
+        // Per-topic time of the last NETWORK fetch that validated a record for that name. Feeds
+        // the cache gate's freshness check (issue #301): a refetch that returns bytes identical to
+        // the cache never refreshes the localStore's write time, so without this an idle name
+        // would re-fetch on every resolve once its record's ttl first expired. Bounded by the set
+        // of IPNS names this helia instance resolves (communities the app follows).
+        const ipnsRecordNetworkValidatedAtMs = new Map<string, number>();
 
         // Side-channel awaitable warmup: gossipsub's pubsub.subscribe(topic) is sync and returns
         // void, so we can't make it awaitable without breaking @helia/ipns and other internal
@@ -454,6 +472,39 @@ export async function createLibp2pJsClientOrUseExistingOne(
                         const ipnsPubsubTopic = ipnsNameToIpnsOverPubsubTopic(ipnsNameAsPeerId.toString());
                         const routingKey = multihashToIPNSRoutingKey(ipnsNameAsPeerId.toMultihash());
 
+                        // Cache gate (issue #301): once a name's topic is subscribed, gossiped
+                        // records keep the localStore fresh (handleRecord, enabled by the
+                        // subscriptions add below), so a repeat resolve is a local read while the
+                        // cached record is inside its ttl window — not a fresh multi-peer fetch
+                        // race per call. This is what turns the update loop's 1s cadence from
+                        // ~150 fetch streams/s at 64 communities into pushes plus one
+                        // revalidation per name per ttl. Gated on the topic being subscribed
+                        // because freshness relies on the push channel this resolver set up on a
+                        // previous call; nocache: true bypasses the cache entirely (explicit
+                        // refresh, kubo semantics). A cache read failure must never fail the
+                        // resolve, so any error falls through to the network path.
+                        if (options?.nocache !== true && helia.libp2p.services.pubsub.getTopics().includes(ipnsPubsubTopic)) {
+                            try {
+                                const cachedRecord = await readFreshCachedIpnsRecordFromPubsubLocalStore({
+                                    localStore: ipnsPubsubLocalStore,
+                                    routingKey,
+                                    lastNetworkValidatedAtMs: ipnsRecordNetworkValidatedAtMs.get(ipnsPubsubTopic)
+                                });
+                                if (cachedRecord) {
+                                    log.trace("Serving IPNS record for", currentName, "from the routing-layer cache");
+                                    yield cachedRecord.value;
+                                    return;
+                                }
+                            } catch (cacheErr) {
+                                log.trace(
+                                    "Reading the cached IPNS record for",
+                                    ipnsPubsubTopic,
+                                    "failed, falling through to the network",
+                                    cacheErr
+                                );
+                            }
+                        }
+
                         // Fast path: fetch the record over libp2p/fetch, in parallel, directly from BOTH
                         // the topic's current gossipsub subscribers AND providers freshly discovered from
                         // the HTTP routers — first signature-valid record wins. This skips the
@@ -471,6 +522,13 @@ export async function createLibp2pJsClientOrUseExistingOne(
                             // future pushes; we do NOT await it — the direct fetch does not need the mesh.
                             if (!helia.libp2p.services.pubsub.getTopics().includes(ipnsPubsubTopic))
                                 helia.libp2p.services.pubsub.subscribe(ipnsPubsubTopic);
+                            // Also register the topic with the pubsub router (issue #301): without
+                            // this, its message listener drops every gossiped record for the topic
+                            // and the subscription above only ever feeds the mesh, not the cache.
+                            // Idempotent, and also heals topics first subscribed via the fallback
+                            // router.get() (which since @helia/ipns 10 skips this add when the
+                            // topic is already libp2p-subscribed).
+                            ipnsPubsubRouterSubscriptions.add(ipnsPubsubTopic);
                             void warmupForTopic(ipnsPubsubTopic, options).catch((e) =>
                                 log.trace("Fire-and-forget warmup failed for", ipnsPubsubTopic, e)
                             );
@@ -497,6 +555,12 @@ export async function createLibp2pJsClientOrUseExistingOne(
                                     // Record already validated inside the helper — unmarshal directly,
                                     // do NOT re-run ipnsValidator.
                                     const record = unmarshalIPNSRecord(direct.recordBytes);
+                                    // Stamp the network validation time for the cache gate even when
+                                    // the fetched bytes turn out identical to the cache (issue #301):
+                                    // identical bytes never refresh the localStore's write time, so
+                                    // this stamp is what lets an idle name serve from cache for
+                                    // another ttl window after a revalidation.
+                                    ipnsRecordNetworkValidatedAtMs.set(ipnsPubsubTopic, Date.now());
                                     // Direct fetch bypasses the pubsub router's handleRecord, which is
                                     // where gossipsub-delivered records get cached at the routing layer.
                                     // Persist the record there ourselves (newer-only, issue #210) so
@@ -584,16 +648,17 @@ export async function createLibp2pJsClientOrUseExistingOne(
                         // - per-router error aggregation below is what the tests and callers report on.
                         // Equivalence of the resolved value with resolve() is pinned in
                         // test/node/community/helia-ipns-resolve-equivalence.unit.test.ts.
-                        // This does NOT bypass an active cache/TTL: all cache-read + TTL logic lives in the
-                        // resolver's #findIpnsRecord and is gated on `nocache !== true`, but pkc always
-                        // resolves IPNS with nocache:true (see resolveIpnsToCidP2P in base-client-manager),
-                        // so that path is inert — the old resolve()-based code skipped it too. IPNS here is
-                        // pubsub-only (HTTP routers have getIPNS disabled in getDelegatedRoutingFields), and
-                        // the pubsub router's get() never serves from cache; it always queries peers. Record
-                        // caching + ipnsSelector happen inside the pubsub router's handleRecord for
-                        // gossipsub-delivered records and router.get() fetches; the direct-fetch fast path
-                        // above bypasses handleRecord, so it writes the record to the router's localStore
-                        // itself (cacheIpnsRecordInPubsubLocalStore, issue #210).
+                        // This does NOT bypass an active cache/TTL: the cache gate at the top of this
+                        // generator (issue #301) is the cache read for this resolver, honoring
+                        // `nocache !== true` and the record's ttl the way @helia/ipns' #findIpnsRecord
+                        // would. IPNS here is pubsub-only (HTTP routers have getIPNS disabled in
+                        // getDelegatedRoutingFields), and the pubsub router's get() never serves from
+                        // cache; it always queries peers. Record caching + ipnsSelector happen inside the
+                        // pubsub router's handleRecord for gossipsub-delivered records (reachable because
+                        // the fast path registers each topic in the router's subscriptions Set) and
+                        // router.get() fetches; the direct-fetch fast path above bypasses handleRecord, so
+                        // it writes the record to the router's localStore itself
+                        // (cacheIpnsRecordInPubsubLocalStore, issue #210).
                         let recordBytes: Uint8Array | undefined;
                         const routerErrors: Error[] = [];
                         for (const router of ipnsNameResolver.routers) {
@@ -628,6 +693,8 @@ export async function createLibp2pJsClientOrUseExistingOne(
                         // Validate the record's signature against its routing key before trusting its value.
                         await ipnsValidator(routingKey, recordBytes);
                         const record = unmarshalIPNSRecord(recordBytes);
+                        // Same freshness stamp as the direct-fetch hit above (issue #301).
+                        ipnsRecordNetworkValidatedAtMs.set(ipnsPubsubTopic, Date.now());
                         yield record.value;
                     }
 

--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -3,6 +3,9 @@ import type { PeerId, PeerInfo, PeerUpdate } from "@libp2p/interface";
 import type { Multiaddr } from "@multiformats/multiaddr";
 import { CID } from "multiformats/cid";
 import { ipnsSelector } from "ipns/selector";
+import { ipnsValidator } from "ipns/validator";
+import { unmarshalIPNSRecord } from "ipns";
+import type { IPNSRecord } from "ipns";
 import { equals as uint8ArrayEquals } from "uint8arrays/equals";
 import Logger from "../logger.js";
 import { PKCError } from "../pkc-error.js";
@@ -860,4 +863,48 @@ export async function cacheIpnsRecordInPubsubLocalStore({
         if (ipnsSelector(routingKey, [currentRecord, marshalledRecord]) === 0) return;
     }
     await localStore.put(routingKey, marshalledRecord);
+}
+
+// When a cached record carries no ttl field, fall back to pkc's own publish cadence: communities
+// publish their IPNS records with ttl = publishInterval * 3 (60s by default, see
+// ipns-publishing.ts), so this matches what a well-formed community record would have carried.
+const DEFAULT_CACHED_IPNS_RECORD_TTL_MS = 60_000;
+
+// Read the record cached at the pubsub routing layer and return it only while it may still be
+// served WITHOUT a network revalidation (issue #301). Freshness follows the IPNS spec's ttl
+// semantics: a record may be served from cache for `ttl` after it was last confirmed current.
+// "Last confirmed current" is the LATER of:
+// - the localStore write time (`created`): refreshed whenever a NEWER record lands, via a
+//   gossipsub push (handleRecord) or a direct fetch (cacheIpnsRecordInPubsubLocalStore);
+// - `lastNetworkValidatedAtMs`, the caller-tracked time of the last network fetch that validated
+//   a record for this name. This half matters for an IDLE name: a network refetch that returns
+//   bytes identical to the cache never refreshes `created` (both localStore.put and
+//   cacheIpnsRecordInPubsubLocalStore deliberately skip identical writes), so without it every
+//   resolve after the first ttl expiry would go back to the network forever, reintroducing the
+//   per-second churn this cache exists to stop.
+// The record's signature and validity window are re-checked on every read (a cached record can
+// pass its EOL while sitting in the store); an invalid, expired, or stale record yields
+// undefined so the caller falls through to the network path.
+export async function readFreshCachedIpnsRecordFromPubsubLocalStore({
+    localStore,
+    routingKey,
+    lastNetworkValidatedAtMs
+}: {
+    localStore: IpnsPubsubLocalStore;
+    routingKey: Uint8Array;
+    lastNetworkValidatedAtMs?: number;
+}): Promise<IPNSRecord | undefined> {
+    if (!(await localStore.has(routingKey))) return undefined;
+    const { record: recordBytes, created } = await localStore.get(routingKey);
+    try {
+        await ipnsValidator(routingKey, recordBytes);
+    } catch {
+        // signature no longer checks out or the record passed its EOL while cached
+        return undefined;
+    }
+    const record = unmarshalIPNSRecord(recordBytes);
+    const ttlMs = record.ttl !== undefined ? Number(record.ttl / 1_000_000n) : DEFAULT_CACHED_IPNS_RECORD_TTL_MS;
+    const lastConfirmedCurrentAtMs = Math.max(created.getTime(), lastNetworkValidatedAtMs ?? 0);
+    if (Date.now() - lastConfirmedCurrentAtMs >= ttlMs) return undefined;
+    return record;
 }

--- a/test/node/helia/ipns-resolve-cache-and-gossip.unit.test.ts
+++ b/test/node/helia/ipns-resolve-cache-and-gossip.unit.test.ts
@@ -1,0 +1,323 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createLibp2pJsClientOrUseExistingOne } from "../../../dist/node/helia/helia-for-pkc.js";
+import { MockHttpRouter } from "../../../dist/node/runtime/node/test/mock-http-router.js";
+import { ipnsNameToIpnsOverPubsubTopic, pubsubTopicToDhtKeyCid } from "../../../dist/node/util.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { generateKeyPair } from "@libp2p/crypto/keys";
+import { peerIdFromPrivateKey } from "@libp2p/peer-id";
+import { createIPNSRecord, marshalIPNSRecord, multihashToIPNSRoutingKey, unmarshalIPNSRecord } from "ipns";
+import { pubSubIPNSRouting } from "@helia/ipns";
+import { CID } from "multiformats/cid";
+import { equals as uint8ArrayEquals } from "uint8arrays/equals";
+import type { Libp2pJsClient } from "../../../dist/node/helia/libp2pjsClient.js";
+import type { IpnsPubsubLocalStore } from "../../../dist/node/helia/util.js";
+
+// Repro suite for issue #301: the community update loop re-resolves IPNS over the network every
+// second per community, while records pushed over the IPNS gossipsub topic never reach the local
+// cache that a repeat resolve could serve from. The intended architecture (and upstream
+// @helia/ipns's own design) is "fetch the record once over libp2p/fetch, then rely on gossipsub
+// pushes": name.resolve subscribes to the topic and the pubsub router's handleRecord is supposed
+// to keep its localStore fresh from gossiped records, so a repeat resolve of a subscribed name
+// should be a local read, not a fresh multi-peer fetch race.
+//
+// Today both halves are broken:
+// 1. name.resolve (src/helia/helia-for-pkc.ts) runs directFetchIpnsRecordFromProviders on every
+//    call. Nothing ever reads the localStore, so each of the update loop's 1s iterations pays a
+//    full network fetch per community (the measured ~150 fetch streams/s at 64 communities).
+// 2. The gossip-to-cache leg is dead: the pubsub router's message listener drops any message
+//    whose topic is not in its private `subscriptions` Set, and that Set is only populated inside
+//    router.get() (the legacy fallback). The fast path subscribes via libp2p directly, so
+//    gossiped record pushes arrive at the node and are then discarded. Only direct-fetch results
+//    reach the cache (cacheIpnsRecordInPubsubLocalStore, issue #210).
+//
+// Expected outcome on master: the three "(issue #301)" tests FAIL (they pin the desired
+// fetch-once-then-listen behavior); the nocache contract test passes and must stay green after
+// the fix so explicit cache bypass keeps working.
+//
+// Like the direct-fetch suite, this stands up a STARTED node-under-test plus a real second libp2p
+// node serving the record over the fetch protocol. Client-side libp2p only and config-independent
+// (never touches Kubo or the PKC RPC server), so it runs once under non-RPC via describeSkipIfRpc.
+describeSkipIfRpc("IPNS resolve cache and gossipsub push (issue #301)", () => {
+    const clientsToStop: Libp2pJsClient[] = [];
+    const startedRouters: MockHttpRouter[] = [];
+    let keyCounter = 0;
+
+    afterEach(async () => {
+        while (clientsToStop.length) await clientsToStop.pop()!.heliaWithKuboRpcClientFunctions.stop();
+        while (startedRouters.length) {
+            try {
+                await startedRouters.pop()!.destroy();
+            } catch {
+                // already destroyed
+            }
+        }
+    });
+
+    const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+    const createNode = async (opts: { listen?: boolean; routers?: string[] } = {}): Promise<Libp2pJsClient> => {
+        const client = (await createLibp2pJsClientOrUseExistingOne({
+            key: `resolve-cache-${keyCounter++}`,
+            httpRoutersOptions: opts.routers ?? ["http://localhost:1"],
+            libp2pOptions: {
+                ...(opts.listen ? { addresses: { listen: ["/ip4/127.0.0.1/tcp/0/ws"] } } : {})
+            },
+            heliaOptions: {}
+        })) as Libp2pJsClient;
+        clientsToStop.push(client);
+        return client;
+    };
+
+    // Two distinct valid CIDv1 values so a resolve result identifies WHICH record it came from.
+    const VALUE_CID_SEQ1 = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+    const VALUE_CID_SEQ2 = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku";
+
+    // A fresh IPNS name plus everything derived from it. Records for the same name are minted
+    // separately (makeMarshalledRecord) so a test can gossip a NEWER record for a name it
+    // already served an older record for.
+    const makeIpnsIdentity = async () => {
+        const privateKey = await generateKeyPair("Ed25519");
+        const ipnsPeerId = peerIdFromPrivateKey(privateKey);
+        const routingKey = multihashToIPNSRoutingKey(ipnsPeerId.toMultihash());
+        const topic = ipnsNameToIpnsOverPubsubTopic(ipnsPeerId.toString());
+        const cid = pubsubTopicToDhtKeyCid(topic).toString();
+        return { privateKey, ipnsPeerId, routingKey, topic, cid };
+    };
+    type IpnsIdentity = Awaited<ReturnType<typeof makeIpnsIdentity>>;
+
+    const makeMarshalledRecord = async (identity: IpnsIdentity, valueCid: string, sequence: bigint): Promise<Uint8Array> =>
+        marshalIPNSRecord(await createIPNSRecord(identity.privateKey, CID.parse(valueCid), sequence, 60 * 60 * 1000));
+
+    // A real libp2p node that listens on /ws and serves a (mutable) record for `routingKey` over
+    // the fetch protocol, counting every lookup it answers for that key. The counter is the
+    // network-traffic oracle: it grows if and only if the node-under-test fetched the record over
+    // the network. If `subscribeTopic` is given the node also subscribes (via the GossipSub
+    // PROTOTYPE method, bypassing helia-for-pkc's instance-level subscribe monkey-patch so it
+    // does not kick off its own warmup), so it can later gossip records on the topic.
+    const startPublisherNode = async (args: { routingKey: Uint8Array; subscribeTopic?: string }) => {
+        const client = await createNode({ listen: true });
+        let servedRecord: Uint8Array | undefined;
+        let fetchCount = 0;
+        const fetchService = client._helia.libp2p.services.fetch;
+        fetchService.unregisterLookupFunction("/ipns/");
+        fetchService.registerLookupFunction("/ipns/", async (key: Uint8Array) => {
+            if (uint8ArrayEquals(key, args.routingKey)) {
+                fetchCount++;
+                return servedRecord;
+            }
+            return undefined;
+        });
+
+        if (args.subscribeTopic) {
+            const pubsub = client._helia.libp2p.services.pubsub;
+            Object.getPrototypeOf(pubsub).subscribe.call(pubsub, args.subscribeTopic);
+        }
+
+        const wsAddrs = client._helia.libp2p
+            .getMultiaddrs()
+            .map((m) => m.toString())
+            .filter((a) => a.includes("/ws"))
+            .map((a) => a.replace(/\/p2p\/[^/]+$/, ""));
+        expect(wsAddrs.length, "publisher must expose at least one ws multiaddr").to.be.greaterThan(0);
+        return {
+            client,
+            ID: client._helia.libp2p.peerId.toString(),
+            Addrs: wsAddrs,
+            setServedRecord: (record: Uint8Array) => {
+                servedRecord = record;
+            },
+            getFetchCount: () => fetchCount
+        };
+    };
+
+    const startRouterServing = async (cid: string, provider: { ID: string; Addrs: string[] }): Promise<string> => {
+        const router = new MockHttpRouter();
+        await router.start();
+        startedRouters.push(router);
+        router.addProviderForTesting(cid, provider);
+        return router.url;
+    };
+
+    // Drain name.resolve's async generator and return the final yielded value (an /ipfs/ path).
+    const resolveOnce = async (node: Libp2pJsClient, ipnsName: string, options?: { nocache?: boolean }): Promise<string> => {
+        const values: string[] = [];
+        for await (const value of node.heliaWithKuboRpcClientFunctions.name.resolve(ipnsName, options)) values.push(value);
+        expect(values.length, "name.resolve must yield at least one value").to.be.greaterThan(0);
+        return values[values.length - 1];
+    };
+
+    // Read the record cached at the pubsub routing layer for `routingKey`, or undefined when the
+    // cache is empty. A fresh PubSubIPNSRouting instance wraps the SAME helia datastore as the one
+    // inside helia-for-pkc (this is the exact access pattern src uses for the issue #210 write),
+    // so its localStore reads the node's real cache.
+    const localStoreByNode = new Map<Libp2pJsClient, IpnsPubsubLocalStore>();
+    const readCachedRecordSequence = async (node: Libp2pJsClient, routingKey: Uint8Array): Promise<bigint | undefined> => {
+        let localStore = localStoreByNode.get(node);
+        if (!localStore) {
+            localStore = (pubSubIPNSRouting(node._helia) as unknown as { localStore: IpnsPubsubLocalStore }).localStore;
+            localStoreByNode.set(node, localStore);
+        }
+        if (!(await localStore.has(routingKey))) return undefined;
+        const { record } = await localStore.get(routingKey);
+        return unmarshalIPNSRecord(record).sequence;
+    };
+    afterEach(() => localStoreByNode.clear());
+
+    // Wait until both nodes report each other as subscribers of `topic`, i.e. gossipsub has
+    // exchanged subscriptions over the live connection and a publish can be delivered.
+    const waitForMutualSubscription = async (a: Libp2pJsClient, b: Libp2pJsClient, topic: string): Promise<void> => {
+        const seenBy = (viewer: Libp2pJsClient, target: Libp2pJsClient) =>
+            viewer._helia.libp2p.services.pubsub.getSubscribers(topic).some((p) => p.toString() === target._helia.libp2p.peerId.toString());
+        const deadline = Date.now() + 15_000;
+        while (Date.now() < deadline && !(seenBy(a, b) && seenBy(b, a))) await sleep(200);
+        expect(seenBy(a, b) && seenBy(b, a), "both nodes must see each other as topic subscribers").to.equal(true);
+    };
+
+    // Publish `data` on `topic` from `from` until `to`'s pubsub layer actually RECEIVES a message
+    // on that topic. This guards the gossip tests against failing for the wrong reason: after this
+    // returns, the record demonstrably arrived at the node, so a stale cache can only mean the
+    // routing layer dropped it.
+    const publishUntilReceived = async (args: {
+        from: Libp2pJsClient;
+        to: Libp2pJsClient;
+        topic: string;
+        data: Uint8Array;
+    }): Promise<void> => {
+        let received = false;
+        const onMessage = (evt: CustomEvent<{ topic: string }>) => {
+            if (evt.detail.topic === args.topic) received = true;
+        };
+        args.to._helia.libp2p.services.pubsub.addEventListener("message", onMessage);
+        try {
+            const deadline = Date.now() + 20_000;
+            while (!received && Date.now() < deadline) {
+                try {
+                    await args.from._helia.libp2p.services.pubsub.publish(args.topic, args.data);
+                } catch {
+                    // gossipsub throws NoPeersSubscribedToTopic until the mesh forms; keep retrying
+                }
+                await sleep(300);
+            }
+            expect(received, "the gossiped record must arrive at the node's pubsub layer").to.equal(true);
+        } finally {
+            args.to._helia.libp2p.services.pubsub.removeEventListener("message", onMessage);
+        }
+    };
+
+    // The core churn pin. After a resolve has fetched, validated, and cached the record (issue
+    // #210 write) and left the topic subscribed, resolving the same name again must be served
+    // locally: the publisher must see ZERO additional fetch lookups. On master every resolve runs
+    // the direct-fetch race unconditionally, so the counter grows with each call. This is the
+    // per-iteration network cost the update loop pays per community per second.
+    it("serves a repeat resolve of a subscribed, cached name locally instead of re-fetching (issue #301)", async () => {
+        const identity = await makeIpnsIdentity();
+        const publisher = await startPublisherNode({ routingKey: identity.routingKey });
+        publisher.setServedRecord(await makeMarshalledRecord(identity, VALUE_CID_SEQ1, 1n));
+        const routerUrl = await startRouterServing(identity.cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+
+        const firstValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+        expect(firstValue, "first resolve must return the served record's value").to.contain(VALUE_CID_SEQ1);
+        const fetchesAfterFirstResolve = publisher.getFetchCount();
+        expect(fetchesAfterFirstResolve, "the first (cold) resolve must fetch over the network").to.be.greaterThan(0);
+
+        // The preconditions of "rely on the subscription from here on" hold: the topic is
+        // subscribed and the validated record is in the routing-layer cache.
+        expect(node._helia.libp2p.services.pubsub.getTopics(), "resolve must leave the ipns topic subscribed").to.include(identity.topic);
+        expect(await readCachedRecordSequence(node, identity.routingKey), "resolve must cache the fetched record").to.equal(1n);
+
+        for (let i = 0; i < 2; i++) {
+            const repeatValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+            expect(repeatValue, "repeat resolve must still return the record's value").to.contain(VALUE_CID_SEQ1);
+        }
+        expect(
+            publisher.getFetchCount(),
+            "a repeat resolve of a subscribed name with a fresh cached record must not fetch over the network again"
+        ).to.equal(fetchesAfterFirstResolve);
+    });
+
+    // The gossip-to-cache pin. A newer record pushed over the topic after a fast-path resolve
+    // must reach the routing-layer cache (handleRecord's job, newest-wins via ipnsSelector). On
+    // master the router's message listener drops it: its private `subscriptions` Set is only
+    // populated by router.get(), which the fast path never calls, so the push is received by
+    // gossipsub and then discarded, and the cache stays at seq 1.
+    it("caches a newer record gossiped on the topic after a fast-path resolve (issue #301)", async () => {
+        const identity = await makeIpnsIdentity();
+        const publisher = await startPublisherNode({ routingKey: identity.routingKey, subscribeTopic: identity.topic });
+        publisher.setServedRecord(await makeMarshalledRecord(identity, VALUE_CID_SEQ1, 1n));
+        const routerUrl = await startRouterServing(identity.cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+
+        const firstValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+        expect(firstValue).to.contain(VALUE_CID_SEQ1);
+        expect(await readCachedRecordSequence(node, identity.routingKey), "resolve must cache the fetched record").to.equal(1n);
+
+        await waitForMutualSubscription(node, publisher.client, identity.topic);
+        const seq2Record = await makeMarshalledRecord(identity, VALUE_CID_SEQ2, 2n);
+        await publishUntilReceived({ from: publisher.client, to: node, topic: identity.topic, data: seq2Record });
+
+        // The push arrived at the node; the routing layer must cache it (the write may be async,
+        // so poll briefly before judging).
+        const deadline = Date.now() + 5_000;
+        let cachedSequence = await readCachedRecordSequence(node, identity.routingKey);
+        while (Date.now() < deadline && cachedSequence !== 2n) {
+            await sleep(200);
+            cachedSequence = await readCachedRecordSequence(node, identity.routingKey);
+        }
+        expect(cachedSequence, "a record gossiped on the subscribed topic must reach the routing-layer cache").to.equal(2n);
+    });
+
+    // The end-to-end pin: the user-visible consequence of the two gaps above. The publisher keeps
+    // serving the STALE seq 1 record over libp2p/fetch but gossips a NEWER seq 2 record on the
+    // topic. A resolve after the push must surface seq 2's value. On master it never does: each
+    // resolve re-fetches seq 1 from the network and the gossiped seq 2 is dropped, which is
+    // exactly why the update loop can burn ~150 fetch streams/s without ever being fresher than
+    // plain fetch-on-demand.
+    it("resolves to the newest gossiped record instead of re-fetching a stale one (issue #301)", async () => {
+        const identity = await makeIpnsIdentity();
+        const publisher = await startPublisherNode({ routingKey: identity.routingKey, subscribeTopic: identity.topic });
+        publisher.setServedRecord(await makeMarshalledRecord(identity, VALUE_CID_SEQ1, 1n));
+        const routerUrl = await startRouterServing(identity.cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+
+        const firstValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+        expect(firstValue).to.contain(VALUE_CID_SEQ1);
+
+        await waitForMutualSubscription(node, publisher.client, identity.topic);
+        const seq2Record = await makeMarshalledRecord(identity, VALUE_CID_SEQ2, 2n);
+        await publishUntilReceived({ from: publisher.client, to: node, topic: identity.topic, data: seq2Record });
+
+        // Poll resolve: once the pushed record is honored, the newest value must win (the cache
+        // write may land asynchronously after receipt, hence the retry loop).
+        const deadline = Date.now() + 8_000;
+        let value = await resolveOnce(node, identity.ipnsPeerId.toString());
+        while (Date.now() < deadline && !value.includes(VALUE_CID_SEQ2)) {
+            await sleep(500);
+            value = await resolveOnce(node, identity.ipnsPeerId.toString());
+        }
+        expect(value, "resolve must surface the newest (gossiped) record, not the stale re-fetched one").to.contain(VALUE_CID_SEQ2);
+    });
+
+    // Contract pin for the fix, green on master: nocache: true must BYPASS any cache and fetch
+    // over the network, mirroring kubo and @helia/ipns semantics. Whatever cache-serving the
+    // issue #301 fix introduces must keep an explicit refresh possible, or "refresh" buttons and
+    // deliberate cache-busting callers silently go stale.
+    it("nocache: true still fetches the record over the network when a cached record exists", async () => {
+        const identity = await makeIpnsIdentity();
+        const publisher = await startPublisherNode({ routingKey: identity.routingKey });
+        publisher.setServedRecord(await makeMarshalledRecord(identity, VALUE_CID_SEQ1, 1n));
+        const routerUrl = await startRouterServing(identity.cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+
+        const firstValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+        expect(firstValue).to.contain(VALUE_CID_SEQ1);
+        expect(await readCachedRecordSequence(node, identity.routingKey), "resolve must cache the fetched record").to.equal(1n);
+        const fetchesAfterFirstResolve = publisher.getFetchCount();
+
+        const nocacheValue = await resolveOnce(node, identity.ipnsPeerId.toString(), { nocache: true });
+        expect(nocacheValue).to.contain(VALUE_CID_SEQ1);
+        expect(publisher.getFetchCount(), "nocache: true must bypass the cached record and fetch over the network").to.be.greaterThan(
+            fetchesAfterFirstResolve
+        );
+    });
+});


### PR DESCRIPTION
## What

Fixes #301 test-first, in two commits:

1. **Repro tests** (`test/node/helia/ipns-resolve-cache-and-gossip.unit.test.ts`) — written and verified red against unmodified src before any fix. Three tests pin the intended "fetch once, then listen" behavior (repeat resolve must not re-fetch; a gossiped newer record must reach the routing-layer cache; resolve must surface the gossiped record over a stale re-fetch), plus a green `nocache: true` contract test guarding against over-caching.
2. **The fix**, which turns fetch-once-then-listen on for the libp2p-js client:
   - `name.resolve` registers every IPNS topic it subscribes in the pubsub router's private `subscriptions` Set, so gossiped records finally reach `handleRecord` and the localStore instead of being dropped. Upstream only populates that Set inside `router.get()`, which the direct-fetch fast path never calls — and since @helia/ipns 10 even that add is skipped when the topic is already libp2p-subscribed, so before this change the gossip-to-cache leg was fully dead.
   - A cache gate at the top of `name.resolve` serves a repeat resolve of a subscribed name from the cached record while it is inside its ttl window (signature and EOL re-checked on every read). `nocache: true` bypasses it entirely.
   - An in-memory per-topic network-validation stamp keeps an idle name cacheable across revalidations that return identical bytes (identical bytes never refresh the localStore write time, so without it every resolve after the first ttl expiry would re-fetch forever, reintroducing the churn).
   - `resolveIpnsToCidP2P` stops forcing `nocache: true` when resolving via the libp2p-js client. Kubo keeps `nocache: true` unchanged: its namesys cache is not fed by pkc's pubsub subscriptions, so serving from it could hand back records up to a full record ttl stale.

## Effect

Community records already carry `ttl = publishInterval * 3` (60s by default), so an idle community costs one network revalidation per minute instead of a 4-5-peer fetch race per second, and active communities update via gossip push. At the issue's measured scale (64 communities, ~150 fetch streams/s sustained) the steady-state resolve traffic drops to roughly one stream per second across the whole page. The update loop itself is untouched: its 1s cadence becomes a cheap local read, per the issue's suggested design.

## Verification

- The repro suite goes red → green across the two commits (each red verified individually against unmodified src under `--pkc-config local-kubo-rpc`).
- Regression suites, all green with the fix: `ipns-direct-fetch.unit` (10), `helia-ipns-resolve-equivalence.unit` + `helia-ipns-router-errors.unit` (8), `helia.test.ts` under remote-libp2pjs (23), community `updatingstate`/`waiting-retry.update`/`libp2pjs.kuboRpc.clients`/`posts` (24), comment `post.updatingstate`/`reply.updatingstate`/`publishingstate` (19+1 todo), `load-cid-without-prior-community` (4), `ipns-hops.community` (2).

Closes #301.

