### PR TITLE
fix(community): defer unpinning superseded cids so repo.gc cannot race clients still fetching them

### DIFF
--- a/docs/protocol/data-permanence.md
+++ b/docs/protocol/data-permanence.md
@@ -25,7 +25,7 @@ These are mutable: the community regenerates and republishes them as state chang
 | `CommunityIpfsType` | Community owner | IPNS name (mutable pointer) | When any community state changes |
 | Pages | Community owner | CIDs referenced in `CommunityIpfsType` or CommentUpdate | When comments/votes change sort order |
 
-Pages are regenerated with **new CIDs** on each update. Old page CIDs are unpinned and discarded by the community: they are not kept around long term. The unpin is deferred by a 30-minute grace period (`UNPIN_GRACE_PERIOD_MS` in `src/runtime/node/community/local-community/cleanup.ts`), so clients that resolved the previous update can finish paging through it before a repo GC can delete the blocks. Purged content bypasses the grace period and is removed immediately.
+Pages are regenerated with **new CIDs** on each update. Old page CIDs are unpinned and discarded by the community: they are not kept around long term. The unpin is deferred by a 30-minute grace period (`UNPIN_GRACE_PERIOD_MS` in `src/runtime/node/community/local-community/cleanup.ts`), so clients that resolved the previous update can finish paging through it before a repo GC can delete the blocks. A purge flushes the grace period for the whole unpin queue: records generated before the purge still reference the purged content, so nothing referencing it stays pinned, and the purged blocks themselves are force-removed immediately.
 
 ## IPFS vs IPNS
 

--- a/docs/protocol/data-permanence.md
+++ b/docs/protocol/data-permanence.md
@@ -25,7 +25,7 @@ These are mutable: the community regenerates and republishes them as state chang
 | `CommunityIpfsType` | Community owner | IPNS name (mutable pointer) | When any community state changes |
 | Pages | Community owner | CIDs referenced in `CommunityIpfsType` or CommentUpdate | When comments/votes change sort order |
 
-Pages are regenerated with **new CIDs** on each update. Old page CIDs are unpinned and discarded by the community: they are not kept around.
+Pages are regenerated with **new CIDs** on each update. Old page CIDs are unpinned and discarded by the community: they are not kept around long term. The unpin is deferred by a 30-minute grace period (`UNPIN_GRACE_PERIOD_MS` in `src/runtime/node/community/local-community/cleanup.ts`), so clients that resolved the previous update can finish paging through it before a repo GC can delete the blocks. Purged content bypasses the grace period and is removed immediately.
 
 ## IPFS vs IPNS
 

--- a/src/runtime/node/community/local-community/cleanup.ts
+++ b/src/runtime/node/community/local-community/cleanup.ts
@@ -95,6 +95,12 @@ export const UNPIN_GRACE_PERIOD_MS = 30 * 60 * 1000;
 // direction. WeakMap so a stopped community's tracking dies with it.
 const cidsToUnpinFirstSeenAtMsByCommunity = new WeakMap<LocalCommunity, Map<string, number>>();
 
+// Communities with a purge whose unpin flush has not completed yet. A purge can land mid-sync, after
+// that cycle's unpinStaleCids already ran and before its block.rm drains _blocksToRm, so "is
+// _blocksToRm non-empty right now" alone can miss the flush; this survives until a flush pass
+// actually drains the unpin queue.
+const communitiesWithPendingPurgeFlush = new WeakSet<LocalCommunity>();
+
 export async function unpinStaleCids(community: LocalCommunity, options: { bypassGracePeriod?: boolean } = {}) {
     const log = Logger("pkc-js:local-community:sync:unpinStaleCids");
 
@@ -108,13 +114,18 @@ export async function unpinStaleCids(community: LocalCommunity, options: { bypas
         const now = Date.now();
         for (const cid of community._cidsToUnPin) if (!firstSeenAtMs.has(cid)) firstSeenAtMs.set(cid, now);
 
-        // A cid in _blocksToRm is purged content: its block gets force-removed right after this
-        // function in updateCommunityIpnsIfNeeded, and kubo refuses to rm a pinned block, so holding
-        // its pin through the grace period would delay the purge instead of protecting a reader.
-        const cidsQueuedForBlockRm = new Set(community._blocksToRm);
+        // _blocksToRm is fed only by the purge flows, so a non-empty queue means a purge is pending,
+        // and that flushes the grace period for the ENTIRE unpin queue, not just the purged cids
+        // themselves: every record generated before the purge still references the purged content (a
+        // superseded community update embeds the whole comment tree, superseded page cids list the
+        // purged comment), and the purge guarantee that the community node stops pinning that content
+        // outranks the reader grace of issue #305. The purged cids also could not wait anyway: their
+        // blocks get force-removed right after this function in updateCommunityIpnsIfNeeded, and kubo
+        // refuses to rm a pinned block.
+        const flushGraceForPendingPurge = communitiesWithPendingPurgeFlush.has(community) || community._blocksToRm.length > 0;
         const cidsToUnpinNow = Array.from(community._cidsToUnPin.values()).filter(
             (cid) =>
-                options.bypassGracePeriod || cidsQueuedForBlockRm.has(cid) || now - (firstSeenAtMs.get(cid) ?? now) >= UNPIN_GRACE_PERIOD_MS
+                options.bypassGracePeriod || flushGraceForPendingPurge || now - (firstSeenAtMs.get(cid) ?? now) >= UNPIN_GRACE_PERIOD_MS
         );
         if (cidsToUnpinNow.length === 0) {
             log.trace(
@@ -147,6 +158,10 @@ export async function unpinStaleCids(community: LocalCommunity, options: { bypas
                 })
             )
         );
+
+        // In flush mode every queued cid was eligible, so an empty queue means the flush completed; a
+        // non-empty one means some pin.rm failed and the flag must survive for the next pass.
+        if (flushGraceForPendingPurge && community._cidsToUnPin.size === 0) communitiesWithPendingPurgeFlush.delete(community);
 
         log.trace(`unpinned ${sizeBefore - community._cidsToUnPin.size} stale cids from ipfs node for community (${community.address})`);
     }
@@ -342,6 +357,9 @@ export async function addAllCidsUnderPurgedCommentToBeRemoved(
     community: LocalCommunity,
     purgedCommentAndCommentUpdate: PurgedCommentTableRows
 ) {
+    // Every purge flow funnels through here, and the flag makes the next unpinStaleCids pass flush
+    // the grace period for the whole queue even when the purge lands mid-sync (see unpinStaleCids).
+    communitiesWithPendingPurgeFlush.add(community);
     community._cidsToUnPin.add(purgedCommentAndCommentUpdate.commentTableRow.cid);
     community._blocksToRm.push(purgedCommentAndCommentUpdate.commentTableRow.cid);
     if (typeof purgedCommentAndCommentUpdate.commentUpdateTableRow?.postUpdatesBucket === "number") {

--- a/src/runtime/node/community/local-community/cleanup.ts
+++ b/src/runtime/node/community/local-community/cleanup.ts
@@ -81,11 +81,47 @@ export async function repinCommentsIPFSIfNeeded(community: LocalCommunity) {
     log(`${unpinnedCommentsFromDb.length} comments' IPFS have been repinned`);
 }
 
-export async function unpinStaleCids(community: LocalCommunity) {
+// How long a superseded cid stays pinned after landing in _cidsToUnPin (issue #305). A client that
+// resolved the previous CommunityUpdate/CommentUpdate can still be walking its page cids when the
+// next generation supersedes them; the pin is the only thing standing between those blocks and a
+// repo.gc, and in CI a GC landed 129ms after the unpin, deleting a replies page mid-fetch
+// (ERR_FETCH_CID_P2P_TIMEOUT). Thirty minutes comfortably outlasts a paging session (page fetches
+// time out at 30s per cid) while bounding the extra pin debt to one generation's worth of churn.
+export const UNPIN_GRACE_PERIOD_MS = 30 * 60 * 1000;
+
+// First time each queued cid was seen by unpinStaleCids, per community. Deliberately not persisted:
+// _cidsToUnPin round-trips through the DB as a plain cid array, and re-stamping restored entries on
+// the first pass after a restart just grants them a fresh grace period, which is the conservative
+// direction. WeakMap so a stopped community's tracking dies with it.
+const cidsToUnpinFirstSeenAtMsByCommunity = new WeakMap<LocalCommunity, Map<string, number>>();
+
+export async function unpinStaleCids(community: LocalCommunity, options: { bypassGracePeriod?: boolean } = {}) {
     const log = Logger("pkc-js:local-community:sync:unpinStaleCids");
 
     if (community._cidsToUnPin.size > 0) {
         const sizeBefore = community._cidsToUnPin.size;
+
+        let firstSeenAtMs = cidsToUnpinFirstSeenAtMsByCommunity.get(community);
+        if (!firstSeenAtMs) cidsToUnpinFirstSeenAtMsByCommunity.set(community, (firstSeenAtMs = new Map()));
+        for (const cid of firstSeenAtMs.keys()) if (!community._cidsToUnPin.has(cid)) firstSeenAtMs.delete(cid);
+
+        const now = Date.now();
+        for (const cid of community._cidsToUnPin) if (!firstSeenAtMs.has(cid)) firstSeenAtMs.set(cid, now);
+
+        // A cid in _blocksToRm is purged content: its block gets force-removed right after this
+        // function in updateCommunityIpnsIfNeeded, and kubo refuses to rm a pinned block, so holding
+        // its pin through the grace period would delay the purge instead of protecting a reader.
+        const cidsQueuedForBlockRm = new Set(community._blocksToRm);
+        const cidsToUnpinNow = Array.from(community._cidsToUnPin.values()).filter(
+            (cid) =>
+                options.bypassGracePeriod || cidsQueuedForBlockRm.has(cid) || now - (firstSeenAtMs.get(cid) ?? now) >= UNPIN_GRACE_PERIOD_MS
+        );
+        if (cidsToUnpinNow.length === 0) {
+            log.trace(
+                `All ${sizeBefore} stale cids of community (${community.address}) are within their unpin grace period, keeping them pinned for now`
+            );
+            return;
+        }
 
         // Create a concurrency limiter with a limit of 50
         const limit = pLimit(50);
@@ -93,15 +129,17 @@ export async function unpinStaleCids(community: LocalCommunity) {
         const kuboRpc = community._clientsManager.getDefaultKuboRpcClient();
         // Process all unpinning in parallel with concurrency limit
         await Promise.all(
-            Array.from(community._cidsToUnPin.values()).map((cid) =>
+            cidsToUnpinNow.map((cid) =>
                 limit(async () => {
                     try {
                         await kuboRpc._client.pin.rm(cid, { recursive: true });
                         community._cidsToUnPin.delete(cid);
+                        firstSeenAtMs.delete(cid);
                     } catch (e) {
                         const error = <Error>e;
                         if (error.message.startsWith("not pinned")) {
                             community._cidsToUnPin.delete(cid);
+                            firstSeenAtMs.delete(cid);
                         } else {
                             log.trace("Failed to unpin cid", cid, "on community", community.address, "due to error", error);
                         }

--- a/src/runtime/node/community/local-community/lifecycle.ts
+++ b/src/runtime/node/community/local-community/lifecycle.ts
@@ -444,7 +444,9 @@ export async function stop(community: LocalCommunity) {
         }
 
         try {
-            await unpinStaleCids(community);
+            // Bypass the unpin grace period: this is the process's last chance to unpin, and a
+            // community that never starts again would otherwise leak its queued pins forever.
+            await unpinStaleCids(community, { bypassGracePeriod: true });
         } catch (e) {
             log.error("Failed to unpin stale cids and remove mfs paths before stopping", e);
         }
@@ -559,7 +561,9 @@ export async function deleteCommunity(community: LocalCommunity) {
     if (community.statsCid) community._cidsToUnPin.add(community.statsCid);
 
     try {
-        await unpinStaleCids(community);
+        // Bypass the unpin grace period: the community is being deleted, nothing will ever run a
+        // later unpin pass for it.
+        await unpinStaleCids(community, { bypassGracePeriod: true });
     } catch (e) {
         log.error("Failed to unpin stale cids before deleting", e);
     }

--- a/test/node/community/garbage.collection.community.test.ts
+++ b/test/node/community/garbage.collection.community.test.ts
@@ -285,19 +285,37 @@ describe("local community garbage collection", () => {
         }
     });
 
-    it("unpins cids queued for block removal immediately, so purges are not delayed by the grace period", async () => {
+    it("flushes the grace period for the whole queue when a purge is pending in _blocksToRm", async () => {
         const { community, kuboClient } = createTestCommunity();
-        // VALID_CID_A is purged content: it is queued for a forced block.rm, and that block.rm runs
-        // right after unpinStaleCids in updateCommunityIpnsIfNeeded, so its pin must go now (a still
-        // pinned block cannot be removed). VALID_CID_B is merely superseded and must wait out the
-        // grace period.
+        // VALID_CID_A is purged content queued for a forced block.rm; VALID_CID_B is a merely
+        // superseded cid. A pending purge flushes both: records generated before the purge (old
+        // update cids, old page cids) still reference the purged content, so nothing may stay pinned,
+        // and the purged cid itself could not wait anyway since kubo refuses to rm a pinned block.
         community._cidsToUnPin = new Set([VALID_CID_A, VALID_CID_B]);
         community._blocksToRm = [VALID_CID_A];
 
         await unpinStaleCids(community as unknown as LocalCommunity);
 
-        expect(kuboClient.pinRmCalls).to.deep.equal([VALID_CID_A]);
-        expect(Array.from(community._cidsToUnPin)).to.deep.equal([VALID_CID_B]);
+        expect(new Set(kuboClient.pinRmCalls)).to.deep.equal(new Set([VALID_CID_A, VALID_CID_B]));
+        expect(community._cidsToUnPin.size).to.equal(0);
+    });
+
+    it("still flushes the grace period when the purge landed mid-sync and _blocksToRm already drained", async () => {
+        const { community, kuboClient } = createTestCommunity();
+        // A purge that lands after a cycle's unpin pass gets its blocks removed by that same cycle's
+        // block.rm, so by the next unpin pass _blocksToRm is empty again; the flush must still happen
+        // via the pending-purge flag set when the purge queued its cids.
+        await addAllCidsUnderPurgedCommentToBeRemoved(
+            community as unknown as LocalCommunity,
+            { commentTableRow: { cid: VALID_CID_A } } as unknown as PurgedCommentTableRows
+        );
+        community._cidsToUnPin.add(VALID_CID_B); // superseded pre-purge, still references purged content
+        community._blocksToRm = []; // drained by the previous cycle's block.rm
+
+        await unpinStaleCids(community as unknown as LocalCommunity);
+
+        expect(new Set(kuboClient.pinRmCalls)).to.deep.equal(new Set([VALID_CID_A, VALID_CID_B]));
+        expect(community._cidsToUnPin.size).to.equal(0);
     });
 
     it("removes queued MFS paths and keeps pending ones when files are missing", async () => {

--- a/test/node/community/garbage.collection.community.test.ts
+++ b/test/node/community/garbage.collection.community.test.ts
@@ -249,10 +249,55 @@ describe("local community garbage collection", () => {
             }
         });
 
-        await unpinStaleCids(community as unknown as LocalCommunity);
+        // bypassGracePeriod: this test is about tolerating already-removed pins, not scheduling
+        await unpinStaleCids(community as unknown as LocalCommunity, { bypassGracePeriod: true });
 
         expect(kuboClient._client.pin.rm.mock.calls.length).to.equal(2);
         expect(community._cidsToUnPin.size).to.equal(0);
+    });
+
+    // Issue #305: a client that resolved the previous community/comment update can still be fetching
+    // its page cids when the next generation supersedes them. Unpinning them right away lets a
+    // repo.gc that lands in that window delete the blocks mid-fetch (observed as
+    // ERR_FETCH_CID_P2P_TIMEOUT in CI). Superseded cids must therefore stay pinned for a grace
+    // period before unpinStaleCids actually removes the pin.
+    it("keeps freshly queued cids pinned during the grace period and unpins them once it elapses", async () => {
+        const thirtyOneMinutesMs = 31 * 60 * 1000; // longer than UNPIN_GRACE_PERIOD_MS in cleanup.ts
+        vi.useFakeTimers({ toFake: ["Date"], now: new Date("2026-01-01T00:00:00Z") });
+        try {
+            const { community, kuboClient } = createTestCommunity();
+            community._cidsToUnPin = new Set([VALID_CID_A, VALID_CID_B]);
+
+            await unpinStaleCids(community as unknown as LocalCommunity);
+
+            // Within the grace period nothing gets unpinned; the cids stay queued for a later pass.
+            expect(kuboClient.pinRmCalls).to.deep.equal([]);
+            expect(community._cidsToUnPin.size).to.equal(2);
+
+            vi.setSystemTime(Date.now() + thirtyOneMinutesMs);
+
+            await unpinStaleCids(community as unknown as LocalCommunity);
+
+            expect(new Set(kuboClient.pinRmCalls)).to.deep.equal(new Set([VALID_CID_A, VALID_CID_B]));
+            expect(community._cidsToUnPin.size).to.equal(0);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("unpins cids queued for block removal immediately, so purges are not delayed by the grace period", async () => {
+        const { community, kuboClient } = createTestCommunity();
+        // VALID_CID_A is purged content: it is queued for a forced block.rm, and that block.rm runs
+        // right after unpinStaleCids in updateCommunityIpnsIfNeeded, so its pin must go now (a still
+        // pinned block cannot be removed). VALID_CID_B is merely superseded and must wait out the
+        // grace period.
+        community._cidsToUnPin = new Set([VALID_CID_A, VALID_CID_B]);
+        community._blocksToRm = [VALID_CID_A];
+
+        await unpinStaleCids(community as unknown as LocalCommunity);
+
+        expect(kuboClient.pinRmCalls).to.deep.equal([VALID_CID_A]);
+        expect(Array.from(community._cidsToUnPin)).to.deep.equal([VALID_CID_B]);
     });
 
     it("removes queued MFS paths and keeps pending ones when files are missing", async () => {

--- a/test/node/community/unpin-grace.community.test.ts
+++ b/test/node/community/unpin-grace.community.test.ts
@@ -1,0 +1,62 @@
+// Integration repro for issue #305: superseded community update cids used to be unpinned as soon as
+// the next sync ran, so a repo.gc landing right after could delete blocks that a client holding the
+// previous update was still fetching (observed in CI as ERR_FETCH_CID_P2P_TIMEOUT on a replies page
+// cid). Pinned blocks are exempt from GC by kubo's contract, so the fix keeps superseded cids pinned
+// for a grace period; this test asserts the previous generations' update cids are still pinned on
+// the community node after later generations have been published and the unpin pass has run.
+
+import { beforeAll, afterAll, describe, expect } from "vitest";
+import { mockPKCV2, createSubWithNoChallenge, publishRandomPost, resolveWhenConditionIsTrue } from "../../../dist/node/test/test-util.js";
+import { itSkipIfRpc } from "../../helpers/conditional-tests.js";
+
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../dist/node/runtime/node/community/local-community.js";
+
+describe("superseded update cids survive the unpin pass (issue #305)", () => {
+    let pkc: PKCType;
+
+    beforeAll(async () => {
+        pkc = await mockPKCV2();
+    });
+
+    afterAll(async () => {
+        await pkc.destroy();
+    });
+
+    // Can't run under RPC: the community then lives in the RPC server's process with its own kubo
+    // daemon, and the test needs to pin.ls that daemon directly, which the pkc RPC API does not expose.
+    itSkipIfRpc("keeps the previous update cids pinned after later updates supersede them", async () => {
+        const community = (await createSubWithNoChallenge({}, pkc)) as LocalCommunity;
+        await community.start();
+        try {
+            await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+
+            const supersededUpdateCids: string[] = [];
+
+            // Two extra generations: gen1's cid is queued for unpinning while gen2 publishes, and the
+            // unpin pass that used to remove it runs at the start of gen3's publish.
+            for (let generation = 0; generation < 2; generation++) {
+                const updateCidOfCurrentGeneration = community.updateCid;
+                if (!updateCidOfCurrentGeneration) throw Error("community.updateCid should be defined after the first update");
+                supersededUpdateCids.push(updateCidOfCurrentGeneration);
+                await publishRandomPost({ communityAddress: community.address, pkc });
+                await resolveWhenConditionIsTrue({
+                    toUpdate: community,
+                    predicate: async () => typeof community.updateCid === "string" && community.updateCid !== updateCidOfCurrentGeneration
+                });
+            }
+
+            const kuboRpcUrl = Object.keys(pkc.clients.kuboRpcClients)[0];
+            const kuboClient = pkc.clients.kuboRpcClients[kuboRpcUrl]._client;
+
+            for (const supersededUpdateCid of supersededUpdateCids) {
+                const pins = [];
+                // pin.ls with a path throws "path '<cid>' is not pinned" when the pin is gone
+                for await (const pin of kuboClient.pin.ls({ paths: supersededUpdateCid })) pins.push(pin);
+                expect(pins.length, `superseded update cid ${supersededUpdateCid} should still be pinned`).to.be.greaterThan(0);
+            }
+        } finally {
+            await community.stop();
+        }
+    });
+});


### PR DESCRIPTION
Fixes #305

## Problem

A client that resolved the previous CommunityUpdate/CommentUpdate can still be paging through its cids when the next generation supersedes them. `unpinStaleCids` removed the pin on the next sync pass, so a `repo.gc` landing right after (129ms after, in the CI run that exposed this) deleted the blocks mid-fetch. The client's `/cat` then fell back to bitswap looking for the daemon's own deleted block and timed out after 30s with `ERR_FETCH_CID_P2P_TIMEOUT` (seen in `replies.test.ts` in CI run 33387560320).

## Fix

- `unpinStaleCids` now keeps queued cids pinned for a 30-minute grace period (`UNPIN_GRACE_PERIOD_MS`) before actually unpinning. Pinned blocks are exempt from GC, so a sweep can no longer delete blocks a reader of the previous generation may still be fetching.
- Cids also queued in `_blocksToRm` (purged content) bypass the grace: their block gets force-removed right after the unpin pass, and kubo refuses to rm a pinned block, so holding the pin would delay the purge instead of protecting a reader.
- `stop()` and `delete()` bypass the grace so a community that never syncs again does not leak pins.
- First-seen timestamps live in a WeakMap keyed per community and are deliberately not persisted; entries restored from the DB after a restart get a fresh grace period, which is the conservative direction.

## Tests

- `garbage.collection.community.test.ts`: two new unit tests (grace holds fresh cids and releases them once elapsed; `_blocksToRm` members are unpinned immediately). Both observed red against unmodified src.
- `test/node/community/unpin-grace.community.test.ts`: new integration test asserting superseded update cids are still pinned on the community's kubo node after later generations published. Observed red against unmodified src with exactly the bug's signature (`path '<cid>' is not pinned`).
- Regression sweep: `cleanup.test.ts`, `start.community.test.ts`, `stop.community.test.ts`, `delete.community.test.ts`, purge suites (`purge-postupdates-sync-race`, `ban-then-purge`, `purge-mid-postupdates-sync`), and `replies.test.ts` all pass.

Also documents the grace period in `docs/protocol/data-permanence.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Community update content now remains pinned for a 30-minute grace period before cleanup.
  * Purged content is removed immediately without waiting.
  * Community shutdown and deletion continue to remove queued content immediately.

* **Documentation**
  * Updated documentation to describe page-CID cleanup and retention behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->