### PR TITLE
fix(community): rm purged post's postUpdates MFS entry when the purge lands mid-sync (#304)

### DIFF
--- a/src/runtime/node/community/local-community/comment-updates.ts
+++ b/src/runtime/node/community/local-community/comment-updates.ts
@@ -333,6 +333,22 @@ export async function syncPostUpdatesWithIpfs(
         postUpdatesDirectoryCid = await kuboRpc._client.files.flush(postUpdatesDirectory);
     }
 
+    // The filter above still leaves a window: a purge landing between it and the writes has already
+    // run its own MFS cleanup, so the write resurrects the purged post's update file with nothing
+    // left to remove it (the comment is gone from the DB and _mfsPathsToRemove is drained). A purge
+    // always deletes from the DB before removing MFS paths, so any purge whose rm preceded one of
+    // the writes is visible to this re-check. If the rm here fails the paths stay queued in
+    // _mfsPathsToRemove and the rmUnneededMfsPaths call above retries them next sync. See issue #304.
+    const rowsPurgedDuringWrites = liveCommentUpdates.filter((row) => !community._dbHandler.commentExistsInDb(row.newCommentUpdate.cid));
+    if (rowsPurgedDuringWrites.length > 0) {
+        log(
+            `${rowsPurgedDuringWrites.length} post CommentUpdate(s) of community ${community.address} were purged during the MFS writes. Removing their MFS entries`
+        );
+        for (const row of rowsPurgedDuringWrites) community._mfsPathsToRemove.add(row.localMfsPath);
+        await rmUnneededMfsPaths(community);
+        postUpdatesDirectoryCid = await kuboRpc._client.files.flush(postUpdatesDirectory);
+    }
+
     const postUpdatesDirectoryCidString = postUpdatesDirectoryCid?.toString();
     log(
         "Community",

--- a/test/node-and-browser/publications/comment-moderation/purged.test.ts
+++ b/test/node-and-browser/publications/comment-moderation/purged.test.ts
@@ -34,6 +34,34 @@ const roles = [
     { role: "mod", signer: signers[3] }
 ];
 
+// One libp2p node for every suite-level pkc in this file (issue #253). Under remote-libp2pjs,
+// mockPKCWithHeliaConfig generates a random libp2pJsClients key per call, so the five concurrent
+// depth suites (each with a beforeAll pkc plus per-test instances) stack a dozen-plus full
+// helia/libp2p nodes inside one browser tab. The CI forensics on issue #253 showed that under
+// that load, pubsub delivery between individual tab nodes and the test kubo goes dark for
+// 20-120s stretches (the community answered every challenge request within ~100ms while the
+// publishing client received nothing), and one such blackout anywhere in a suite's serial
+// beforeAll pipeline blows the 120s hook budget. A fixed key makes every pkcInstancePromise()
+// pkc share one refcounted libp2p node, the topology a real app has. The random component keeps
+// the key unique per browser page in case another file's realm ever shares this environment.
+// The "Should not be able to load" tests are unaffected: their differentPKC instances are
+// created via mockPKCNoDataPathWithOnlyKuboClient and must stay isolated (a shared blockstore
+// would serve the purged comment locally).
+const SHARED_LIBP2PJS_CLIENT_KEY = `purged-shared-libp2pjs-${Math.random()}`;
+const sharedLibp2pJsClientArgs = (config: ReturnType<typeof getAvailablePKCConfigsToTestAgainst>[number]) =>
+    config.testConfigCode === "remote-libp2pjs"
+        ? {
+              pkcOptions: {
+                  libp2pJsClientsOptions: [
+                      {
+                          key: SHARED_LIBP2PJS_CLIENT_KEY,
+                          libp2pOptions: { connectionGater: { denyDialMultiaddr: async () => false } }
+                      }
+                  ]
+              }
+          }
+        : undefined;
+
 // I suspect libp2p config is not emitting error
 getAvailablePKCConfigsToTestAgainst().map((config) => {
     [0, 1, 2, 15, 30].map((commentDepth) => {
@@ -44,7 +72,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             let remotePKCIpfs: PKC;
             let updateCidOfCommunityWithPurgedComment: string;
             beforeAll(async () => {
-                pkc = await config.pkcInstancePromise();
+                pkc = await config.pkcInstancePromise(sharedLibp2pJsClientArgs(config));
                 remotePKCIpfs = await mockPKCNoDataPathWithOnlyKuboClientNoAdd(); // this instance is connected to the same IPFS node as the sub
                 const community = await pkc.getCommunity({ address: communityAddress });
                 const commentToPurgeTemp = await publishCommentWithDepth({ depth: commentDepth, community: community }); // reason why we publish in a different pkc instance so it doesn't get added to local kubo node
@@ -240,7 +268,7 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             });
 
             it(`Purged comment with depth ${commentDepth} don't show in community.posts`, async () => {
-                const pkc = await config.pkcInstancePromise();
+                const pkc = await config.pkcInstancePromise(sharedLibp2pJsClientArgs(config));
                 const community = await pkc.createCommunity({ address: commentToPurge.communityAddress });
 
                 await community.update();

--- a/test/node/publications/comment-moderation/purge-mid-postupdates-sync.test.ts
+++ b/test/node/publications/comment-moderation/purge-mid-postupdates-sync.test.ts
@@ -1,0 +1,160 @@
+import {
+    publishRandomPost,
+    publishWithExpectedResult,
+    resolveWhenConditionIsTrue,
+    createSubWithNoChallenge,
+    mockPKC
+} from "../../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import type { PKC } from "../../../../dist/node/pkc/pkc.js";
+import type { Comment } from "../../../../dist/node/publications/comment/comment.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+import type { SignerWithPublicKeyAddress } from "../../../../dist/node/signer/index.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Deterministic repro of issue #304: a purge that lands between syncPostUpdatesWithIpfs's
+// commentExistsInDb filter and its MFS writes gets resurrected. The purge's own MFS cleanup has
+// already run by the time the held write goes through, and the comment is gone from the DB, so on
+// buggy code nothing ever removes the resurrected postUpdates entry again.
+//
+// Skipped under RPC: the test instruments LocalCommunity internals (wraps the community's kubo
+// files.write and reads _dbHandler/_mfsPathsToRemove), which is impossible when the community
+// lives in a separate RPC server process.
+describeSkipIfRpc("Purge landing during postUpdates MFS writes (issue #304)", () => {
+    let pkc: PKC;
+    let community: LocalCommunity;
+    let moderatorSigner: SignerWithPublicKeyAddress;
+    let post: Comment;
+    let postMfsPath: string;
+    let restoreWrite: (() => void) | undefined;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = (await createSubWithNoChallenge({}, pkc)) as LocalCommunity;
+        await community.start();
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => typeof community.updatedAt === "number"
+        });
+
+        moderatorSigner = await pkc.createSigner();
+        await community.edit({ roles: { [moderatorSigner.address]: { role: "moderator" } } });
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => community.roles?.[moderatorSigner.address]?.role === "moderator"
+        });
+
+        post = await publishRandomPost({ communityAddress: community.address, pkc });
+        if (!post.cid) throw Error("Published post has no cid");
+
+        // Wait until the post's CommentUpdate has landed in the community's postUpdates MFS directory
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => typeof community.postUpdates === "object" && Object.keys(community.postUpdates).length > 0
+        });
+        const postUpdatesBuckets = Object.keys(community.postUpdates!);
+        expect(postUpdatesBuckets.length).to.equal(1);
+        postMfsPath = `/${community.address}/postUpdates/${postUpdatesBuckets[0]}/${post.cid}/update`;
+
+        const kuboFilesApi = community._clientsManager.getDefaultKuboRpcClient()._client.files;
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => {
+                try {
+                    await kuboFilesApi.stat(postMfsPath);
+                    return true;
+                } catch {
+                    return false;
+                }
+            }
+        });
+    });
+
+    afterAll(async () => {
+        restoreWrite?.();
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it(`Purged post's postUpdates MFS entry is removed even when the purge lands mid-write`, async () => {
+        const kuboRpcClient = community._clientsManager.getDefaultKuboRpcClient()._client;
+        const kuboFilesApi = kuboRpcClient.files;
+        const originalWrite = kuboFilesApi.write.bind(kuboFilesApi);
+        restoreWrite = () => {
+            kuboFilesApi.write = originalWrite;
+        };
+
+        const purgeWhileWriteIsHeld = async () => {
+            const purgeMod = await pkc.createCommentModeration({
+                communityAddress: community.address,
+                commentCid: post.cid,
+                commentModeration: { reason: "Purge mid-sync (issue #304)", purged: true },
+                signer: moderatorSigner
+            });
+            await publishWithExpectedResult({ publication: purgeMod, expectedChallengeSuccess: true });
+
+            // The purge must have finished both its DB delete and its MFS cleanup before the held
+            // write is released, otherwise the interleaving under test is not reproduced
+            const deadline = Date.now() + 60_000;
+            while (community._dbHandler.commentExistsInDb(post.cid!)) {
+                if (Date.now() > deadline) throw Error("Timed out waiting for the purge to delete the post from the DB");
+                await sleep(100);
+            }
+            while (true) {
+                try {
+                    await kuboFilesApi.stat(postMfsPath);
+                } catch (e) {
+                    expect((e as Error).message).to.equal("file does not exist");
+                    break; // the purge's rmUnneededMfsPaths removed the entry
+                }
+                if (Date.now() > deadline) throw Error("Timed out waiting for the purge to remove the post's MFS entry");
+                await sleep(100);
+            }
+        };
+
+        let raceExercised = false;
+        let purgeDuringHeldWrite: Promise<void> | undefined;
+        const interceptedWrite = async (...args: Parameters<typeof originalWrite>): Promise<void> => {
+            const path = args[0];
+            if (!raceExercised && typeof path === "string" && path === postMfsPath) {
+                raceExercised = true;
+                purgeDuringHeldWrite = purgeWhileWriteIsHeld();
+                await purgeDuringHeldWrite;
+            }
+            return originalWrite(...args);
+        };
+        kuboFilesApi.write = interceptedWrite as typeof kuboFilesApi.write;
+
+        // Make the next sync cycle rewrite the post's CommentUpdate so the interceptor gets to hold
+        // that exact write while the purge runs to completion
+        community._dbHandler.forceUpdateOnAllCommentsWithCid([post.cid!]);
+
+        const raceDeadline = Date.now() + 60_000;
+        while (!raceExercised) {
+            if (Date.now() > raceDeadline) throw Error("Timed out waiting for the sync loop to write the post's CommentUpdate");
+            await sleep(100);
+        }
+        await purgeDuringHeldWrite;
+        restoreWrite();
+        restoreWrite = undefined;
+
+        // The held write has now resurrected the purged post's update file. Fixed code detects the
+        // mid-write purge in the same sync cycle and removes the entry; buggy code leaves it forever
+        const cleanupDeadline = Date.now() + 45_000;
+        while (true) {
+            try {
+                await kuboFilesApi.stat(postMfsPath);
+            } catch (e) {
+                expect((e as Error).message).to.equal("file does not exist");
+                return; // entry removed, race closed
+            }
+            if (Date.now() > cleanupDeadline)
+                expect.fail(
+                    `MFS path ${postMfsPath} still exists 45s after a purge landed mid-write - resurrected entry was never cleaned up`
+                );
+            await sleep(1000);
+        }
+    });
+});


### PR DESCRIPTION
Two changes: a community-side fix for the purge/sync MFS race (#304) that this PR's own CI run exposed, and the original test-only change that stops the pubsub blackout flake (#253).

## Fix: purge landing mid postUpdates sync resurrects the purged post's MFS entry (#304)

This PR's first CI run (33380103001, node-remote-libp2pjs) failed the depth-0 purged suite with `MFS path .../postUpdates/86400/<postCid>/update still exists after 30s`. That was not the blackout flake this PR targets; forensics on the `test-server-log` artifact showed a genuine community-side race:

- `10:03:26.09` - an in-flight sync cycle calculates the post's CommentUpdate (the post is still in the DB, so it passes the `commentExistsInDb` guard added for #142)
- `10:03:26.390-.398` - the purge lands: comment tree deleted from DB, MFS paths removed via `rmUnneededMfsPaths`
- `10:03:26.464` - the sync finishes its `files.write` batch, re-creating the purged post's update file

After that nothing can ever clean the entry up: the comment is gone from the DB (no future sync flags it) and `_mfsPathsToRemove` is drained, so every postUpdates directory published afterwards keeps serving the purged comment's update. Full analysis in #304.

**Fix**: `syncPostUpdatesWithIpfs` re-checks `commentExistsInDb` for every written row after the write batches; rows purged mid-write get their MFS path re-queued, removed, and the directory re-flushed in the same sync cycle. A purge always deletes from the DB before removing MFS paths, so every resurrecting interleaving is visible to the post-write re-check. If the re-check's rm fails, the paths stay queued and the next sync retries them.

**Test**: deterministic repro in `test/node/publications/comment-moderation/purge-mid-postupdates-sync.test.ts` (skipped under RPC: it instruments LocalCommunity internals). It wraps the community's kubo `files.write`, holds the write of the post's update path while a full purge round-trip completes (DB delete plus MFS rm verified), then releases the write. Red on previous code (entry persists past 45s of syncs), green with the fix (removed in the same cycle, test completes in ~2s). `ban-then-purge` (12/12) and the full `purged.test.ts` suite under remote-kubo-rpc + remote-pkc-rpc (146/146) still pass.

Fixes #304.

## Test change: share one libp2p node across the depth suites (#253)

### Root cause (forensics on run 33375288854, firefox-remote-libp2pjs, depth-2 beforeAll hook timeout)

Full evidence trail posted on #253. Summary:

- Under remote-libp2pjs, `mockPKCWithHeliaConfig` generates a **random `libp2pJsClients` key per call**, so the five concurrent depth suites in `purged.test.ts` (each with a beforeAll pkc plus per-test instances) stack **a dozen-plus full helia/libp2p nodes inside one browser tab**. (Mocked-pubsub instances already share one node by design; only real-pubsub instances got a node each.)
- Under that load, pubsub delivery between individual tab nodes and the test kubo goes dark for 20-120s stretches, **in both directions**: the community answered every challenge request within ~100ms (16 CHALLENGEVERIFICATIONs published at 08:59:09-11), while the publishing client received nothing until a burst of stale deliveries **121 seconds later**, and in the final 20s before recovery the server received zero requests on the community while clients were still publishing. Tab-wide, the community-update push stream showed 23s/13s/49s gaps.
- One blackout anywhere in a depth suite's serial beforeAll pipeline (3-level chain publish → updatedAt waits → 2 replies → page waits) exhausts the 120s hook budget. Which suite dies is a lottery: depth 15 in the original #253 report, depth 2 this time; the chromium recurrence saw the same "P2P fetch timed out" saturation signature.
- Red herring eliminated: the 2s `Fetching CID … timed out` errors in the logs are the *negative* "Should not be able to load" tests' own `differentPKC` instances with deliberately-short timeouts. Expected noise, misattributed by vitest's per-test console bucketing (unreliable under concurrent suites).

### Fix

A module-level fixed key so every suite-level `pkcInstancePromise()` pkc in the file shares **one refcounted libp2p node**, the topology a real app has. The negative tests keep their isolated `mockPKCNoDataPathWithOnlyKuboClient` instances (a shared blockstore would serve the purged comment locally and invert those assertions). Non-libp2pjs configs get `undefined` args and are unchanged.

### Verification

- node remote-libp2pjs: 74/74, and the debug log confirms exactly **one** helia init for the whole file (previously 5+).
- firefox remote-libp2pjs: 4 consecutive local runs, 74/74 each.
- remote-kubo-rpc: 74/74 (config untouched by the helper).

The definitive validation is CI attrition: the blackout only reproduces under full-suite CI load, so this PR removes the load amplifier rather than proving a negative locally. If the hook timeout recurs after this lands, #253's next suspect (the silent mirror branch in `Comment.update()`) gets promoted.

Refs #253.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where comments purged during synchronization could briefly reappear in community posts.
  * Ensured related update data is cleaned up so published content accurately reflects moderation actions.

* **Tests**
  * Added regression coverage for purges occurring during post-update synchronization.
  * Improved comment moderation test setup while preserving isolation for unavailable-content scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->