### PR TITLE
feat(community-list): add CommunityList, immutable signed lists of curated communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Note: IPFS files are immutable, fetched by their CID, which is a hash of their c
 ### Schema:
 
 ```js
-Address: string // a PKC author, community or multisub "address" can be a crypto domain like memes.bso, an IPNS name, an ethereum address, etc.
+Address: string // a PKC author or community "address" can be a crypto domain like memes.bso, an IPNS name, an ethereum address, etc.
 Publication {
   author: Author
   communityPublicKey: string // IPNS public key of the community this publication is directed to
@@ -84,7 +84,6 @@ CommentModeration extends Publication {
 CommunityEdit extends Publication {
   communityEdit: CreateCommunityOptions
 }
-MultisubEdit extends CreateMultisubOptions, Publication {} // not yet implemented
 CommentUpdate /* (IPFS file) */ {
   cid: string // cid of the comment, need it in signature to prevent attack
   edit?: AuthorCommentEdit // most recent edit by comment author, commentUpdate.edit.content, commentUpdate.edit.deleted, commentUpdate.edit.flairs override Comment instance props. Validate commentUpdate.edit.signature
@@ -282,29 +281,24 @@ ChallengeType {
   type: 'image/png' | 'text/plain' | 'chain/<chainTicker>'
   //...other properties for more complex types later, e.g. an array of whitelisted addresses, a token address, etc,
 }
-Multisub /* (IPNS record Multisub.address) (not yet implemented) */ {
+CommunityList /* (immutable IPFS file, addressed by CID, see docs/protocol/community-lists.md) */ {
   title?: string
   description?: string
-  communities: MultisubCommunity[]
-  createdAt: number
-  updatedAt: number
-  signature: Signature // signature of the Multisub update by the multisub owner to protect against malicious gateway
+  author?: Author // the curator's profile, same schema as publication.author
+  communities: CommunityListEntry[]
+  timestamp: number // seconds
+  protocolVersion: '1.0.0'
+  signature: Signature // any key can sign, including the curator's personal author key
 }
-MultisubCommunity { // (not yet implemented) this metadata is set by the owner of the Multisub, not the owner of the community
-  address: Address
+CommunityListEntry { // this metadata is set by the curator of the CommunityList, not the owner of the community
+  publicKey: string // IPNS public key of the community
+  name?: string // optional crypto domain (e.g. 'memes.bso')
   title?: string
   description?: string
   languages?: string[] // client can detect language and hide/show community based on it
   locations?: string[] // client can detect location and hide/show community based on it
   features?: string[] // client can detect user's SFW setting and hide/show community based on it
   tags?: string[] // arbitrary keywords used for search
-}
-PKCDefaults { // fetched once when app first load, a dictionary of default settings (not yet implemented)
-  multisubAddresses: {[multisubName: string]: Address}
-  // PKC has 3 default multisubs
-  multisubAddresses.all: Address // the default communities to show at url pkc.bso/p/all
-  multisubAddresses.crypto: Address // the communities to show at url pkc.bso/p/crypto
-  multisubAddresses.search: Address // list of thousands of semi-curated communities to "search" for in the client (only search the Multisub metadata, don't load each community)
 }
 ```
 
@@ -388,10 +382,10 @@ PubsubSignature {
 
 - [PKC API](#pkc-api)
   - [`PKC(pkcOptions)`](#pkcpkcoptions)
-  - [`pkc.getMultisub(multisubAddress)`](#pkcgetmultisubmultisubaddress) *(not yet implemented)*
+  - [`pkc.getCommunityList({cid})`](#pkcgetcommunitylistcid)
   - [`pkc.getCommunity({address})`](#pkcgetcommunityaddress)
   - [`pkc.getComment({cid})`](#pkcgetcommentcid)
-  - [`pkc.createMultisub(createMultisubOptions)`](#pkccreatemultisubcreatemultisuboptions) *(not yet implemented)*
+  - [`pkc.createCommunityList(createCommunityListOptions)`](#pkccreatecommunitylistcreatecommunitylistoptions)
   - [`pkc.createCommunity(createCommunityOptions)`](#pkccreatecommunitycreatecommunityoptions)
   - [`pkc.createCommunityEdit(createCommunityEditOptions)`](#pkccreatecommunityeditcreatecommunityeditoptions)
   - [`pkc.createComment(createCommentOptions)`](#pkccreatecommentcreatecommentoptions)
@@ -631,29 +625,28 @@ const helia = pkc.clients.libp2pJsClients['main'].heliaNode
 helia.libp2p.services.pubsub.subscribe('my-topic')
 ```
 
-### `pkc.getMultisub(multisubAddress)` *(not yet implemented)*
+### `pkc.getCommunityList({cid})`
 
-> Get a multisub by its `Address`. A multisub is a list of communities curated by the creator of the multisub. E.g. `'pkc.bso/#/m/john.bso'` would display a feed of the multisub communities curated by `'john.bso'` (multisub `Address` `'john.bso'`).
+> Get a `CommunityList` by its CID. A `CommunityList` is an immutable, signed list of communities curated by its author, used for default feeds and client-side community search. See [docs/protocol/community-lists.md](docs/protocol/community-lists.md).
 
 #### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| multisubAddress | `string` | The `Address` of the multisub |
+| cid | `string` | The CID of the community list |
+| abortSignal | `AbortSignal` | Optional. Cancels the fetch. Rejects with `ERR_GET_COMMUNITY_LIST_ABORTED`. |
 
 #### Returns
 
 | Type | Description |
 | -------- | -------- |
-| `Promise<Multisub>` | A `Multisub` instance. |
+| `Promise<CommunityList>` | A `CommunityList` instance. |
 
 #### Example
 
 ```js
-const multisubAddress = '12D3KooW...' // or 'john.bso'
-const multisub = await pkc.getCommunity({address: multisubAddress})
-const multisubCommunityAddresses = multisub.map(community => community.address)
-console.log(multisubCommunityAddresses)
+const communityList = await pkc.getCommunityList({cid: 'QmZbc...'})
+console.log(communityList.communities.map(entry => entry.address))
 ```
 
 ### `pkc.getCommunity({address})`
@@ -745,57 +738,55 @@ Prints:
 */
 ```
 
-### `pkc.createMultisub(createMultisubOptions)` *(not yet implemented)*
+### `pkc.createCommunityList(createCommunityListOptions)`
 
-> Create a multisub instance. A multisub is a list of communities curated by the creator of the multisub. E.g. `'pkc.bso/#/m/john.bso'` would display a feed of the multisub communities curated by `'john.bso'` (multisub `Address` `'john.bso'`).
+> Create a `CommunityList` instance: an immutable, signed IPFS file of curated communities, addressed by CID (see [docs/protocol/community-lists.md](docs/protocol/community-lists.md)). With `{signer, ...props}` the instance can `publish()`; with `{cid}` it can `update()`/`stop()`. Publishing a revision means creating a new list and publishing a new CID; clients never auto-follow between versions.
 
 #### Parameters
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| createMultisubOptions | `CreateMultisubOptions` | Options for the `Multisub` instance |
+| createCommunityListOptions | `CreateCommunityListOptions` | Options for the `CommunityList` instance |
 
-##### CreateMultisubOptions
+##### CreateCommunityListOptions
 
-An object which may have the following keys:
+Either `{cid}` to load an existing list, or an object which may have the following keys:
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| address | `string` or `undefined` | `Address` of the multisub |
-| signer | `Signer` or `undefined` | (Multisub owners only) Optional `Signer` of the community to create a multisub with a specific private key |
-| title | `string` or `undefined` | Title of the multisub |
-| description | `string` or `undefined` | Description of the multisub |
-| communities | `MultisubCommunity[]` or `undefined` | List of `MultisubCommunity` of the multisub |
+| signer | `Signer` | `Signer` that signs the list; any key works, including the curator's personal author key. The caller persists it |
+| title | `string` or `undefined` | Title of the community list |
+| description | `string` or `undefined` | Description of the community list |
+| author | `Author` or `undefined` | The curator's profile, same schema as `publication.author` |
+| communities | `CommunityListEntry[]` | Entries of the list; duplicate `publicKey` entries throw |
+| timestamp | `number` or `undefined` | Seconds, defaults to now |
 
 #### Returns
 
 | Type | Description |
 | -------- | -------- |
-| `Promise<Multisub>` | A `Multisub` instance |
+| `Promise<CommunityList>` | A `CommunityList` instance |
 
 #### Example
 
 ```js
-const multisubOptions = {signer}
-const multisub = await pkc.createMultisub(multisubOptions)
-
-// edit the multisub info in the database (only in Node and if multisub.signer is defined)
-await multisub.edit({
-  address: 'funny-communities.bso',
+// curate and publish a list (requires a node that can `ipfs add`: a kubo RPC client or a PKC RPC server)
+const communityList = await pkc.createCommunityList({
+  signer,
   title: 'Funny communities',
   description: 'The funniest communities',
+  author: {displayName: 'John'},
+  communities: [
+    {publicKey: '12D3KooW...', name: 'funny.bso', title: 'Funny things', tags: ['funny']},
+    {publicKey: '12D3KooX...'}
+  ]
 })
+const cid = await communityList.publish()
 
-// add a list of communities to the multisub in the database (only in Node and if multisub.signer is defined)
-const multisubCommunity1 = {address: 'funny.bso', title: 'Funny things', tags: ['funny']}
-const multisubCommunity2 = {address: 'even-more-funny.bso'}
-await multisub.edit({communities: [multisubCommunity1, multisubCommunity2]})
-
-// start publishing updates to your multisub (only in Node and if multisub.signer is defined)
-await multisub.start()
-
-// stop publishing updates to your multisub
-await multisub.stop()
+// load an existing list with events (the instance stops itself once there is nothing left to settle)
+const loaded = await pkc.createCommunityList({cid})
+loaded.on('update', () => console.log(loaded.title, loaded.author?.nameResolved))
+await loaded.update()
 ```
 
 ### `pkc.createCommunity(createCommunityOptions)`

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -9,6 +9,7 @@ Concise protocol reference for AI agents and contributors. Each doc covers one d
 | [names-and-addresses.md](names-and-addresses.md) | `address = name \|\| publicKey`, domain resolution, immutability |
 | [delegated-ipns.md](delegated-ipns.md) | Delegated IPNS chains (anchor → minter → /ipfs), client-side loading & verification |
 | [community-architecture.md](community-architecture.md) | Local vs Remote vs RPC variants, state machines |
+| [community-lists.md](community-lists.md) | `CommunityList` (formerly "multisub"): curated community lists, wire format, owner publish, delegated RPC publish |
 | [signing.md](signing.md) | Ed25519 signatures, signedPropertyNames, CBORG encoding |
 | [pages.md](pages.md) | Pagination, sort types, ephemeral nature of pages |
 | [crossposts.md](crossposts.md) | `comment.crosspost`, the embedded record, tier-1 vs tier-2 verification, `features.noCrossposts` |

--- a/docs/protocol/README.md
+++ b/docs/protocol/README.md
@@ -9,7 +9,7 @@ Concise protocol reference for AI agents and contributors. Each doc covers one d
 | [names-and-addresses.md](names-and-addresses.md) | `address = name \|\| publicKey`, domain resolution, immutability |
 | [delegated-ipns.md](delegated-ipns.md) | Delegated IPNS chains (anchor → minter → /ipfs), client-side loading & verification |
 | [community-architecture.md](community-architecture.md) | Local vs Remote vs RPC variants, state machines |
-| [community-lists.md](community-lists.md) | `CommunityList` (formerly "multisub"): curated community lists, wire format, owner publish, delegated RPC publish |
+| [community-lists.md](community-lists.md) | `CommunityList` (formerly "multisub"): immutable CID-addressed curated community lists, wire format, author, publish and load |
 | [signing.md](signing.md) | Ed25519 signatures, signedPropertyNames, CBORG encoding |
 | [pages.md](pages.md) | Pagination, sort types, ephemeral nature of pages |
 | [crossposts.md](crossposts.md) | `comment.crosspost`, the embedded record, tier-1 vs tier-2 verification, `features.noCrossposts` |

--- a/docs/protocol/community-lists.md
+++ b/docs/protocol/community-lists.md
@@ -1,9 +1,9 @@
 # Community lists (`CommunityList`, formerly "multisub")
 
-> **Status: design settled, implementation in progress.** Tracked in issue #21 (original
-> design) and issue #342 (`author` field). The original design published lists over IPNS;
-> that was reversed on 2026-09-06 in favor of immutable records (see
-> [Why immutable](#why-immutable)). This doc is the spec the implementation must follow.
+> **Status: implemented** (`src/community-list/`). Tracked in issue #21 (original design) and
+> issue #342 (`author` field). The original design published lists over IPNS; that was
+> reversed on 2026-09-06 in favor of immutable records (see [Why immutable](#why-immutable)).
+> This doc is the spec the implementation follows.
 
 A `CommunityList` is a signed, **immutable** IPFS file, addressed by CID like a comment: a
 list of communities with curator-set metadata. It is what clients load to render a default
@@ -135,7 +135,10 @@ schema verbatim, wire and runtime:
   with the previous record's props (obtained from a loaded instance) and publishing a new
   CID.
 - Publishing is isomorphic (Node and browser). There is no Node-only dependency: no
-  sqlite, no MFS, no pubsub.
+  sqlite, no MFS, no pubsub. It does require a node that can `ipfs add`: a kubo RPC client
+  or a PKC RPC server. Gateway-only and libp2p-js-only instances can load lists but not
+  publish them (helia exposes no add in pkc-js today, and a browser cannot reliably provide
+  blocks anyway).
 
 ## Consumer API
 
@@ -148,9 +151,10 @@ schema verbatim, wire and runtime:
     `pkc.resolveAuthorNames` is on, `update()` keeps driving the background resolution
     until the verdict is **definitive**, emits `update` again with `author.nameResolved`
     set, then stops itself. Definitive means: resolved to `signature.publicKey` (true),
-    resolved to a different key (false), or a permanent failure such as no resolver for the
-    TLD or no TXT record (false). Transient resolver failures keep retrying until the
-    caller's `stop()`.
+    resolved to a different key (false), or no resolver in this PKC instance handles the TLD
+    (false). A resolution that returns nothing is indistinguishable from a resolver outage
+    today, so it retries rather than failing shut, the same policy as publication authors.
+    Transient resolver failures keep retrying until the caller's `stop()`.
   - When there is nothing to settle (no `author`, `author.name` absent or not a domain, or
     `resolveAuthorNames: false`), the instance stops itself right after the first `update`.
 - One-shot `pkc.getCommunityList({cid})`: resolves after fetch + verify, without waiting

--- a/docs/protocol/community-lists.md
+++ b/docs/protocol/community-lists.md
@@ -41,6 +41,16 @@ CommunityListEntry { // metadata set by the list owner, NOT the community owner
   check like every other record.
 - All array-valued fields are plural (`communities`, `languages`, `locations`, `features`,
   `tags`).
+- **Load schemas are loose.** When loading a record, `CommunityListSchema` and
+  `CommunityListEntrySchema` must accept and preserve unknown extra props (zod `.loose()`),
+  exactly like `CommentIpfsSchema` and `CommunityIpfsSchema`. This is load-bearing, not
+  stylistic: a newer publisher may add fields and sign them, and verification walks the
+  record's own `signature.signedPropertyNames`, so a strict schema would both reject records
+  from newer publishers and break signature verification by dropping signed props. Extra
+  props ride along into the runtime instance and JSON round-trips untouched.
+- The runtime-only conveniences (`address`, `shortAddress`) go on reserved-field lists
+  (`CommunityListReservedFields` and the entry equivalent), so looseness never lets a wire
+  record smuggle in runtime-only names; same rule as every other record type.
 
 ## Identity and addressing
 

--- a/docs/protocol/community-lists.md
+++ b/docs/protocol/community-lists.md
@@ -1,12 +1,14 @@
 # Community lists (`CommunityList`, formerly "multisub")
 
-> **Status: design settled, not yet implemented.** Tracked in issue #21, where the design
-> decisions below were recorded. This doc is the spec the implementation must follow.
+> **Status: design settled, implementation in progress.** Tracked in issue #21 (original
+> design) and issue #342 (`author` field). The original design published lists over IPNS;
+> that was reversed on 2026-09-06 in favor of immutable records (see
+> [Why immutable](#why-immutable)). This doc is the spec the implementation must follow.
 
-A `CommunityList` is a signed, IPNS-published curation record: a list of communities with
-owner-set metadata. It is what clients load to render a default feed (`all`, `crypto`) or to
-power client-side community search (a large semi-curated list searched by its metadata alone,
-without loading each community).
+A `CommunityList` is a signed, **immutable** IPFS file, addressed by CID like a comment: a
+list of communities with curator-set metadata. It is what clients load to render a default
+feed (`all`, `crypto`) or to power client-side community search (a large semi-curated list
+searched by its metadata alone, without loading each community).
 
 The name replaces "multisub", a fossil of the "subplebbit" vocabulary this repo renamed to
 "community". There is no `Multisub`, `MultisubCommunity`, or `MultisubEdit` in the protocol.
@@ -14,16 +16,16 @@ The name replaces "multisub", a fossil of the "subplebbit" vocabulary this repo 
 ## Wire format
 
 ```js
-CommunityList /* (IPNS-published IPFS file) */ {
+CommunityList /* immutable IPFS file, addressed by CID */ {
   title?: string
   description?: string
+  author?: Author // the curator's profile, same schema as publication.author (see below)
   communities: CommunityListEntry[]
-  createdAt: number // seconds
-  updatedAt: number // seconds, bumped on every edit
+  timestamp: number // seconds, when this version was signed
   protocolVersion: string
   signature: Signature
 }
-CommunityListEntry { // metadata set by the list owner, NOT the community owner
+CommunityListEntry { // metadata set by the list curator, NOT the community owner
   publicKey: string // required, IPNS public key of the community
   name?: string // optional crypto domain (e.g. 'memes.bso')
   title?: string
@@ -35,8 +37,8 @@ CommunityListEntry { // metadata set by the list owner, NOT the community owner
 }
 ```
 
-- `CommunityListSignedPropertyNames = ["title", "description", "communities", "createdAt",
-  "updatedAt", "protocolVersion"]`: every wire field except the signature itself, per the
+- `CommunityListSignedPropertyNames = ["title", "description", "author", "communities",
+  "timestamp", "protocolVersion"]`: every wire field except the signature itself, per the
   conventions in [signing.md](signing.md). Future fields must go through the reserved-field
   check like every other record.
 - All array-valued fields are plural (`communities`, `languages`, `locations`, `features`,
@@ -48,109 +50,173 @@ CommunityListEntry { // metadata set by the list owner, NOT the community owner
   record's own `signature.signedPropertyNames`, so a strict schema would both reject records
   from newer publishers and break signature verification by dropping signed props. Extra
   props ride along into the runtime instance and JSON round-trips untouched.
-- The runtime-only conveniences (`address`, `shortAddress`) go on reserved-field lists
-  (`CommunityListReservedFields` and the entry equivalent), so looseness never lets a wire
-  record smuggle in runtime-only names; same rule as every other record type.
+- The runtime-only conveniences (`cid`, `shortCid` on the record; `address`, `shortAddress`
+  on entries) go on reserved-field lists (`CommunityListReservedFields` and the entry
+  equivalent), so looseness never lets a wire record smuggle in runtime-only names; same
+  rule as every other record type. The author object reuses the publication author reserved
+  list (`address`, `publicKey`, `shortAddress`, `community`, `nameResolved`).
+
+## Why immutable
+
+The original design published lists as mutable IPNS records. That was rejected for a
+security reason: apps ship list addresses as defaults, and a mutable list is a permanent,
+unreviewable trust delegation to one keyholder. A single IPNS update could redirect every
+installed client to arbitrary new communities, including illegal content, with nobody in
+the loop. A list update also amplifies: it swaps the whole set of places a client will go.
+
+With immutable CIDs, the trust decision is made once, over concrete bytes, by whoever
+adopts the CID. Each revision is a new CID that gets re-reviewed at adoption time. Clients
+MUST NOT auto-follow any pointer from an old list version to a newer one.
+
+Publishing a revision = building a new record and publishing a new CID (see
+[Versioning and discovery](#versioning-and-discovery)). Immutability also collapses the
+implementation: no IPNS liveliness or republish loops, no delegated publishing, no
+staleness rules, no sequence numbers.
 
 ## Identity and addressing
 
-- Entry identity follows the publication convention (issue #70): the wire carries `publicKey`
-  (required) plus `name` (optional domain). Runtime instances add `address` and `shortAddress`
-  as conveniences, exactly like publications do. See
+- **The list's identity is its CID.** There is no IPNS name, no `names[]` field, and no
+  magnet URIs.
+- Entry identity follows the publication convention (issue #70): the wire carries
+  `publicKey` (required) plus `name` (optional domain). Runtime instances add `address` and
+  `shortAddress` as conveniences, exactly like publications do. See
   [names-and-addresses.md](names-and-addresses.md).
-- **No eager name resolution.** Entries have no `nameResolved`. A list can hold thousands of
-  entries; resolving every name at parse time is a network storm, and the community load path
-  already verifies name-to-key when a client actually opens a community. The list is a pointer
-  directory, not an authority: entry metadata is the list owner's claim.
-- The list itself is referenced by `{publicKey, name?}`, same as communities. The record has
-  no `names[]` field and there are no magnet URIs.
+- **No eager name resolution for entries.** Entries have no `nameResolved`. A list can hold
+  thousands of entries; resolving every name at parse time is a network storm, and the
+  community load path already verifies name-to-key when a client actually opens a
+  community. The list is a pointer directory, not an authority: entry metadata is the
+  curator's claim.
+
+## Author
+
+The optional `author` field is the curator's profile, shown by clients next to the list the
+way a publication's author is shown next to a comment. It reuses the publication author
+schema verbatim, wire and runtime:
+
+- **Wire**: same shape as `publication.author` (`AuthorPubsubSchema`): `name?`,
+  `displayName?`, `previousCommentCid?`, `wallets?`, `avatar?`, `flairs?`. Strict on
+  create, loose on load, like the rest of the record. There is no identity field on the
+  wire author; identity always comes from the signature, per the publication convention.
+- **Runtime**: instances derive `author.publicKey`, `author.address`, and
+  `author.shortAddress` from `signature.publicKey` with the same helpers publications use
+  (`buildRuntimeAuthor` in `src/publications/publication-author.ts`), and a domain in
+  `author.name` reports resolution through `author.nameResolved` (same lazy background
+  resolution as publications, gated on the `resolveAuthorNames` option), never by
+  overriding `author.address`.
+- **Any key can sign a list**, including the curator's personal author key (the one they
+  sign comments with). Signing a list consumes no IPNS slot, so one key can sign any number
+  of lists, and a list signed with the curator's personal key carries their real,
+  verifiable author identity.
+- **No community-assigned author state.** A `CommunityList` is never published to a
+  community: there is no challenge flow and no `CommentUpdate` analog, so
+  `author.community` (community-assigned flair, ban state, karma) does not exist on a list
+  author, on the wire or at runtime.
 
 ## Ownership and custody
 
-Only the holder of the list's IPNS key can publish. There is no third-party edit publication
-(no `MultisubEdit` analog, no challenge flow) and none is planned.
-
-- `pkc.createCommunityList()` takes a caller-supplied `signer`. The signer is a field on the
-  instance and **the caller persists it**, the same custody model as comments and votes.
-  pkc-js stores nothing (this differs from `LocalCommunity`, which persists its key under
-  `dataPath`).
-- Losing the signer means losing the list's address forever.
+- `pkc.createCommunityList({signer, ...props})` takes a caller-supplied `signer`. The
+  signer is a field on the instance and **the caller persists it**, the same custody model
+  as comments and votes. pkc-js stores nothing.
+- Because the record is immutable and CID-addressed, losing the signer does not lose the
+  list: published CIDs stay valid forever. It only loses the ability to sign future
+  revisions under the same author identity.
+- There is no third-party edit publication (no `MultisubEdit` analog, no challenge flow)
+  and none is planned.
 
 ## Owner API
 
-- `publish()`: explicit one-shot. Sign the JSON, add the file to IPFS, publish the IPNS
-  record. Throws on any validation failure (see below).
-- `edit(props)`: bumps `updatedAt`, re-signs, republishes.
-- **No background republish loop.** Record liveliness is infrastructure's job: the owner's
-  node republishing while online today, delegated publishing RPCs once they are online (their
-  code exists and this design targets that path). Browser nodes can publish IPNS records
-  themselves and will use delegated publishing RPCs to keep records alive.
-- Publishing is isomorphic (Node and browser). Unlike `LocalCommunity` there is no Node-only
-  dependency: no sqlite, no MFS, no pubsub.
+- `pkc.createCommunityList({signer, title?, description?, author?, communities,
+  timestamp?})`: builds the instance. `timestamp` defaults to now, like publications.
+- `publish()`: explicit one-shot. Signs the JSON and adds the file to IPFS (locally, or via
+  the RPC server). Sets `cid` on the instance and returns. Throws on any validation
+  failure (see below).
+- `stop()`: aborts an in-flight `publish()`.
+- There is no `edit()`. Publishing a revision means calling `createCommunityList()` again
+  with the previous record's props (obtained from a loaded instance) and publishing a new
+  CID.
+- Publishing is isomorphic (Node and browser). There is no Node-only dependency: no
+  sqlite, no MFS, no pubsub.
 
 ## Consumer API
 
-- One-shot `pkc.getCommunityList({publicKey, name?})`, plus an `update()`/`stop()` event loop
-  reusing the existing IPNS resolve machinery (mirrors `RemoteCommunity`; tests should prefer
-  create + `update()` over the one-shot for the same CI-reliability reasons as communities).
+- `pkc.createCommunityList({cid})` + `update()`/`stop()` is the evented path (tests should
+  prefer it over the one-shot for the same CI-reliability reasons as communities):
+  - `update()` fetches and verifies the record (retrying on transient failures) and emits
+    `update`.
+  - The record is immutable, so there is no subscription afterwards. The only thing left to
+    settle is `author.nameResolved`: if `author.name` is a domain and
+    `pkc.resolveAuthorNames` is on, `update()` keeps driving the background resolution
+    until the verdict is **definitive**, emits `update` again with `author.nameResolved`
+    set, then stops itself. Definitive means: resolved to `signature.publicKey` (true),
+    resolved to a different key (false), or a permanent failure such as no resolver for the
+    TLD or no TXT record (false). Transient resolver failures keep retrying until the
+    caller's `stop()`.
+  - When there is nothing to settle (no `author`, `author.name` absent or not a domain, or
+    `resolveAuthorNames: false`), the instance stops itself right after the first `update`.
+- One-shot `pkc.getCommunityList({cid})`: resolves after fetch + verify, without waiting
+  for the `nameResolved` verdict (same as `getComment`); the verdict lands in the pkc-wide
+  cache, so evented instances pick it up.
 - Load-side rejection (a cap only enforced by honest publishers is not a cap):
   - records over **2 MB**, rejected before parsing (DoS guard),
+  - invalid signatures,
   - duplicate `publicKey` entries,
-  - schema violations,
-  - records whose `updatedAt` is older than the one already held (the staleness rule that
-    makes `update()` events trustworthy).
+  - schema violations.
 
 ## Validation on publish
 
-`publish()` (and `edit()`) throw on:
+`publish()` throws on:
 
 - any schema violation,
 - a duplicate `publicKey` in `communities` (a duplicate is always a curation bug),
 - serialized size over **2 MB**.
 
 No pagination or chunking in v1. Rough math: ~200 bytes per entry means even a
-thousands-of-entries search list fits in well under the cap. Revisit chunking only if a real
-list outgrows single-file fetching.
+thousands-of-entries search list fits in well under the cap. Revisit chunking only if a
+real list outgrows single-file fetching.
+
+## Versioning and discovery
+
+- A revision is a brand-new record with a new CID. The record carries no revision-chain
+  field in v1 (one can be added later as a signed optional field; load schemas are loose).
+- Discovery of newer revisions is out of protocol: future IPNS-published author profiles
+  and communities (both mutable, the latter moderated) are the channels through which a
+  curator announces a new list CID. Client-side default lists are app configuration
+  (`PKCDefaults` stays a non-goal).
+- Clients MUST NOT auto-follow from one list version to another (see
+  [Why immutable](#why-immutable)).
 
 ## RPC
 
-Full RPC support, with the signer never leaving the client. Same trust model as the delegated
-anchor flow from issue #234 (see [delegated-ipns.md](delegated-ipns.md)):
+Full RPC support, with the signer never leaving the client:
 
-1. The client builds and signs the `CommunityList` JSON locally and hands it to the server.
-   The server adds it to IPFS and returns the CID plus IPNS prep params (sequence number
-   etc.).
-2. The client signs the IPNS record over that CID locally and sends the bytes. The server
-   verifies them, `routing.put`s them **byte-identical**, and keeps re-providing. The server
-   can re-provide the same signed bytes but can never extend an EOL, since it lacks the key;
-   EOL conventions follow [delegated-ipns.md](delegated-ipns.md).
+- **Publish**: the client builds and signs the `CommunityList` JSON locally and hands it to
+  the server. The server validates it, adds it to IPFS, and returns the CID.
+- **Fetch**: the client asks the server for a CID; the server fetches the file and returns
+  it; the client parses and verifies it locally like any other record.
 
-This is a **list-specific method pair** mirroring `prepareAnchorPublish` /
-`publishAnchorRecord` and sharing their plumbing. The anchor methods themselves stay
-community-bound (they are entangled with `LocalCommunity` lifecycle that lists do not have).
-
-The server **persists hosted list records in the RPC state DB** and restores re-providing on
-boot. (Follow-up: retrofit the same restart persistence onto anchor records, which currently
-lack it.)
+No delegated IPNS machinery is involved (there is no IPNS record). This is deliberately the
+same shape as comment publish/fetch over RPC.
 
 ## Class shape
 
-Two classes, not the community four-class tower:
+One class, `CommunityList`, not the community four-class tower and not a
+`RemoteCommunityList` split (those existed for the IPNS update loop, which is gone):
 
-- `RemoteCommunityList`: fetch, `update()`, `stop()`.
-- `CommunityList extends RemoteCommunityList`: adds `signer`, `publish()`, `edit()`.
+- constructed with a `signer` (owner path): `publish()`/`stop()`.
+- constructed with a `cid` (consumer path): `update()`/`stop()`.
 
-Direct-vs-RPC transport lives in the client manager rather than the class hierarchy. The
-community tower's extra layers (`RpcRemoteCommunity`, `RpcLocalCommunity`) encode a
-server-side key custody split; for lists, signing never moves server-side, so that split does
-not exist.
+Direct-vs-RPC transport lives in the client manager rather than the class hierarchy;
+signing never moves server-side.
 
 ## Non-goals
 
-- `MultisubEdit` / third-party edit publications: contradicts the ownership model (only the
-  keyholder publishes).
+- Mutability / IPNS publishing: rejected, see [Why immutable](#why-immutable).
+- `MultisubEdit` / third-party edit publications: contradicts the custody model (only the
+  keyholder signs).
 - `PKCDefaults` (`multisubAddresses` dictionary): client-side app configuration, not pkc-js
   protocol.
-- `names[]` on the record or magnet URIs: not implemented for communities either; entries'
+- `names[]`, magnet URIs, or any name for the list itself: the list is its CID; entries'
   `publicKey` + `name` suffice.
+- A revision-chain field (`previousCommunityListCid`): deferred; additive later without
+  breaking.
 - Pagination of large lists: deferred until a real list needs it.

--- a/docs/protocol/community-lists.md
+++ b/docs/protocol/community-lists.md
@@ -1,0 +1,146 @@
+# Community lists (`CommunityList`, formerly "multisub")
+
+> **Status: design settled, not yet implemented.** Tracked in issue #21, where the design
+> decisions below were recorded. This doc is the spec the implementation must follow.
+
+A `CommunityList` is a signed, IPNS-published curation record: a list of communities with
+owner-set metadata. It is what clients load to render a default feed (`all`, `crypto`) or to
+power client-side community search (a large semi-curated list searched by its metadata alone,
+without loading each community).
+
+The name replaces "multisub", a fossil of the "subplebbit" vocabulary this repo renamed to
+"community". There is no `Multisub`, `MultisubCommunity`, or `MultisubEdit` in the protocol.
+
+## Wire format
+
+```js
+CommunityList /* (IPNS-published IPFS file) */ {
+  title?: string
+  description?: string
+  communities: CommunityListEntry[]
+  createdAt: number // seconds
+  updatedAt: number // seconds, bumped on every edit
+  protocolVersion: string
+  signature: Signature
+}
+CommunityListEntry { // metadata set by the list owner, NOT the community owner
+  publicKey: string // required, IPNS public key of the community
+  name?: string // optional crypto domain (e.g. 'memes.bso')
+  title?: string
+  description?: string
+  languages?: string[] // client can detect language and hide/show the community
+  locations?: string[] // client can detect location and hide/show the community
+  features?: string[] // client can match against user settings (e.g. SFW) to hide/show
+  tags?: string[] // arbitrary keywords used for search
+}
+```
+
+- `CommunityListSignedPropertyNames = ["title", "description", "communities", "createdAt",
+  "updatedAt", "protocolVersion"]`: every wire field except the signature itself, per the
+  conventions in [signing.md](signing.md). Future fields must go through the reserved-field
+  check like every other record.
+- All array-valued fields are plural (`communities`, `languages`, `locations`, `features`,
+  `tags`).
+
+## Identity and addressing
+
+- Entry identity follows the publication convention (issue #70): the wire carries `publicKey`
+  (required) plus `name` (optional domain). Runtime instances add `address` and `shortAddress`
+  as conveniences, exactly like publications do. See
+  [names-and-addresses.md](names-and-addresses.md).
+- **No eager name resolution.** Entries have no `nameResolved`. A list can hold thousands of
+  entries; resolving every name at parse time is a network storm, and the community load path
+  already verifies name-to-key when a client actually opens a community. The list is a pointer
+  directory, not an authority: entry metadata is the list owner's claim.
+- The list itself is referenced by `{publicKey, name?}`, same as communities. The record has
+  no `names[]` field and there are no magnet URIs.
+
+## Ownership and custody
+
+Only the holder of the list's IPNS key can publish. There is no third-party edit publication
+(no `MultisubEdit` analog, no challenge flow) and none is planned.
+
+- `pkc.createCommunityList()` takes a caller-supplied `signer`. The signer is a field on the
+  instance and **the caller persists it**, the same custody model as comments and votes.
+  pkc-js stores nothing (this differs from `LocalCommunity`, which persists its key under
+  `dataPath`).
+- Losing the signer means losing the list's address forever.
+
+## Owner API
+
+- `publish()`: explicit one-shot. Sign the JSON, add the file to IPFS, publish the IPNS
+  record. Throws on any validation failure (see below).
+- `edit(props)`: bumps `updatedAt`, re-signs, republishes.
+- **No background republish loop.** Record liveliness is infrastructure's job: the owner's
+  node republishing while online today, delegated publishing RPCs once they are online (their
+  code exists and this design targets that path). Browser nodes can publish IPNS records
+  themselves and will use delegated publishing RPCs to keep records alive.
+- Publishing is isomorphic (Node and browser). Unlike `LocalCommunity` there is no Node-only
+  dependency: no sqlite, no MFS, no pubsub.
+
+## Consumer API
+
+- One-shot `pkc.getCommunityList({publicKey, name?})`, plus an `update()`/`stop()` event loop
+  reusing the existing IPNS resolve machinery (mirrors `RemoteCommunity`; tests should prefer
+  create + `update()` over the one-shot for the same CI-reliability reasons as communities).
+- Load-side rejection (a cap only enforced by honest publishers is not a cap):
+  - records over **2 MB**, rejected before parsing (DoS guard),
+  - duplicate `publicKey` entries,
+  - schema violations,
+  - records whose `updatedAt` is older than the one already held (the staleness rule that
+    makes `update()` events trustworthy).
+
+## Validation on publish
+
+`publish()` (and `edit()`) throw on:
+
+- any schema violation,
+- a duplicate `publicKey` in `communities` (a duplicate is always a curation bug),
+- serialized size over **2 MB**.
+
+No pagination or chunking in v1. Rough math: ~200 bytes per entry means even a
+thousands-of-entries search list fits in well under the cap. Revisit chunking only if a real
+list outgrows single-file fetching.
+
+## RPC
+
+Full RPC support, with the signer never leaving the client. Same trust model as the delegated
+anchor flow from issue #234 (see [delegated-ipns.md](delegated-ipns.md)):
+
+1. The client builds and signs the `CommunityList` JSON locally and hands it to the server.
+   The server adds it to IPFS and returns the CID plus IPNS prep params (sequence number
+   etc.).
+2. The client signs the IPNS record over that CID locally and sends the bytes. The server
+   verifies them, `routing.put`s them **byte-identical**, and keeps re-providing. The server
+   can re-provide the same signed bytes but can never extend an EOL, since it lacks the key;
+   EOL conventions follow [delegated-ipns.md](delegated-ipns.md).
+
+This is a **list-specific method pair** mirroring `prepareAnchorPublish` /
+`publishAnchorRecord` and sharing their plumbing. The anchor methods themselves stay
+community-bound (they are entangled with `LocalCommunity` lifecycle that lists do not have).
+
+The server **persists hosted list records in the RPC state DB** and restores re-providing on
+boot. (Follow-up: retrofit the same restart persistence onto anchor records, which currently
+lack it.)
+
+## Class shape
+
+Two classes, not the community four-class tower:
+
+- `RemoteCommunityList`: fetch, `update()`, `stop()`.
+- `CommunityList extends RemoteCommunityList`: adds `signer`, `publish()`, `edit()`.
+
+Direct-vs-RPC transport lives in the client manager rather than the class hierarchy. The
+community tower's extra layers (`RpcRemoteCommunity`, `RpcLocalCommunity`) encode a
+server-side key custody split; for lists, signing never moves server-side, so that split does
+not exist.
+
+## Non-goals
+
+- `MultisubEdit` / third-party edit publications: contradicts the ownership model (only the
+  keyholder publishes).
+- `PKCDefaults` (`multisubAddresses` dictionary): client-side app configuration, not pkc-js
+  protocol.
+- `names[]` on the record or magnet URIs: not implemented for communities either; entries'
+  `publicKey` + `name` suffice.
+- Pagination of large lists: deferred until a real list needs it.

--- a/src/clients/rpc-client/pkc-rpc-client.ts
+++ b/src/clients/rpc-client/pkc-rpc-client.ts
@@ -210,8 +210,12 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
                         })
                     });
                 } catch (e) {
-                    const typedError = <PKCError | { code: number; message: string } | Error | ZodError>e;
-                    //e is an error json representation of PKCError
+                    // A JSON-RPC rejection is the serialized server error as a plain object, never an
+                    // Error instance: reconstruct a PKCError (or Error) from it, same as subscription
+                    // "error" notifications. Locally-created errors (e.g. the pTimeout
+                    // ERR_RPC_CALL_TIMED_OUT above, or transport errors) are already instances and
+                    // pass through untouched.
+                    const typedError = e instanceof Error ? <PKCError | Error | ZodError>e : this._deserializeRpcError(e);
                     //@ts-expect-error
                     typedError.details = { ...typedError.details, rpcArgs: args, rpcServerUrl: this._websocketServerUrl };
 

--- a/src/clients/rpc-client/pkc-rpc-client.ts
+++ b/src/clients/rpc-client/pkc-rpc-client.ts
@@ -25,6 +25,8 @@ import type {
     CommunityIdentifierRpcParam,
     CidRpcParam,
     FetchCidRpcParam,
+    FetchCommunityListRpcParam,
+    PublishCommunityListRpcParam,
     CommentPageRpcParam,
     CommunityPageRpcParam,
     EditCommunityRpcParam,
@@ -44,7 +46,9 @@ import type {
     RpcExportCommunityModLogsResult,
     PublishAnchorRecordRpcParam,
     AnchorPublishPreparation,
-    PublishedAnchorRecord
+    PublishedAnchorRecord,
+    RpcPublishCommunityListResult,
+    RpcFetchCommunityListResult
 } from "./types.js";
 import {
     parseRpcCommunityIdentifierParam,
@@ -65,7 +69,11 @@ import {
     parseRpcExportCommunityModLogsResult,
     parseRpcPublishAnchorRecordParam,
     parseRpcAnchorPublishPreparationResult,
-    parseRpcPublishedAnchorRecordResult
+    parseRpcPublishedAnchorRecordResult,
+    parseRpcPublishCommunityListParam,
+    parseRpcPublishCommunityListResult,
+    parseRpcFetchCommunityListParam,
+    parseRpcFetchCommunityListResult
 } from "./rpc-schema-util.js";
 
 const log = Logger("pkc-js:PKCRpcClient");
@@ -509,6 +517,19 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
     async fetchCid(args: FetchCidRpcParam): Promise<RpcFetchCidResult> {
         const parsedFetchCidArgs = parseRpcFetchCidParam(args);
         return parseRpcFetchCidResult(await this._webSocketClient.call("fetchCid", [parsedFetchCidArgs]));
+    }
+
+    // CommunityList (docs/protocol/community-lists.md). The client signs locally; the server only
+    // adds the signed JSON to IPFS and returns the cid. The fetch result is the raw record string so
+    // the caller can check the bytes against the cid and verify the signature locally.
+    async publishCommunityList(args: PublishCommunityListRpcParam): Promise<RpcPublishCommunityListResult> {
+        const parsedArgs = parseRpcPublishCommunityListParam(args);
+        return parseRpcPublishCommunityListResult(await this._webSocketClient.call("publishCommunityList", [parsedArgs]));
+    }
+
+    async fetchCommunityList(args: FetchCommunityListRpcParam): Promise<RpcFetchCommunityListResult> {
+        const parsedArgs = parseRpcFetchCommunityListParam(args);
+        return parseRpcFetchCommunityListResult(await this._webSocketClient.call("fetchCommunityList", [parsedArgs]));
     }
 
     async setSettings(settings: z.input<typeof SetNewSettingsPKCWsServerSchema>): Promise<RpcSuccessResult> {

--- a/src/clients/rpc-client/rpc-schema-util.ts
+++ b/src/clients/rpc-client/rpc-schema-util.ts
@@ -20,7 +20,11 @@ import {
     RpcExportCommunityModLogsResultSchema,
     RpcPublishAnchorRecordParamSchema,
     RpcAnchorPublishPreparationResultSchema,
-    RpcPublishedAnchorRecordResultSchema
+    RpcPublishedAnchorRecordResultSchema,
+    RpcPublishCommunityListParamSchema,
+    RpcPublishCommunityListResultSchema,
+    RpcFetchCommunityListParamSchema,
+    RpcFetchCommunityListResultSchema
 } from "./schema.js";
 
 // Param parsers — all use .loose() so newer clients can send extra fields
@@ -44,6 +48,12 @@ export const parseRpcSubscriptionIdResult = (result: unknown) => RpcSubscription
 export const parseRpcPublishAnchorRecordParam = (params: unknown) => RpcPublishAnchorRecordParamSchema.loose().parse(params);
 export const parseRpcAnchorPublishPreparationResult = (result: unknown) => RpcAnchorPublishPreparationResultSchema.loose().parse(result);
 export const parseRpcPublishedAnchorRecordResult = (result: unknown) => RpcPublishedAnchorRecordResultSchema.loose().parse(result);
+
+// CommunityList — wire param/result parsers
+export const parseRpcPublishCommunityListParam = (params: unknown) => RpcPublishCommunityListParamSchema.loose().parse(params);
+export const parseRpcPublishCommunityListResult = (result: unknown) => RpcPublishCommunityListResultSchema.loose().parse(result);
+export const parseRpcFetchCommunityListParam = (params: unknown) => RpcFetchCommunityListParamSchema.loose().parse(params);
+export const parseRpcFetchCommunityListResult = (result: unknown) => RpcFetchCommunityListResultSchema.loose().parse(result);
 
 // community.export() — wire param/result parsers
 export const parseRpcExportCommunityParam = (params: unknown) => RpcExportCommunityParamSchema.loose().parse(params);

--- a/src/clients/rpc-client/schema.ts
+++ b/src/clients/rpc-client/schema.ts
@@ -111,3 +111,13 @@ export const RpcExportCommunityModLogsParamSchema = ExportCommunityModLogsOption
 export const RpcExportCommunityModLogsResultSchema = z.object({
     moderations: z.array(CommentModerationsTableRowSchema.loose()) // .loose() element preserves extraProps / future fields
 });
+
+// CommunityList (docs/protocol/community-lists.md). The client signs locally; the server only adds
+// the signed JSON to IPFS and returns the cid. Fetch returns the raw string so the client can check
+// the bytes against the cid and verify the signature locally.
+// The publish param is the raw signed string (not a parsed object): the server must add the exact
+// bytes the client signed, and object round-trips through JSON-RPC/zod may reorder keys
+export const RpcPublishCommunityListParamSchema = z.object({ communityListRawString: z.string() });
+export const RpcPublishCommunityListResultSchema = z.object({ cid: CidStringSchema });
+export const RpcFetchCommunityListParamSchema = z.object({ cid: CidStringSchema });
+export const RpcFetchCommunityListResultSchema = z.object({ communityListRawString: z.string() });

--- a/src/clients/rpc-client/types.ts
+++ b/src/clients/rpc-client/types.ts
@@ -18,7 +18,11 @@ import {
     RpcExportschangeResultSchema,
     RpcExportCommunityModLogsParamSchema,
     RpcExportCommunityModLogsResultSchema,
-    RpcPublishAnchorRecordParamSchema
+    RpcPublishAnchorRecordParamSchema,
+    RpcPublishCommunityListParamSchema,
+    RpcPublishCommunityListResultSchema,
+    RpcFetchCommunityListParamSchema,
+    RpcFetchCommunityListResultSchema
 } from "./schema.js";
 import type { PageIpfs, ModQueuePageIpfs } from "../../pages/types.js";
 import type { PageRuntimeFields } from "../../pages/util.js";
@@ -36,6 +40,8 @@ export type ExportCommunityRpcParam = z.infer<typeof RpcExportCommunityParamSche
 export type CancelExportRpcParam = z.infer<typeof RpcCancelExportParamSchema>;
 export type ExportCommunityModLogsRpcParam = z.infer<typeof RpcExportCommunityModLogsParamSchema>;
 export type PublishAnchorRecordRpcParam = z.infer<typeof RpcPublishAnchorRecordParamSchema>;
+export type PublishCommunityListRpcParam = z.infer<typeof RpcPublishCommunityListParamSchema>;
+export type FetchCommunityListRpcParam = z.infer<typeof RpcFetchCommunityListParamSchema>;
 
 // Result types (shared between RPC client and server)
 export type RpcResolveAuthorNameResult = z.infer<typeof RpcResolveAuthorNameResultSchema>;
@@ -45,6 +51,8 @@ export type RpcSubscriptionIdResult = z.infer<typeof RpcSubscriptionIdResultSche
 export type RpcExportCommunityResult = z.infer<typeof RpcExportCommunityResultSchema>;
 export type RpcExportschangeResult = z.infer<typeof RpcExportschangeResultSchema>;
 export type RpcExportCommunityModLogsResult = z.infer<typeof RpcExportCommunityModLogsResultSchema>;
+export type RpcPublishCommunityListResult = z.infer<typeof RpcPublishCommunityListResultSchema>;
+export type RpcFetchCommunityListResult = z.infer<typeof RpcFetchCommunityListResultSchema>;
 
 // Re-export existing complex types used as RPC return values
 export type {

--- a/src/community-list/community-list.ts
+++ b/src/community-list/community-list.ts
@@ -215,8 +215,11 @@ export class CommunityList extends TypedEmitter<CommunityListEvents> {
     // Deterministic record errors: the record is content-addressed, so refetching the same cid can
     // never fix these. Everything else (transport) is retried forever
     private _isNonRetriableError(e: unknown): boolean {
+        // Classified by code, not instanceof: an error rejected by an RPC call crosses the wire as a
+        // plain object carrying the server-side PKCError's code, never as a PKCError instance
+        const code = (<{ code?: unknown }>e)?.code;
         return (
-            e instanceof PKCError &&
+            typeof code === "string" &&
             (
                 [
                     "ERR_INVALID_JSON",
@@ -225,7 +228,7 @@ export class CommunityList extends TypedEmitter<CommunityListEvents> {
                     "ERR_OVER_DOWNLOAD_LIMIT",
                     "ERR_CALCULATED_CID_DOES_NOT_MATCH"
                 ] as const
-            ).includes(<never>e.code)
+            ).includes(<never>code)
         );
     }
 
@@ -312,8 +315,9 @@ export class CommunityList extends TypedEmitter<CommunityListEvents> {
             cache.set(cacheKey, verdict);
             return verdict;
         } catch (e) {
-            if (e instanceof PKCError && e.code === "ERR_NO_RESOLVER_FOR_NAME") {
-                // Definitive: no resolver in this PKC instance handles this TLD
+            // Classified by code, not instanceof: over RPC the rejection is a plain object carrying the code
+            if ((<{ code?: unknown }>e)?.code === "ERR_NO_RESOLVER_FOR_NAME") {
+                // Definitive: no resolver in this PKC instance (or its RPC server) handles this TLD
                 cache.set(cacheKey, false);
                 return false;
             }

--- a/src/community-list/community-list.ts
+++ b/src/community-list/community-list.ts
@@ -1,0 +1,376 @@
+import { TypedEmitter } from "tiny-typed-emitter";
+import retry, { RetryOperation } from "retry";
+import Logger from "../logger.js";
+import type { PKC } from "../pkc/pkc.js";
+import { PKCError } from "../pkc-error.js";
+import { cleanUpBeforePublishing, signCommunityList, verifyCommunityList } from "../signer/signatures.js";
+import { getPKCAddressFromPublicKeySync } from "../signer/util.js";
+import type { SignerWithPublicKeyAddress } from "../signer/index.js";
+import { buildRuntimeAuthor } from "../publications/publication-author.js";
+import {
+    calculateIpfsCidV0,
+    calculateStringSizeSameAsIpfsAddCidV0,
+    isStringDomain,
+    retryKuboIpfsAddAndProvide,
+    shortifyAddress,
+    shortifyCid
+} from "../util.js";
+import { parseCommunityListSchemaWithPKCErrorIfItFails, parseJsonWithPKCErrorIfFails } from "../schema/schema-util.js";
+import { MAX_COMMUNITY_LIST_SIZE_BYTES } from "./schema.js";
+import type { CommunityListEntryJson, CommunityListEvents, CommunityListIpfsType, CommunityListState } from "./types.js";
+import type { AuthorPubsubJsonType, AuthorPubsubType } from "../types.js";
+import type { JsonSignature } from "../signer/types.js";
+import { sha256 } from "js-sha256";
+
+type UnsignedCommunityListProps = Omit<CommunityListIpfsType, "signature">;
+
+// A CommunityList is an immutable, signed IPFS file addressed by CID. One class, no Remote split:
+// constructed with a signer it can publish(), constructed with a cid it can update(). Spec:
+// docs/protocol/community-lists.md
+export class CommunityList extends TypedEmitter<CommunityListEvents> {
+    // wire-derived props (runtime view)
+    title?: string;
+    description?: string;
+    author?: AuthorPubsubJsonType & { nameResolved?: boolean };
+    communities?: CommunityListEntryJson[];
+    timestamp?: number;
+    protocolVersion?: string;
+    signature?: JsonSignature;
+
+    cid?: string;
+    shortCid?: string;
+    signer?: SignerWithPublicKeyAddress;
+    state: CommunityListState = "stopped";
+    raw: { communityList?: CommunityListIpfsType } = {};
+
+    _pkc: PKC;
+    private _unsignedProps?: UnsignedCommunityListProps;
+    private _stopAbortController?: AbortController;
+    private _loadingAbortController?: AbortController;
+    private _loadingOperation?: RetryOperation;
+
+    constructor(pkc: PKC) {
+        super();
+        this._pkc = pkc;
+        // The error listener initialized here must never be removed (see AGENTS.md on removeAllListeners)
+        this.on("error", (...args) => this.listenerCount("error") === 1 && this._pkc.emit("error", ...args)); // only bubble up to pkc if no other listeners are attached
+    }
+
+    _initWithCidOnly(cid: string) {
+        this.cid = cid;
+        this.shortCid = shortifyCid(cid);
+    }
+
+    _initUnsignedProps({ signer, ...props }: UnsignedCommunityListProps & { signer: SignerWithPublicKeyAddress }) {
+        this.signer = signer;
+        this._unsignedProps = props;
+        this.title = props.title;
+        this.description = props.description;
+        this.timestamp = props.timestamp;
+        this.protocolVersion = props.protocolVersion;
+        this.communities = props.communities.map((entry) => this._buildRuntimeEntry(entry));
+        // author identity always comes from the signature; before publishing, the signer is who will sign
+        this.author = this._buildRuntimeAuthor(props.author, signer.publicKey);
+    }
+
+    private _buildRuntimeEntry(entry: CommunityListIpfsType["communities"][number]): CommunityListEntryJson {
+        const address = entry.name || entry.publicKey;
+        return { ...entry, address, shortAddress: shortifyAddress(address) };
+    }
+
+    private _buildRuntimeAuthor(
+        wireAuthor: AuthorPubsubType | undefined,
+        signaturePublicKey: string
+    ): AuthorPubsubJsonType & { nameResolved?: boolean } {
+        const runtimeAuthor = buildRuntimeAuthor({ author: wireAuthor, signaturePublicKey });
+        return { ...runtimeAuthor, shortAddress: shortifyAddress(runtimeAuthor.address) };
+    }
+
+    _initFromWireRecord(record: CommunityListIpfsType, cid: string) {
+        this.raw.communityList = record;
+        this.cid = cid;
+        this.shortCid = shortifyCid(cid);
+        this.title = record.title;
+        this.description = record.description;
+        this.timestamp = record.timestamp;
+        this.protocolVersion = record.protocolVersion;
+        this.signature = record.signature;
+        this.communities = record.communities.map((entry) => this._buildRuntimeEntry(entry));
+        const previousNameResolved = this.author?.nameResolved;
+        this.author = this._buildRuntimeAuthor(record.author, record.signature.publicKey);
+        if (typeof previousNameResolved === "boolean") this.author.nameResolved = previousNameResolved;
+    }
+
+    toJSON() {
+        return {
+            ...this.raw.communityList,
+            ...(this.author ? { author: this.author } : undefined),
+            ...(this.communities ? { communities: this.communities } : undefined),
+            cid: this.cid,
+            shortCid: this.shortCid
+        };
+    }
+
+    private _setState(newState: CommunityListState) {
+        if (this.state === newState) return;
+        this.state = newState;
+        this.emit("statechange", newState);
+    }
+
+    private _throwIfPublishAborted(signal: AbortSignal) {
+        if (signal.aborted) throw new PKCError("ERR_COMMUNITY_LIST_PUBLISH_ABORTED", { cid: this.cid });
+    }
+
+    // Sign the JSON and add the file to IPFS (locally, or via the RPC server). Sets cid and returns it
+    async publish(): Promise<string> {
+        const log = Logger("pkc-js:community-list:publish");
+        if (!this.signer || !this._unsignedProps) throw new PKCError("ERR_COMMUNITY_LIST_HAS_NO_SIGNER", { cid: this.cid });
+        if (this.state === "publishing") throw new PKCError("ERR_COMMUNITY_LIST_ALREADY_PUBLISHING", {});
+        if (this.state === "updating") throw new PKCError("ERR_COMMUNITY_LIST_ALREADY_UPDATING", {});
+        this._setState("publishing");
+        this._stopAbortController = new AbortController();
+        const signal = this._stopAbortController.signal;
+        try {
+            const cleanedProps = cleanUpBeforePublishing(this._unsignedProps);
+            const signature = await signCommunityList({ communityList: cleanedProps, signer: this.signer, pkc: this._pkc });
+            const record = <CommunityListIpfsType>{ ...cleanedProps, signature };
+            parseCommunityListSchemaWithPKCErrorIfItFails(record); // throws on schema violations incl. duplicate entry publicKey
+            const recordString = JSON.stringify(record);
+            const sizeBytes = await calculateStringSizeSameAsIpfsAddCidV0(recordString);
+            if (sizeBytes > MAX_COMMUNITY_LIST_SIZE_BYTES)
+                throw new PKCError("ERR_COMMUNITY_LIST_OVER_ALLOWED_SIZE", {
+                    sizeBytes,
+                    maxSizeBytes: MAX_COMMUNITY_LIST_SIZE_BYTES
+                });
+            this._throwIfPublishAborted(signal);
+
+            let cid: string;
+            if (this._pkc._pkcRpcClient) {
+                // The raw string crosses the wire so the server adds the exact bytes we signed
+                const res = await this._pkc._pkcRpcClient.publishCommunityList({ communityListRawString: recordString });
+                // The server can pin whatever it wants, but the cid it hands back must be the cid of
+                // the exact bytes we signed, or every consumer would fail signature verification
+                const expectedCid = await calculateIpfsCidV0(recordString);
+                if (res.cid !== expectedCid)
+                    throw new PKCError("ERR_ADDED_COMMUNITY_LIST_TO_IPFS_BUT_GOT_DIFFERENT_CID", {
+                        expectedCid,
+                        cidFromRpcServer: res.cid
+                    });
+                cid = res.cid;
+            } else {
+                const kuboRpcClient = this._pkc._clientsManager.getDefaultKuboRpcClient();
+                const addRes = await retryKuboIpfsAddAndProvide({
+                    ipfsClient: kuboRpcClient._client,
+                    log,
+                    content: recordString,
+                    addOptions: { pin: true },
+                    provideInBackground: true
+                });
+                cid = String(addRes.cid);
+            }
+            this._throwIfPublishAborted(signal);
+            this._initFromWireRecord(record, cid);
+            log(`Published CommunityList (${cid}) with ${record.communities.length} entries`);
+            return cid;
+        } finally {
+            this._setState("stopped");
+        }
+    }
+
+    // Fetch and verify the record (retrying transient failures), emit `update`, then keep driving
+    // author.nameResolved until the verdict is definitive, emit `update` again, and stop itself
+    async update(): Promise<void> {
+        if (this.state === "updating") return; // no-op, same as Comment.update()
+        if (this.state === "publishing") throw new PKCError("ERR_COMMUNITY_LIST_ALREADY_PUBLISHING", {});
+        if (!this.cid) throw new PKCError("ERR_COMMUNITY_LIST_HAS_NO_CID", {});
+        this._setState("updating");
+        this._stopAbortController = new AbortController();
+        const signal = this._stopAbortController.signal;
+        this._pkc._updatingCommunityLists.add(this);
+        void this._runUpdateLoop(signal);
+    }
+
+    private async _runUpdateLoop(signal: AbortSignal) {
+        const log = Logger("pkc-js:community-list:update");
+        // Next macrotask, so a caller doing `await list.update()` can attach listeners before the
+        // already-loaded path emits synchronously
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        if (signal.aborted) return;
+        try {
+            if (!this.raw.communityList) await this._loadCommunityListIpfsWithRetries(signal);
+            else this.emit("update", this); // already loaded (e.g. update() after publish()): emit current state
+            if (signal.aborted) return;
+            await this._settleAuthorNameResolvedIfNeeded(signal);
+            // The record is immutable: once the record is loaded and the nameResolved verdict is
+            // definitive (or there is nothing to settle) there is nothing left to watch
+            if (!signal.aborted) await this.stop();
+        } catch (e) {
+            if (signal.aborted) return;
+            log.error(`Failed to update CommunityList (${this.cid})`, e);
+            this.emit("error", <Error>e);
+            await this.stop();
+        }
+    }
+
+    // Deterministic record errors: the record is content-addressed, so refetching the same cid can
+    // never fix these. Everything else (transport) is retried forever
+    private _isNonRetriableError(e: unknown): boolean {
+        return (
+            e instanceof PKCError &&
+            (
+                [
+                    "ERR_INVALID_JSON",
+                    "ERR_INVALID_COMMUNITY_LIST_SCHEMA",
+                    "ERR_COMMUNITY_LIST_SIGNATURE_IS_INVALID",
+                    "ERR_OVER_DOWNLOAD_LIMIT",
+                    "ERR_CALCULATED_CID_DOES_NOT_MATCH"
+                ] as const
+            ).includes(<never>e.code)
+        );
+    }
+
+    async _loadCommunityListIpfsWithRetries(outerSignal?: AbortSignal): Promise<void> {
+        if (this.raw.communityList) return;
+        const cid = this.cid;
+        if (!cid) throw new PKCError("ERR_COMMUNITY_LIST_HAS_NO_CID", {});
+        // Own controller so stop() can cancel a load that was started without update() (getCommunityList)
+        this._loadingAbortController = new AbortController();
+        const signal = this._loadingAbortController.signal;
+        const onOuterAbort = () => this._loadingAbortController?.abort(outerSignal?.reason);
+        outerSignal?.addEventListener("abort", onOuterAbort, { once: true });
+        try {
+            this._loadingOperation = retry.operation({ forever: true, factor: 2 });
+            const record = await new Promise<CommunityListIpfsType>((resolve, reject) => {
+                this._loadingOperation!.attempt(async () => {
+                    if (signal.aborted) return reject(<Error>signal.reason || new Error("Aborted loading CommunityList"));
+                    try {
+                        resolve(await this._fetchAndVerifyOnce(cid, signal));
+                    } catch (e) {
+                        if (signal.aborted || this._isNonRetriableError(e)) return reject(<Error>e);
+                        this.emit("error", <Error>e);
+                        this._loadingOperation!.retry(<Error>e);
+                    }
+                });
+            });
+            this._loadingOperation.stop();
+            if (signal.aborted) return;
+            this._initFromWireRecord(record, cid);
+            this.emit("update", this);
+        } finally {
+            outerSignal?.removeEventListener("abort", onOuterAbort);
+        }
+    }
+
+    private async _fetchAndVerifyOnce(cid: string, signal?: AbortSignal): Promise<CommunityListIpfsType> {
+        let rawString: string;
+        if (this._pkc._pkcRpcClient) {
+            const res = await this._pkc._pkcRpcClient.fetchCommunityList({ cid });
+            rawString = res.communityListRawString;
+            // The RPC server is not trusted with record validity: check the bytes are the cid's bytes
+            const calculatedCid = await calculateIpfsCidV0(rawString);
+            if (calculatedCid !== cid) throw new PKCError("ERR_CALCULATED_CID_DOES_NOT_MATCH", { calculatedCid, cid });
+        } else {
+            rawString = await this._pkc._clientsManager.fetchCid(cid, {
+                maxFileSizeBytes: MAX_COMMUNITY_LIST_SIZE_BYTES,
+                abortSignal: signal
+            });
+        }
+        const record = parseCommunityListSchemaWithPKCErrorIfItFails(parseJsonWithPKCErrorIfFails(rawString));
+        const validity = await verifyCommunityList({ communityList: record });
+        if (!validity.valid) throw new PKCError("ERR_COMMUNITY_LIST_SIGNATURE_IS_INVALID", { validity, cid });
+        return record;
+    }
+
+    // The name of the author on the wire, only when it's a domain that can be resolved
+    private _authorDomainToSettle(): string | undefined {
+        const wireAuthorName = this.raw.communityList?.author?.name;
+        if (typeof wireAuthorName !== "string" || !isStringDomain(wireAuthorName)) return undefined;
+        return wireAuthorName;
+    }
+
+    private _nameResolvedCacheKey(authorDomain: string): string {
+        return sha256(authorDomain + this.raw.communityList!.signature.publicKey);
+    }
+
+    // One resolution attempt. Returns a definitive verdict (boolean) or undefined for a transient
+    // failure that should be retried. Definitive verdicts are cached pkc-wide, same as publications
+    private async _resolveAuthorNameVerdictOnce(authorDomain: string): Promise<boolean | undefined> {
+        const cache = this._pkc._memCaches.nameResolvedCache;
+        const cacheKey = this._nameResolvedCacheKey(authorDomain);
+        const cached = cache.get(cacheKey);
+        if (typeof cached === "boolean") return cached;
+        try {
+            // Works over both transports: PKCWithRpcClient overrides resolveAuthorName to delegate to the RPC server
+            const { resolvedAuthorName } = await this._pkc.resolveAuthorName({ name: authorDomain });
+            if (typeof resolvedAuthorName !== "string") {
+                // null: no TXT record OR all resolvers errored — indistinguishable today, so retry
+                // rather than fail shut (same policy as resolveAuthorNamesInBackground)
+                return undefined;
+            }
+            const signerAddress = getPKCAddressFromPublicKeySync(this.raw.communityList!.signature.publicKey);
+            const verdict = resolvedAuthorName === signerAddress;
+            cache.set(cacheKey, verdict);
+            return verdict;
+        } catch (e) {
+            if (e instanceof PKCError && e.code === "ERR_NO_RESOLVER_FOR_NAME") {
+                // Definitive: no resolver in this PKC instance handles this TLD
+                cache.set(cacheKey, false);
+                return false;
+            }
+            return undefined; // transient
+        }
+    }
+
+    // Fire-and-forget cache warmup, used by the one-shot getCommunityList path which does not wait
+    // for the verdict: evented instances pick it up from the pkc-wide cache
+    _kickOffBackgroundAuthorNameResolution(): void {
+        const log = Logger("pkc-js:community-list:resolve-author-name");
+        const authorDomain = this._authorDomainToSettle();
+        if (!authorDomain || !this._pkc.resolveAuthorNames) return;
+        this._resolveAuthorNameVerdictOnce(authorDomain).catch((e) =>
+            log.error("Failed background author name resolution", authorDomain, e)
+        );
+    }
+
+    private async _settleAuthorNameResolvedIfNeeded(signal: AbortSignal): Promise<void> {
+        const authorDomain = this._authorDomainToSettle();
+        if (!authorDomain || !this.author || !this._pkc.resolveAuthorNames) return;
+        let attempt = 0;
+        while (!signal.aborted) {
+            const verdict = await this._resolveAuthorNameVerdictOnce(authorDomain);
+            if (signal.aborted) return;
+            if (typeof verdict === "boolean") {
+                this.author.nameResolved = verdict;
+                this.emit("update", this);
+                return;
+            }
+            attempt++;
+            await this._delayWithAbort(Math.min(1000 * 2 ** attempt, 60_000), signal);
+        }
+    }
+
+    private async _delayWithAbort(ms: number, signal: AbortSignal): Promise<void> {
+        if (signal.aborted) return;
+        await new Promise<void>((resolve) => {
+            const timeout = setTimeout(() => {
+                signal.removeEventListener("abort", onAbort);
+                resolve();
+            }, ms);
+            const onAbort = () => {
+                clearTimeout(timeout);
+                resolve();
+            };
+            signal.addEventListener("abort", onAbort, { once: true });
+        });
+    }
+
+    // Aborts an in-flight publish(), update(), or getCommunityList() load
+    async stop(): Promise<void> {
+        this._pkc._updatingCommunityLists.delete(this);
+        this._stopAbortController?.abort();
+        this._loadingAbortController?.abort();
+        this._loadingOperation?.stop();
+        if (this.state === "stopped") return;
+        this._setState("stopped");
+    }
+}

--- a/src/community-list/schema.ts
+++ b/src/community-list/schema.ts
@@ -1,0 +1,85 @@
+import { z } from "zod";
+import { keys, omit } from "remeda";
+import {
+    AuthorPubsubSchema,
+    CidStringSchema,
+    CreateSignerSchema,
+    JsonSignatureSchema,
+    PKCTimestampSchema,
+    ProtocolVersionSchema
+} from "../schema/schema.js";
+import { messages } from "../errors.js";
+
+// CommunityList: an immutable, signed IPFS file addressed by CID. Spec: docs/protocol/community-lists.md
+
+// A cap only enforced by honest publishers is not a cap: enforced on publish AND on load
+export const MAX_COMMUNITY_LIST_SIZE_BYTES = 2 * 1024 * 1024; // 2mb
+
+export const communityListHasNoDuplicateEntryPublicKeys = (list: { communities: { publicKey: string }[] }) =>
+    new Set(list.communities.map((entry) => entry.publicKey)).size === list.communities.length;
+
+// Entry metadata is set by the list curator, NOT the community owner
+const communityListEntryShape = {
+    publicKey: z.string().min(1), // IPNS public key of the community
+    name: z.string().min(1).optional(), // crypto domain (e.g. 'memes.bso')
+    title: z.string().optional(),
+    description: z.string().optional(),
+    languages: z.string().array().optional(),
+    locations: z.string().array().optional(),
+    features: z.string().array().optional(),
+    tags: z.string().array().optional()
+};
+
+// Loose on load: a newer publisher may add fields and sign them; a strict schema would drop signed
+// props and break signature verification
+export const CommunityListEntrySchema = z.looseObject(communityListEntryShape);
+export const CreateCommunityListEntrySchema = z.object(communityListEntryShape).strict(); // strict on create
+
+// Strict base is the typing schema (same idiom as CommunityIpfsSchema); loading MUST go through the
+// loose variant below so extra signed props are preserved
+const communityListIpfsBaseSchema = z
+    .object({
+        title: z.string().optional(),
+        description: z.string().optional(),
+        author: AuthorPubsubSchema.loose().optional(),
+        communities: CommunityListEntrySchema.array(),
+        timestamp: PKCTimestampSchema,
+        protocolVersion: ProtocolVersionSchema,
+        signature: JsonSignatureSchema
+    })
+    .strict();
+
+export const CommunityListSignedPropertyNames = keys(omit(communityListIpfsBaseSchema.shape, ["signature"]));
+
+export const CommunityListIpfsSchema = communityListIpfsBaseSchema.refine(
+    communityListHasNoDuplicateEntryPublicKeys,
+    messages.ERR_COMMUNITY_LIST_HAS_DUPLICATE_COMMUNITY_PUBLIC_KEY
+);
+
+// The parse schema for loading records (and validating built records before publish)
+export const CommunityListIpfsLooseSchema = communityListIpfsBaseSchema
+    .loose()
+    .refine(communityListHasNoDuplicateEntryPublicKeys, messages.ERR_COMMUNITY_LIST_HAS_DUPLICATE_COMMUNITY_PUBLIC_KEY);
+
+// Strict on create, loose on load, like every other record type
+export const CreateNewCommunityListOptionsSchema = z
+    .object({
+        signer: CreateSignerSchema,
+        title: z.string().optional(),
+        description: z.string().optional(),
+        author: AuthorPubsubSchema.partial().loose().optional(), // runtime fields are stripped before signing
+        communities: CreateCommunityListEntrySchema.array(),
+        timestamp: PKCTimestampSchema.optional(), // defaults to now
+        protocolVersion: ProtocolVersionSchema.optional()
+    })
+    .strict()
+    .refine(communityListHasNoDuplicateEntryPublicKeys, messages.ERR_COMMUNITY_LIST_HAS_DUPLICATE_COMMUNITY_PUBLIC_KEY);
+
+export const CreateCommunityListWithCidOptionsSchema = z.object({ cid: CidStringSchema }).strict();
+
+export const CreateCommunityListOptionsSchema = z.union([CreateCommunityListWithCidOptionsSchema, CreateNewCommunityListOptionsSchema]);
+
+// Runtime-only instance props: looseness must never let a wire record smuggle these in
+export const CommunityListReservedFields = ["cid", "shortCid", "state", "updatingState", "publishingState", "clients", "signer", "raw"];
+
+export const CommunityListEntryReservedFields = ["address", "shortAddress"];

--- a/src/community-list/types.ts
+++ b/src/community-list/types.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import type {
+    CommunityListEntrySchema,
+    CommunityListIpfsSchema,
+    CreateCommunityListOptionsSchema,
+    CreateCommunityListWithCidOptionsSchema,
+    CreateNewCommunityListOptionsSchema
+} from "./schema.js";
+import type { PKCError } from "../pkc-error.js";
+import type { CommunityList } from "./community-list.js";
+
+export type CommunityListEntryType = z.infer<typeof CommunityListEntrySchema>;
+export type CommunityListIpfsType = z.infer<typeof CommunityListIpfsSchema>;
+export type CreateNewCommunityListOptions = z.infer<typeof CreateNewCommunityListOptionsSchema>;
+export type CreateCommunityListWithCidOptions = z.infer<typeof CreateCommunityListWithCidOptionsSchema>;
+export type CreateCommunityListOptions = z.infer<typeof CreateCommunityListOptionsSchema>;
+
+// Entry identity follows the publication convention: wire carries publicKey (+ optional name),
+// runtime adds address and shortAddress as conveniences
+export type CommunityListEntryJson = CommunityListEntryType & { address: string; shortAddress: string };
+
+export type CommunityListState = "stopped" | "updating" | "publishing";
+
+export interface CommunityListEvents {
+    update: (list: CommunityList) => void;
+    statechange: (newState: CommunityListState) => void;
+    error: (error: PKCError | Error) => void;
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -422,5 +422,23 @@ export enum messages {
     ERR_CHALLENGE_REQUIRED_OPTION_MISSING = "settings.challenges[i].options is missing an option whose optionInputs entry is required",
     ERR_CHALLENGE_PUBLIC_OPTION_NOT_DECLARED_IN_OPTION_INPUTS = "settings.challenges[i].publicOptions names an option that no optionInputs entry of the challenge declares",
     ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED = "The challenge's validateChallengeSettings hook rejected settings.challenges[i]",
-    ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED_FOR_CHALLENGES = "One or more challenges in settings.challenges failed validation"
+    ERR_CHALLENGE_SETTINGS_VALIDATION_FAILED_FOR_CHALLENGES = "One or more challenges in settings.challenges failed validation",
+
+    // CommunityList errors (docs/protocol/community-lists.md)
+    ERR_INVALID_COMMUNITY_LIST_SCHEMA = "The schema of the CommunityList record is invalid",
+    ERR_INVALID_CREATE_COMMUNITY_LIST_OPTIONS_SCHEMA = "The options sent to pkc.createCommunityList() have an invalid schema",
+    ERR_COMMUNITY_LIST_RECORD_INCLUDES_RESERVED_FIELD = "CommunityList record includes a reserved field",
+    ERR_COMMUNITY_LIST_AUTHOR_INCLUDES_RESERVED_FIELD = "CommunityList record's author includes a reserved field",
+    ERR_COMMUNITY_LIST_ENTRY_INCLUDES_RESERVED_FIELD = "A CommunityList entry includes a reserved field",
+    ERR_COMMUNITY_LIST_RECORD_INCLUDES_SIGNABLE_FIELD_NOT_IN_SIGNED_PROPERTY_NAMES = "CommunityList record includes a signable field that is not in signature.signedPropertyNames",
+    ERR_COMMUNITY_LIST_HAS_DUPLICATE_COMMUNITY_PUBLIC_KEY = "CommunityList communities include a duplicate publicKey",
+    ERR_COMMUNITY_LIST_OVER_ALLOWED_SIZE = "CommunityList record size is over 2mb",
+    ERR_COMMUNITY_LIST_HAS_NO_CID = "CommunityList instance has no cid to update from. To fetch a list, create it with pkc.createCommunityList({cid})",
+    ERR_COMMUNITY_LIST_HAS_NO_SIGNER = "CommunityList instance has no signer. To publish a new list, create it with pkc.createCommunityList({signer, ...})",
+    ERR_COMMUNITY_LIST_ALREADY_PUBLISHING = "CommunityList.publish() is already in progress",
+    ERR_COMMUNITY_LIST_ALREADY_UPDATING = "CommunityList.update() is already in progress",
+    ERR_COMMUNITY_LIST_PUBLISH_ABORTED = "CommunityList.publish() was aborted via stop()",
+    ERR_COMMUNITY_LIST_SIGNATURE_IS_INVALID = "CommunityList record has an invalid signature",
+    ERR_ADDED_COMMUNITY_LIST_TO_IPFS_BUT_GOT_DIFFERENT_CID = "The RPC server returned a cid different from the cid of the signed CommunityList bytes",
+    ERR_GET_COMMUNITY_LIST_ABORTED = "pkc.getCommunityList() was aborted by a signal"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,3 +58,13 @@ export type { NameResolver } from "./types.js";
 // the root entry instead of reaching through private fields or deep-importing internals.
 export type { Libp2pJsClient } from "./helia/libp2pjsClient.js";
 export type { HeliaWithLibp2pPubsub } from "./helia/types.js";
+
+// Public re-exports: CommunityList (docs/protocol/community-lists.md)
+export type { CommunityList } from "./community-list/community-list.js";
+export type {
+    CommunityListIpfsType,
+    CommunityListEntryType,
+    CreateCommunityListOptions,
+    CreateNewCommunityListOptions,
+    CreateCommunityListWithCidOptions
+} from "./community-list/types.js";

--- a/src/pkc/pkc-client-manager.ts
+++ b/src/pkc/pkc-client-manager.ts
@@ -158,13 +158,14 @@ export class PKCClientsManager extends BaseClientsManager {
         this.clients.nameResolvers[resolverKey].emit("statechange", newState);
     }
 
-    async fetchCid(cid: string): Promise<string> {
+    async fetchCid(cid: string, opts?: { maxFileSizeBytes?: number; abortSignal?: AbortSignal }): Promise<string> {
         let finalCid = clone(cid);
         if (!isIpfsCid(finalCid) && isIpfsPath(finalCid)) finalCid = finalCid.split("/")[2];
         if (!isIpfsCid(finalCid)) throw new PKCError("ERR_CID_IS_INVALID", { cid });
         const timeoutMs = this._pkc._timeouts["generic-ipfs"];
+        const maxFileSizeBytes = opts?.maxFileSizeBytes ?? 1024 * 1024;
         if (Object.keys(this.clients.kuboRpcClients).length > 0 || Object.keys(this.clients.libp2pJsClients).length > 0)
-            return this._fetchCidP2P(cid, { maxFileSizeBytes: 1024 * 1024, timeoutMs });
+            return this._fetchCidP2P(cid, { maxFileSizeBytes, timeoutMs, abortSignal: opts?.abortSignal });
         else {
             const log = Logger("pkc-js:clients-manager:fetchCid");
             const resObj = await this.fetchFromMultipleGateways({
@@ -173,8 +174,9 @@ export class PKCClientsManager extends BaseClientsManager {
                 recordPKCType: "generic-ipfs",
                 validateGatewayResponseFunc: async () => {}, // no need to validate body against cid here, fetchFromMultipleGateways already does it
                 log,
-                maxFileSizeBytes: 1024 * 1024,
-                timeoutMs
+                maxFileSizeBytes,
+                timeoutMs,
+                abortSignal: opts?.abortSignal
             });
             return resObj.resText;
         }

--- a/src/pkc/pkc.ts
+++ b/src/pkc/pkc.ts
@@ -141,6 +141,9 @@ import type { Libp2pJsClient } from "../helia/libp2pjsClient.js";
 import type { AuthorNameRpcParam, CidRpcParam, RpcFetchCidResult } from "../clients/rpc-client/types.js";
 import { parseRpcAuthorNameParam, parseRpcCidParam } from "../clients/rpc-client/rpc-schema-util.js";
 import { cleanWireAuthor, normalizeCreatePublicationAuthor } from "../publications/publication-author.js";
+import { CommunityList } from "../community-list/community-list.js";
+import { CreateCommunityListWithCidOptionsSchema, CreateNewCommunityListOptionsSchema } from "../community-list/schema.js";
+import type { CreateCommunityListOptions, CreateCommunityListWithCidOptions } from "../community-list/types.js";
 import type Publication from "../publications/publication.js";
 import { stripNameResolvedFromCrosspost } from "../publications/comment/crosspost-runtime.js";
 import { IndexedTrackedInstanceRegistry, TrackedInstanceRegistry } from "./tracked-instance-registry.js";
@@ -202,6 +205,9 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
     // Publications that are mid-publish. A plain Set rather than a TrackedInstanceRegistry because
     // a publication has no stable key to look it up by, and destroy() only ever iterates them.
     _publishingPublications = new Set<Publication>();
+    // CommunityList instances mid-update(). Immutable records need no shared-instance registry;
+    // destroy() only ever iterates these to stop them.
+    _updatingCommunityLists = new Set<CommunityList>();
     private _communityFsWatchAbort?: AbortController;
     private _destroyAbortController?: AbortController;
 
@@ -549,6 +555,89 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
             abortSignal?.removeEventListener("abort", abortListener);
             comment.removeListener("error", errorListener);
             await comment.stop();
+        }
+    }
+
+    // CommunityList: an immutable, signed IPFS file addressed by CID (docs/protocol/community-lists.md).
+    // {signer, ...props} creates a publishable list; {cid} creates one that can update()
+    async createCommunityList(options: CreateCommunityListOptions): Promise<CommunityList> {
+        if (options && typeof options === "object" && "cid" in options) {
+            const parseRes = CreateCommunityListWithCidOptionsSchema.safeParse(options);
+            if (!parseRes.success)
+                throw new PKCError("ERR_INVALID_CREATE_COMMUNITY_LIST_OPTIONS_SCHEMA", { zodError: parseRes.error, options });
+            const communityList = new CommunityList(this);
+            communityList._initWithCidOnly(parseRes.data.cid);
+            return communityList;
+        }
+        const parseRes = CreateNewCommunityListOptionsSchema.safeParse(options);
+        if (!parseRes.success)
+            throw new PKCError("ERR_INVALID_CREATE_COMMUNITY_LIST_OPTIONS_SCHEMA", { zodError: parseRes.error, options });
+        const parsedOptions = parseRes.data;
+        const signer = await this.createSigner(parsedOptions.signer);
+        const cleanedAuthor = cleanWireAuthor(normalizeCreatePublicationAuthor(parsedOptions.author));
+        const communityList = new CommunityList(this);
+        communityList._initUnsignedProps({
+            signer,
+            title: parsedOptions.title,
+            description: parsedOptions.description,
+            author: cleanedAuthor,
+            communities: parsedOptions.communities,
+            timestamp: typeof parsedOptions.timestamp === "number" ? parsedOptions.timestamp : timestamp(),
+            protocolVersion: parsedOptions.protocolVersion || env.PROTOCOL_VERSION
+        });
+        return communityList;
+    }
+
+    // One-shot fetch + verify. Does not wait for the author.nameResolved verdict (same as getComment);
+    // the verdict lands in the pkc-wide cache so evented instances pick it up
+    async getCommunityList(
+        getCommunityListArgs: CreateCommunityListWithCidOptions & { abortSignal?: AbortSignal }
+    ): Promise<CommunityList> {
+        const { abortSignal, ...cidArgs } = getCommunityListArgs;
+        const parseRes = CreateCommunityListWithCidOptionsSchema.safeParse(cidArgs);
+        if (!parseRes.success)
+            throw new PKCError("ERR_INVALID_CREATE_COMMUNITY_LIST_OPTIONS_SCHEMA", { zodError: parseRes.error, getCommunityListArgs });
+        const cid = parseRes.data.cid;
+        if (abortSignal?.aborted) throw new PKCError("ERR_GET_COMMUNITY_LIST_ABORTED", { cid, abortReason: abortSignal.reason });
+        const communityList = await this.createCommunityList(parseRes.data);
+
+        let lastUpdateError: Error | undefined;
+        const errorListener = (err: Error) => (lastUpdateError = err);
+        communityList.on("error", errorListener);
+
+        let abortError: PKCError | undefined;
+        let abortReject: ((err: PKCError) => void) | undefined;
+        const abortListener = () => {
+            abortError = new PKCError("ERR_GET_COMMUNITY_LIST_ABORTED", { cid, abortReason: abortSignal?.reason, lastUpdateError });
+            abortReject?.(abortError);
+        };
+        const abortPromise = new Promise<never>((_, reject) => {
+            abortReject = reject;
+        });
+        // pTimeout attaches its own handler, but only once we hand it the race below. Give it one up
+        // front so an abort landing before that never surfaces as an unhandled rejection.
+        void abortPromise.catch(() => {});
+        // The signal outlives this call, so the listener is removed in the `finally` on every outcome
+        abortSignal?.addEventListener("abort", abortListener);
+
+        const timeoutMs = this._timeouts["generic-ipfs"];
+        try {
+            await pTimeout(Promise.race([communityList._loadCommunityListIpfsWithRetries(abortSignal), abortPromise]), {
+                milliseconds: timeoutMs,
+                message: lastUpdateError || new TimeoutError(`pkc.getCommunityList({cid: ${cid}}) timed out after ${timeoutMs}ms`)
+            });
+            if (!communityList.signature) throw Error("Failed to load CommunityList");
+            communityList._kickOffBackgroundAuthorNameResolution();
+            return communityList;
+        } catch (e) {
+            // Abort wins over whatever the list happened to emit: the caller cancelled on purpose
+            if (abortError) throw abortError;
+            if (lastUpdateError) throw lastUpdateError;
+            throw e;
+        } finally {
+            abortSignal?.removeEventListener("abort", abortListener);
+            communityList.removeListener("error", errorListener);
+            await communityList.stop();
         }
     }
 
@@ -1300,6 +1389,10 @@ export class PKC extends PKCTypedEmitter<PKCEvents> implements ParsedPKCOptions 
         this._publishingPublications.clear();
 
         for (const comment of listUpdatingComments(this)) await comment.stop();
+
+        for (const communityList of [...this._updatingCommunityLists])
+            await communityList.stop().catch((e) => log.error("Error stopping CommunityList during destroy", e));
+        this._updatingCommunityLists.clear();
 
         for (const community of listUpdatingCommunities(this)) await community.stop();
 

--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -38,7 +38,9 @@ import Publication from "../../publications/publication.js";
 import { PKCError } from "../../pkc-error.js";
 import { LocalCommunity } from "../../runtime/node/community/local-community.js";
 import { RemoteCommunity } from "../../community/remote-community.js";
-import { hideClassPrivateProps, replaceXWithY } from "../../util.js";
+import { calculateStringSizeSameAsIpfsAddCidV0, hideClassPrivateProps, replaceXWithY, retryKuboIpfsAddAndProvide } from "../../util.js";
+import { MAX_COMMUNITY_LIST_SIZE_BYTES } from "../../community-list/schema.js";
+import { verifyCommunityList } from "../../signer/signatures.js";
 import { keys, mapValues, omit } from "remeda";
 import type { IncomingMessage } from "http";
 import type {
@@ -64,7 +66,9 @@ import {
     parseSetNewSettingsPKCWsServerSchemaWithPKCErrorIfItFails,
     parseCommunityEditChallengeRequestToEncryptSchemaWithPKCErrorIfItFails,
     parseCommunityEditOptionsSchemaWithPKCErrorIfItFails,
-    parseVoteChallengeRequestToEncryptSchemaWithPKCErrorIfItFails
+    parseVoteChallengeRequestToEncryptSchemaWithPKCErrorIfItFails,
+    parseCommunityListSchemaWithPKCErrorIfItFails,
+    parseJsonWithPKCErrorIfFails
 } from "../../schema/schema-util.js";
 import { stringify as deterministicStringify } from "safe-stable-stringify";
 import type { VoteChallengeRequestToEncryptType } from "../../publications/vote/types.js";
@@ -90,7 +94,9 @@ import {
     parseRpcExportCommunityParam,
     parseRpcCancelExportParam,
     parseRpcExportCommunityModLogsParam,
-    parseRpcPublishAnchorRecordParam
+    parseRpcPublishAnchorRecordParam,
+    parseRpcPublishCommunityListParam,
+    parseRpcFetchCommunityListParam
 } from "../../clients/rpc-client/rpc-schema-util.js";
 import { fromString as uint8ArrayFromString } from "uint8arrays/from-string";
 import type {
@@ -105,7 +111,9 @@ import type {
     RpcCommunityPageResult,
     RpcLocalCommunityUpdateResultType,
     RpcExportCommunityResult,
-    RpcExportCommunityModLogsResult
+    RpcExportCommunityModLogsResult,
+    RpcPublishCommunityListResult,
+    RpcFetchCommunityListResult
 } from "../../clients/rpc-client/types.js";
 import type { CommunityExportRecord } from "../../community/types.js";
 import { findStartedCommunity } from "../../pkc/tracked-instance-registry-util.js";
@@ -308,6 +316,8 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
         this.rpcWebsocketsRegister("settingsSubscribe", this.settingsSubscribe.bind(this));
 
         this.rpcWebsocketsRegister("fetchCid", this.fetchCid.bind(this));
+        this.rpcWebsocketsRegister("publishCommunityList", this.publishCommunityList.bind(this));
+        this.rpcWebsocketsRegister("fetchCommunityList", this.fetchCommunityList.bind(this));
         this.rpcWebsocketsRegister("resolveAuthorName", this.resolveAuthorName.bind(this));
         this.rpcWebsocketsRegister("setSettings", this.setSettings.bind(this));
         // JSON RPC pubsub methods
@@ -957,6 +967,45 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
         const parsedArgs = parseRpcCidParam(params[0]);
         const pkc = await this._getPKCInstance();
         return pkc.fetchCid(parsedArgs);
+    }
+
+    // CommunityList (docs/protocol/community-lists.md). The client signs locally; the server only
+    // adds the exact signed bytes to IPFS and returns the cid. The record is validated before
+    // pinning so the server cannot be used to pin arbitrary or unsigned JSON
+    async publishCommunityList(params: any): Promise<RpcPublishCommunityListResult> {
+        const log = Logger("pkc-js-rpc:publishCommunityList");
+        const parsedArgs = parseRpcPublishCommunityListParam(params[0]);
+        const pkc = await this._getPKCInstance();
+        const recordString = parsedArgs.communityListRawString;
+        const sizeBytes = await calculateStringSizeSameAsIpfsAddCidV0(recordString);
+        if (sizeBytes > MAX_COMMUNITY_LIST_SIZE_BYTES)
+            throw new PKCError("ERR_COMMUNITY_LIST_OVER_ALLOWED_SIZE", {
+                sizeBytes,
+                maxSizeBytes: MAX_COMMUNITY_LIST_SIZE_BYTES
+            });
+        const record = parseCommunityListSchemaWithPKCErrorIfItFails(parseJsonWithPKCErrorIfFails(recordString));
+        const validity = await verifyCommunityList({ communityList: record });
+        if (!validity.valid) throw new PKCError("ERR_COMMUNITY_LIST_SIGNATURE_IS_INVALID", { validity });
+        const kuboRpcClient = pkc._clientsManager.getDefaultKuboRpcClient();
+        const addRes = await retryKuboIpfsAddAndProvide({
+            ipfsClient: kuboRpcClient._client,
+            log,
+            content: recordString,
+            addOptions: { pin: true },
+            provideInBackground: true
+        });
+        return { cid: String(addRes.cid) };
+    }
+
+    // Returns the raw record string so the client can check the bytes against the cid and verify
+    // the signature locally: the server is not trusted with record validity
+    async fetchCommunityList(params: any): Promise<RpcFetchCommunityListResult> {
+        const parsedArgs = parseRpcFetchCommunityListParam(params[0]);
+        const pkc = await this._getPKCInstance();
+        const communityListRawString = await pkc._clientsManager.fetchCid(parsedArgs.cid, {
+            maxFileSizeBytes: MAX_COMMUNITY_LIST_SIZE_BYTES
+        });
+        return { communityListRawString };
     }
 
     private _serializeSettingsFromPKC(pkc: PKC): PKCWsServerSettingsSerialized {

--- a/src/schema/schema-util.ts
+++ b/src/schema/schema-util.ts
@@ -1,5 +1,7 @@
 import { ModQueuePageIpfsSchema, PageIpfsSchema } from "../pages/schema.js";
 import type { PageIpfs } from "../pages/types.js";
+import { CommunityListIpfsLooseSchema, CommunityListIpfsSchema } from "../community-list/schema.js";
+import type { CommunityListIpfsType } from "../community-list/types.js";
 import { PKCError } from "../pkc-error.js";
 import type { messages } from "../errors.js";
 import {
@@ -144,6 +146,21 @@ export function parseCommentIpfsSchemaWithPKCErrorIfItFails(commentIpfsJson: z.i
     );
     if (!parseRes.success) throw new PKCError("ERR_INVALID_COMMENT_IPFS_SCHEMA", { zodError: parseRes.error, commentIpfsJson });
     else return <CommentIpfsType>commentIpfsJson;
+}
+
+export function parseCommunityListSchemaWithPKCErrorIfItFails(
+    communityListJson: z.infer<typeof CommunityListIpfsSchema>
+): CommunityListIpfsType {
+    const parseRes = _safeParseWithoutLettingNonZodThrowsEscape(
+        CommunityListIpfsLooseSchema,
+        communityListJson,
+        "ERR_INVALID_COMMUNITY_LIST_SCHEMA",
+        {
+            communityListJson
+        }
+    );
+    if (!parseRes.success) throw new PKCError("ERR_INVALID_COMMUNITY_LIST_SCHEMA", { zodError: parseRes.error, communityListJson });
+    else return <CommunityListIpfsType>communityListJson;
 }
 
 export function parseCommentUpdateSchemaWithPKCErrorIfItFails(commentUpdateJson: z.infer<typeof CommentUpdateSchema>): CommentUpdateType {

--- a/src/signer/signatures.ts
+++ b/src/signer/signatures.ts
@@ -86,7 +86,14 @@ import type {
     CommunityEditPubsubMessagePublication
 } from "../publications/community-edit/types.js";
 import { CommunityEditPublicationSignedPropertyNames } from "../publications/community-edit/schema.js";
-import { AuthorCommentIpfsReservedFields } from "../schema/schema.js";
+import { AuthorCommentIpfsReservedFields, AuthorReservedFields } from "../schema/schema.js";
+import {
+    CommunityListEntryReservedFields,
+    CommunityListReservedFields,
+    CommunityListSignedPropertyNames,
+    communityListHasNoDuplicateEntryPublicKeys
+} from "../community-list/schema.js";
+import type { CommunityListIpfsType } from "../community-list/types.js";
 import { of as calculateIpfsHash } from "typestub-ipfs-only-hash";
 import { stringify as deterministicStringify } from "safe-stable-stringify";
 import { RemoteCommunity } from "../community/remote-community.js";
@@ -332,6 +339,20 @@ export async function signCommunity({
 }): Promise<CommunitySignature> {
     const log = Logger("pkc-js:signatures:signCommunity");
     return <CommunitySignature>await _signJson(<JsonSignature["signedPropertyNames"]>CommunitySignedPropertyNames, community, signer, log);
+}
+
+export async function signCommunityList({
+    communityList,
+    signer,
+    pkc
+}: {
+    communityList: Omit<CommunityListIpfsType, "signature">;
+    signer: SignerType;
+    pkc: PKC;
+}): Promise<JsonSignature> {
+    const log = Logger("pkc-js:signatures:signCommunityList");
+    await _validateAuthorAddressBeforeSigning(communityList.author, signer, pkc);
+    return await _signJson(<JsonSignature["signedPropertyNames"]>CommunityListSignedPropertyNames, communityList, signer, log);
 }
 
 export async function signChallengeRequest({
@@ -683,6 +704,37 @@ export async function verifyCommentIpfs(opts: {
 
     opts.clientsManager._pkc._memCaches.commentVerificationCache.set(cacheKey, true);
     return validRes;
+}
+
+function _isThereUnsignedSignableFieldInCommunityList(record: CommunityListIpfsType): boolean {
+    const fields = record as Partial<Record<(typeof CommunityListSignedPropertyNames)[number], unknown>>;
+    for (const name of CommunityListSignedPropertyNames)
+        if (fields[name] !== undefined && !record.signature.signedPropertyNames.includes(name)) return true;
+    return false;
+}
+
+export async function verifyCommunityList({ communityList }: { communityList: CommunityListIpfsType }): Promise<ValidationResult> {
+    if (intersection(Object.keys(communityList), CommunityListReservedFields).length > 0)
+        return { valid: false, reason: messages.ERR_COMMUNITY_LIST_RECORD_INCLUDES_RESERVED_FIELD };
+
+    if (communityList.author && intersection(Object.keys(communityList.author), AuthorReservedFields).length > 0)
+        return { valid: false, reason: messages.ERR_COMMUNITY_LIST_AUTHOR_INCLUDES_RESERVED_FIELD };
+
+    for (const entry of communityList.communities)
+        if (intersection(Object.keys(entry), CommunityListEntryReservedFields).length > 0)
+            return { valid: false, reason: messages.ERR_COMMUNITY_LIST_ENTRY_INCLUDES_RESERVED_FIELD };
+
+    if (!communityListHasNoDuplicateEntryPublicKeys(communityList))
+        return { valid: false, reason: messages.ERR_COMMUNITY_LIST_HAS_DUPLICATE_COMMUNITY_PUBLIC_KEY };
+
+    // Must run on the raw record, before verification walks signedPropertyNames only (issue #249)
+    if (_isThereUnsignedSignableFieldInCommunityList(communityList))
+        return { valid: false, reason: messages.ERR_COMMUNITY_LIST_RECORD_INCLUDES_SIGNABLE_FIELD_NOT_IN_SIGNED_PROPERTY_NAMES };
+
+    const signatureValidity = await _verifyJsonSignature(communityList);
+    if (!signatureValidity) return { valid: false, reason: messages.ERR_SIGNATURE_IS_INVALID };
+
+    return { valid: true };
 }
 
 function _allFieldsOfRecordInSignedPropertyNames(

--- a/test/node-and-browser/clients/rpc-call-error-deserialization.test.ts
+++ b/test/node-and-browser/clients/rpc-call-error-deserialization.test.ts
@@ -1,0 +1,39 @@
+// A server-side PKCError rejecting a JSON-RPC request/response call must reach the caller as a
+// PKCError instance, exactly like subscription "error" notifications do (which already go through
+// _deserializeRpcError). Before the fix, the monkey-patched _webSocketClient.call only decorated
+// the raw JSON-RPC error object with rpcArgs/rpcServerUrl, so every call-path rejection was a
+// plain object and `instanceof PKCError` checks on it always failed.
+//
+// These tests need a live RPC server, so they only run under the remote-pkc-rpc config
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { describeIfRpc } from "../../helpers/conditional-tests.js";
+import { mockRpcRemotePKC } from "../../../dist/node/test/test-util.js";
+import { PKCError } from "../../../dist/node/pkc-error.js";
+import { messages } from "../../../dist/node/errors.js";
+import type { PKC } from "../../../dist/node/pkc/pkc.js";
+
+describeIfRpc("rpc call error deserialization", () => {
+    let pkc: PKC;
+    beforeAll(async () => {
+        pkc = await mockRpcRemotePKC();
+    });
+    afterAll(async () => {
+        await pkc.destroy();
+    });
+
+    it("a server-side PKCError rejects the call as a PKCError instance with its code, message and details", async () => {
+        try {
+            // the server rejects this with ERR_INVALID_COMMUNITY_LIST_SCHEMA before touching IPFS
+            await pkc._pkcRpcClient!.publishCommunityList({ communityListRawString: JSON.stringify({ not: "a CommunityList" }) });
+            expect.fail("should have thrown");
+        } catch (e) {
+            const err = <PKCError>e;
+            expect(err).to.be.instanceOf(PKCError);
+            expect(err.code).to.equal("ERR_INVALID_COMMUNITY_LIST_SCHEMA");
+            expect(err.message).to.equal(messages.ERR_INVALID_COMMUNITY_LIST_SCHEMA);
+            // the local decoration must survive deserialization
+            expect((<{ rpcArgs?: unknown }>err.details).rpcArgs).to.be.an("array");
+            expect((<{ rpcServerUrl?: unknown }>err.details).rpcServerUrl).to.be.a("string");
+        }
+    });
+});

--- a/test/node-and-browser/community-list/author-name-resolved.communitylist.test.ts
+++ b/test/node-and-browser/community-list/author-name-resolved.communitylist.test.ts
@@ -1,0 +1,179 @@
+// CommunityList author.nameResolved (docs/protocol/community-lists.md, issue #342).
+//
+// A list's author identity derives from signature.publicKey; a domain in author.name is only a
+// claim. update() keeps driving the background resolution until the verdict is DEFINITIVE
+// (resolves to the signer = true; resolves to a different key = false; no resolver for the TLD =
+// false), emits `update` again with author.nameResolved set, then stops itself. Transient resolver
+// failures retry until the caller's own stop(). The one-shot getCommunityList never waits for the
+// verdict; it only warms the pkc-wide cache.
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import signers from "../../fixtures/signers.js";
+import {
+    createMockNameResolver,
+    getAvailablePKCConfigsToTestAgainst,
+    mockRemotePKC,
+    resolveWhenConditionIsTrue
+} from "../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import type { PKC } from "../../../dist/node/pkc/pkc.js";
+import type { CommunityList } from "../../../dist/node/community-list/community-list.js";
+import type { SignerWithPublicKeyAddress } from "../../../dist/node/signer/index.js";
+import { addCommunityListRecordToIpfs, buildSignedCommunityListRecord } from "./communitylist-test-util.js";
+
+// The default mock resolver maps plebbit.bso -> signers[3]
+const DOMAIN = "plebbit.bso";
+const DOMAIN_SIGNER = signers[3];
+
+const waitUntilStoppedByItself = (list: CommunityList) =>
+    resolveWhenConditionIsTrue({ toUpdate: list, predicate: async () => list.state === "stopped", eventName: "statechange" });
+
+const publishListWithAuthorName = async (pkc: PKC, signer?: SignerWithPublicKeyAddress) => {
+    const finalSigner = signer ?? (await pkc.createSigner());
+    const { record } = await buildSignedCommunityListRecord({ pkc, signer: finalSigner, author: { name: DOMAIN } });
+    const cid = await addCommunityListRecordToIpfs(record);
+    return { cid, record, signer: finalSigner };
+};
+
+getAvailablePKCConfigsToTestAgainst().map((config) =>
+    describe(`communitylist author.nameResolved - ${config.name}`, () => {
+        let pkc: PKC;
+        beforeAll(async () => {
+            pkc = await config.pkcInstancePromise();
+        });
+        afterAll(async () => {
+            await pkc.destroy();
+        });
+
+        it("resolves to true when the author domain points at the signer, then the instance stops itself", async () => {
+            const domainSigner = await pkc.createSigner({ privateKey: DOMAIN_SIGNER.privateKey, type: "ed25519" });
+            const { cid } = await publishListWithAuthorName(pkc, domainSigner);
+            const list = await pkc.createCommunityList({ cid });
+            let updateEvents = 0;
+            list.on("update", () => updateEvents++);
+            await list.update();
+            await resolveWhenConditionIsTrue({ toUpdate: list, predicate: async () => list.author?.nameResolved === true });
+            expect(list.author?.name).to.equal(DOMAIN);
+            expect(list.author?.address).to.equal(DOMAIN); // address = name || publicKey, never overridden
+            expect(updateEvents).to.equal(2); // one for the record, one for the verdict
+            await waitUntilStoppedByItself(list);
+        });
+
+        it("resolves to false when the author domain points at a different key (impersonation), then stops itself", async () => {
+            // signed by a fresh key the domain does not point at
+            const { cid } = await publishListWithAuthorName(pkc);
+            const list = await pkc.createCommunityList({ cid });
+            await list.update();
+            await resolveWhenConditionIsTrue({ toUpdate: list, predicate: async () => list.author?.nameResolved === false });
+            expect(list.author?.name).to.equal(DOMAIN);
+            await waitUntilStoppedByItself(list);
+        });
+
+        it("the wire record never carries nameResolved or any other runtime author field", async () => {
+            const domainSigner = await pkc.createSigner({ privateKey: DOMAIN_SIGNER.privateKey, type: "ed25519" });
+            const { cid } = await publishListWithAuthorName(pkc, domainSigner);
+            const list = await pkc.createCommunityList({ cid });
+            await list.update();
+            await resolveWhenConditionIsTrue({ toUpdate: list, predicate: async () => typeof list.author?.nameResolved === "boolean" });
+            for (const runtimeField of ["nameResolved", "address", "publicKey", "shortAddress", "community"])
+                expect(list.raw.communityList?.author).to.not.have.property(runtimeField);
+            await waitUntilStoppedByItself(list);
+        });
+
+        it("getCommunityList does not wait for the verdict, but warms the cache for evented instances", async () => {
+            const domainSigner = await pkc.createSigner({ privateKey: DOMAIN_SIGNER.privateKey, type: "ed25519" });
+            const { cid } = await publishListWithAuthorName(pkc, domainSigner);
+            const oneShot = await pkc.getCommunityList({ cid });
+            // the one-shot instance is stopped on return and never updated afterwards
+            expect(oneShot.state).to.equal("stopped");
+
+            // the background kick lands the verdict in the pkc-wide cache, so an evented instance settles
+            const evented = await pkc.createCommunityList({ cid });
+            await evented.update();
+            await resolveWhenConditionIsTrue({ toUpdate: evented, predicate: async () => evented.author?.nameResolved === true });
+            await waitUntilStoppedByItself(evented);
+        });
+    })
+);
+
+// Clients of RPC delegate name resolution to the RPC server, which has its own nameResolvers:
+// client-side resolver mocks (canResolve, throwing resolvers, resolveAuthorNames toggles) cannot
+// reach it, so these behaviors are only testable against a locally-constructed PKC instance
+describeSkipIfRpc("communitylist author.nameResolved - custom resolvers", () => {
+    it("resolves to false (definitive) when no resolver handles the author TLD, then stops itself", async () => {
+        const pkc = await mockRemotePKC({
+            mockResolve: false,
+            pkcOptions: { nameResolvers: [createMockNameResolver({ canResolve: () => false })] }
+        });
+        try {
+            const { cid } = await publishListWithAuthorName(pkc);
+            const list = await pkc.createCommunityList({ cid });
+            await list.update();
+            await resolveWhenConditionIsTrue({ toUpdate: list, predicate: async () => list.author?.nameResolved === false });
+            await waitUntilStoppedByItself(list);
+        } finally {
+            await pkc.destroy();
+        }
+    });
+
+    it("keeps retrying on transient resolver failures: nameResolved stays undefined and the instance keeps updating", async () => {
+        let resolveCalls = 0;
+        const pkc = await mockRemotePKC({
+            mockResolve: false,
+            pkcOptions: {
+                nameResolvers: [
+                    createMockNameResolver({
+                        resolveFunction: async () => {
+                            resolveCalls++;
+                            throw Error("mock transient resolver outage");
+                        }
+                    })
+                ]
+            }
+        });
+        try {
+            const { cid } = await publishListWithAuthorName(pkc);
+            const list = await pkc.createCommunityList({ cid });
+            await list.update();
+            await resolveWhenConditionIsTrue({ toUpdate: list, predicate: async () => typeof list.title === "string" });
+            const started = Date.now();
+            while (resolveCalls < 1 && Date.now() - started < 10_000) await new Promise((resolve) => setTimeout(resolve, 50));
+            // give the failed attempt time to settle
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            expect(resolveCalls).to.be.greaterThanOrEqual(1);
+            expect(list.author?.nameResolved).to.be.undefined;
+            expect(list.state).to.equal("updating"); // no definitive verdict: never stops on its own
+            await list.stop();
+        } finally {
+            await pkc.destroy();
+        }
+    });
+
+    it("stops itself right after the first update when resolveAuthorNames is off", async () => {
+        let resolveCalls = 0;
+        const pkc = await mockRemotePKC({
+            mockResolve: false,
+            pkcOptions: {
+                resolveAuthorNames: false,
+                nameResolvers: [
+                    createMockNameResolver({
+                        resolveFunction: async () => {
+                            resolveCalls++;
+                            return undefined;
+                        }
+                    })
+                ]
+            }
+        });
+        try {
+            const { cid } = await publishListWithAuthorName(pkc);
+            const list = await pkc.createCommunityList({ cid });
+            await list.update();
+            await resolveWhenConditionIsTrue({ toUpdate: list, predicate: async () => typeof list.title === "string" });
+            await waitUntilStoppedByItself(list);
+            expect(list.author?.nameResolved).to.be.undefined;
+            expect(resolveCalls).to.equal(0);
+        } finally {
+            await pkc.destroy();
+        }
+    });
+});

--- a/test/node-and-browser/community-list/communitylist-test-util.ts
+++ b/test/node-and-browser/community-list/communitylist-test-util.ts
@@ -1,0 +1,47 @@
+// Shared helpers for CommunityList tests (docs/protocol/community-lists.md). Not a test file.
+import signers from "../../fixtures/signers.js";
+import { createSigner, type SignerWithPublicKeyAddress } from "../../../dist/node/signer/index.js";
+import { cleanUpBeforePublishing, signCommunityList } from "../../../dist/node/signer/signatures.js";
+import { timestamp } from "../../../dist/node/util.js";
+import env from "../../../dist/node/version.js";
+import { addStringToIpfs } from "../../../dist/node/test/test-util.js";
+import type { PKC } from "../../../dist/node/pkc/pkc.js";
+import type { CommunityListEntryType, CommunityListIpfsType } from "../../../dist/node/community-list/types.js";
+import type { AuthorPubsubType } from "../../../dist/node/types.js";
+
+export const mockCommunityListEntries: CommunityListEntryType[] = [
+    { publicKey: signers[0].address, title: "Test community 0", tags: ["test", "mock"], languages: ["en"] },
+    { publicKey: signers[1].address, name: "memes.bso", description: "Second test community" }
+];
+
+export async function buildSignedCommunityListRecord({
+    pkc,
+    signer,
+    author,
+    communities,
+    title,
+    description
+}: {
+    pkc: PKC;
+    signer?: SignerWithPublicKeyAddress;
+    author?: AuthorPubsubType;
+    communities?: CommunityListEntryType[];
+    title?: string;
+    description?: string;
+}): Promise<{ record: CommunityListIpfsType; signer: SignerWithPublicKeyAddress }> {
+    const finalSigner = signer ?? (await createSigner());
+    const props = cleanUpBeforePublishing({
+        title: title ?? "Mock community list",
+        description: description ?? "A mock list of communities used in tests",
+        author,
+        communities: communities ?? mockCommunityListEntries,
+        timestamp: timestamp(),
+        protocolVersion: env.PROTOCOL_VERSION
+    });
+    const signature = await signCommunityList({ communityList: props, signer: finalSigner, pkc });
+    return { record: <CommunityListIpfsType>{ ...props, signature }, signer: finalSigner };
+}
+
+export async function addCommunityListRecordToIpfs(record: CommunityListIpfsType | Record<string, unknown>): Promise<string> {
+    return addStringToIpfs(JSON.stringify(record));
+}

--- a/test/node-and-browser/community-list/communitylist.test.ts
+++ b/test/node-and-browser/community-list/communitylist.test.ts
@@ -1,0 +1,252 @@
+// CommunityList lifecycle (docs/protocol/community-lists.md): an immutable, signed IPFS file
+// addressed by CID. publish() = sign + IPFS add; update() = fetch + verify with retries, emit
+// `update`, then auto-stop once there is nothing left to settle.
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { clone } from "remeda";
+import signers from "../../fixtures/signers.js";
+import { getAvailablePKCConfigsToTestAgainst, mockRemotePKC, resolveWhenConditionIsTrue } from "../../../dist/node/test/test-util.js";
+import { messages } from "../../../dist/node/errors.js";
+import { PKCError } from "../../../dist/node/pkc-error.js";
+import type { PKC } from "../../../dist/node/pkc/pkc.js";
+import type { CommunityList } from "../../../dist/node/community-list/community-list.js";
+import type { CommunityListIpfsType } from "../../../dist/node/community-list/types.js";
+import { addCommunityListRecordToIpfs, buildSignedCommunityListRecord, mockCommunityListEntries } from "./communitylist-test-util.js";
+
+const expectPKCErrorCode = (err: unknown, code: keyof typeof messages) => {
+    expect(err).to.be.instanceOf(PKCError);
+    expect((<PKCError>err).code).to.equal(code);
+};
+
+const waitUntilStoppedByItself = (list: CommunityList) =>
+    resolveWhenConditionIsTrue({ toUpdate: list, predicate: async () => list.state === "stopped", eventName: "statechange" });
+
+const updateAndAwaitError = async (list: CommunityList): Promise<PKCError> => {
+    const errPromise = new Promise<PKCError>((resolve) => list.once("error", (e) => resolve(<PKCError>e)));
+    await list.update();
+    const err = await errPromise;
+    await waitUntilStoppedByItself(list); // deterministic record errors stop the instance on their own
+    return err;
+};
+
+// publish() needs a node that can `ipfs add`: a kubo-rpc client or a pkc RPC server
+getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc", "remote-pkc-rpc", "local-kubo-rpc"] }).map((config) =>
+    describe(`communitylist publish - ${config.name}`, () => {
+        let pkc: PKC;
+        beforeAll(async () => {
+            pkc = await config.pkcInstancePromise();
+        });
+        afterAll(async () => {
+            await pkc.destroy();
+        });
+
+        it("publishes a CommunityList, sets cid, and derives runtime conveniences", async () => {
+            const signer = await pkc.createSigner();
+            const list = await pkc.createCommunityList({
+                signer,
+                title: "My default feed",
+                description: "Curated communities",
+                communities: mockCommunityListEntries
+            });
+            const cid = await list.publish();
+            expect(cid).to.be.a("string");
+            expect(list.cid).to.equal(cid);
+            expect(list.shortCid).to.be.a("string").and.not.equal(cid);
+            expect(list.state).to.equal("stopped");
+            expect(list.title).to.equal("My default feed");
+            expect(list.timestamp).to.be.a("number");
+            expect(list.protocolVersion).to.be.a("string");
+            expect(list.signature?.publicKey).to.equal(signer.publicKey);
+
+            // entry identity follows the publication convention: address = name || publicKey
+            expect(list.communities?.[0].address).to.equal(mockCommunityListEntries[0].publicKey);
+            expect(list.communities?.[1].address).to.equal(mockCommunityListEntries[1].name);
+            expect(list.communities?.[0].shortAddress).to.be.a("string");
+
+            // the wire record carries no runtime fields
+            expect(list.raw.communityList).to.not.have.property("cid");
+            expect(list.raw.communityList?.communities[0]).to.not.have.property("address");
+            expect(list.raw.communityList?.communities[0]).to.not.have.property("shortAddress");
+        });
+
+        it("a published list loads back identically with getCommunityList", async () => {
+            const signer = await pkc.createSigner();
+            const list = await pkc.createCommunityList({ signer, communities: mockCommunityListEntries });
+            const cid = await list.publish();
+
+            const loaded = await pkc.getCommunityList({ cid });
+            expect(loaded.raw.communityList).to.deep.equal(list.raw.communityList);
+            expect(loaded.cid).to.equal(cid);
+            expect(loaded.state).to.equal("stopped");
+        });
+
+        it("author identity derives from the signature, and author runtime fields never reach the wire", async () => {
+            const signer = await pkc.createSigner();
+            const list = await pkc.createCommunityList({
+                signer,
+                communities: mockCommunityListEntries,
+                // runtime fields passed by mistake must be stripped before signing
+                author: <never>{ displayName: "Curator", nameResolved: true, shortAddress: "12D3KooShort", community: { postScore: 1 } }
+            });
+            await list.publish();
+            expect(list.raw.communityList?.author).to.deep.equal({ displayName: "Curator" });
+            expect(list.author?.displayName).to.equal("Curator");
+            expect(list.author?.address).to.equal(signer.address);
+            expect(list.author?.publicKey).to.equal(signer.address);
+            expect(list.author?.shortAddress).to.be.a("string");
+            expect(list.author?.nameResolved).to.be.undefined;
+            expect(list.author).to.not.have.property("community");
+        });
+
+        it("createCommunityList throws on a duplicate entry publicKey", async () => {
+            const signer = await pkc.createSigner();
+            const entry = mockCommunityListEntries[0];
+            try {
+                await pkc.createCommunityList({ signer, communities: [entry, clone(entry)] });
+                expect.fail("should have thrown");
+            } catch (e) {
+                expectPKCErrorCode(e, "ERR_INVALID_CREATE_COMMUNITY_LIST_OPTIONS_SCHEMA");
+            }
+        });
+
+        it("publish throws when the serialized record is over 2mb", async () => {
+            const signer = await pkc.createSigner();
+            const hugeTags = new Array(3).fill(undefined).map((_, i) => `${i}`.repeat(1024 * 1024)); // ~3mb
+            const list = await pkc.createCommunityList({
+                signer,
+                communities: [{ ...mockCommunityListEntries[0], tags: hugeTags }]
+            });
+            try {
+                await list.publish();
+                expect.fail("should have thrown");
+            } catch (e) {
+                expectPKCErrorCode(e, "ERR_COMMUNITY_LIST_OVER_ALLOWED_SIZE");
+            }
+            expect(list.state).to.equal("stopped");
+        });
+
+        it("update() after publish() emits update with the already-loaded record and stops itself", async () => {
+            const signer = await pkc.createSigner();
+            const list = await pkc.createCommunityList({ signer, communities: mockCommunityListEntries });
+            await list.publish();
+            let updateEvents = 0;
+            list.on("update", () => updateEvents++);
+            await list.update();
+            await waitUntilStoppedByItself(list);
+            expect(updateEvents).to.equal(1);
+        });
+    })
+);
+
+describe("communitylist load", () => {
+    let fixture: { record: CommunityListIpfsType; cid: string };
+
+    beforeAll(async () => {
+        const helperPkc = await mockRemotePKC();
+        const { record } = await buildSignedCommunityListRecord({ pkc: helperPkc });
+        const cid = await addCommunityListRecordToIpfs(record);
+        fixture = { record, cid };
+        await helperPkc.destroy();
+    });
+
+    getAvailablePKCConfigsToTestAgainst().map((config) =>
+        describe(`communitylist load - ${config.name}`, () => {
+            let pkc: PKC;
+            beforeAll(async () => {
+                pkc = await config.pkcInstancePromise();
+            });
+            afterAll(async () => {
+                await pkc.destroy();
+            });
+
+            it("one-shot getCommunityList fetches and verifies the record", async () => {
+                const list = await pkc.getCommunityList({ cid: fixture.cid });
+                expect(list.raw.communityList).to.deep.equal(fixture.record);
+                expect(list.title).to.equal(fixture.record.title);
+                expect(list.timestamp).to.equal(fixture.record.timestamp);
+                expect(list.communities?.length).to.equal(fixture.record.communities.length);
+                expect(list.communities?.[1].address).to.equal(fixture.record.communities[1].name);
+                expect(list.author?.address).to.be.a("string");
+                expect(list.state).to.equal("stopped");
+                expect(list.toJSON().cid).to.equal(fixture.cid);
+            });
+
+            it("createCommunityList({cid}) + update() emits update and stops itself when there is nothing to settle", async () => {
+                const list = await pkc.createCommunityList({ cid: fixture.cid });
+                expect(list.cid).to.equal(fixture.cid);
+                expect(list.state).to.equal("stopped");
+                await list.update();
+                await resolveWhenConditionIsTrue({ toUpdate: list, predicate: async () => typeof list.title === "string" });
+                expect(list.raw.communityList).to.deep.equal(fixture.record);
+                // the record is immutable and this fixture's author has no domain: nothing to watch,
+                // so the instance must stop on its own without a manual stop() call
+                await waitUntilStoppedByItself(list);
+            });
+
+            it("update() emits an error and stops itself when the signature is invalid", async () => {
+                const invalidRecord = clone(fixture.record);
+                invalidRecord.signature.signature = invalidRecord.signature.signature.slice(0, -4) + "AAAA";
+                const invalidCid = await addCommunityListRecordToIpfs(invalidRecord);
+                const list = await pkc.createCommunityList({ cid: invalidCid });
+                const err = await updateAndAwaitError(list);
+                expect(err.code).to.equal("ERR_COMMUNITY_LIST_SIGNATURE_IS_INVALID");
+            });
+
+            it("update() emits a schema error and stops itself on duplicate entry publicKeys", async () => {
+                const helperPkc = await mockRemotePKC();
+                const dupEntry = mockCommunityListEntries[0];
+                const { record } = await buildSignedCommunityListRecord({
+                    pkc: helperPkc,
+                    communities: [dupEntry, clone(dupEntry)]
+                });
+                await helperPkc.destroy();
+                const dupCid = await addCommunityListRecordToIpfs(record);
+                const list = await pkc.createCommunityList({ cid: dupCid });
+                const err = await updateAndAwaitError(list);
+                expect(err.code).to.equal("ERR_INVALID_COMMUNITY_LIST_SCHEMA");
+            });
+
+            it("update() emits an error and stops itself when the record includes a reserved field", async () => {
+                // a wire record must never smuggle in runtime-only names; `cid` is added after signing
+                // so it hits the reserved-field check, not the unsigned-signable-field check
+                const recordWithReserved = { ...clone(fixture.record), cid: fixture.cid };
+                const reservedCid = await addCommunityListRecordToIpfs(recordWithReserved);
+                const list = await pkc.createCommunityList({ cid: reservedCid });
+                const err = await updateAndAwaitError(list);
+                expect(err.code).to.equal("ERR_COMMUNITY_LIST_SIGNATURE_IS_INVALID");
+                expect((<{ validity?: { reason?: string } }>err.details).validity?.reason).to.equal(
+                    messages.ERR_COMMUNITY_LIST_RECORD_INCLUDES_RESERVED_FIELD
+                );
+            });
+        })
+    );
+
+    // Gateways report an oversize download through an aggregated gateway error rather than
+    // ERR_OVER_DOWNLOAD_LIMIT, so the deterministic-rejection assertion is P2P/RPC-only
+    getAvailablePKCConfigsToTestAgainst({
+        includeOnlyTheseTests: ["remote-kubo-rpc", "remote-pkc-rpc", "local-kubo-rpc", "remote-libp2pjs"]
+    }).map((config) =>
+        describe(`communitylist load rejects oversize records - ${config.name}`, () => {
+            let pkc: PKC;
+            beforeAll(async () => {
+                pkc = await config.pkcInstancePromise();
+            });
+            afterAll(async () => {
+                await pkc.destroy();
+            });
+
+            it("update() rejects a record over 2mb before parsing it", async () => {
+                const helperPkc = await mockRemotePKC();
+                const hugeTags = new Array(3).fill(undefined).map((_, i) => `${i}`.repeat(1024 * 1024)); // ~3mb
+                const { record } = await buildSignedCommunityListRecord({
+                    pkc: helperPkc,
+                    communities: [{ ...mockCommunityListEntries[0], tags: hugeTags }]
+                });
+                await helperPkc.destroy();
+                const oversizeCid = await addCommunityListRecordToIpfs(record);
+                const list = await pkc.createCommunityList({ cid: oversizeCid });
+                const err = await updateAndAwaitError(list);
+                expect(err.code).to.equal("ERR_OVER_DOWNLOAD_LIMIT");
+            });
+        })
+    );
+});

--- a/test/node-and-browser/community-list/signatures.communitylist.test.ts
+++ b/test/node-and-browser/community-list/signatures.communitylist.test.ts
@@ -1,0 +1,109 @@
+// verifyCommunityList unit tests (docs/protocol/community-lists.md): reserved fields, unsigned
+// signable fields, duplicate entry publicKeys, and signature validity.
+// Clients of RPC trust the RPC server's response and don't validate locally, and these tests call
+// the verify function directly on a locally-constructed clients manager, so they can't run under RPC
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { clone } from "remeda";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { mockRemotePKC } from "../../../dist/node/test/test-util.js";
+import { verifyCommunityList } from "../../../dist/node/signer/signatures.js";
+import { messages } from "../../../dist/node/errors.js";
+import type { PKC } from "../../../dist/node/pkc/pkc.js";
+import type { CommunityListIpfsType } from "../../../dist/node/community-list/types.js";
+import { buildSignedCommunityListRecord, mockCommunityListEntries } from "./communitylist-test-util.js";
+
+describeSkipIfRpc("verifyCommunityList", () => {
+    let pkc: PKC;
+    let validRecord: CommunityListIpfsType;
+
+    beforeAll(async () => {
+        pkc = await mockRemotePKC();
+        validRecord = (await buildSignedCommunityListRecord({ pkc, author: { displayName: "Curator" } })).record;
+    });
+    afterAll(async () => {
+        await pkc.destroy();
+    });
+
+    it("a freshly signed record is valid, both as an object and after a JSON round-trip", async () => {
+        expect(await verifyCommunityList({ communityList: validRecord })).to.deep.equal({ valid: true });
+        const roundTripped = <CommunityListIpfsType>JSON.parse(JSON.stringify(validRecord));
+        expect(await verifyCommunityList({ communityList: roundTripped })).to.deep.equal({ valid: true });
+    });
+
+    it("signedPropertyNames cover every wire field except the signature", () => {
+        expect([...validRecord.signature.signedPropertyNames].sort()).to.deep.equal(
+            ["title", "description", "author", "communities", "timestamp", "protocolVersion"].sort()
+        );
+    });
+
+    it("rejects a record whose signature bytes are tampered", async () => {
+        const tampered = clone(validRecord);
+        tampered.signature.signature = tampered.signature.signature.slice(0, -4) + "AAAA";
+        expect(await verifyCommunityList({ communityList: tampered })).to.deep.equal({
+            valid: false,
+            reason: messages.ERR_SIGNATURE_IS_INVALID
+        });
+    });
+
+    it("rejects a record where a signed field was modified after signing", async () => {
+        const tampered = clone(validRecord);
+        tampered.title = "modified after signing";
+        expect(await verifyCommunityList({ communityList: tampered })).to.deep.equal({
+            valid: false,
+            reason: messages.ERR_SIGNATURE_IS_INVALID
+        });
+    });
+
+    it("rejects a record that includes a signable field not in signedPropertyNames (issue #249)", async () => {
+        // sign a record without description, then attach one post-signing
+        const { record } = await buildSignedCommunityListRecord({ pkc });
+        const withUnsigned = <CommunityListIpfsType>{ ...clone(record), description: undefined };
+        delete (<Record<string, unknown>>withUnsigned).description;
+        withUnsigned.signature = {
+            ...withUnsigned.signature,
+            signedPropertyNames: withUnsigned.signature.signedPropertyNames.filter((name) => name !== "description")
+        };
+        // signature is now invalid anyway, but the signable-field check must fire first with its own reason
+        (<Record<string, unknown>>withUnsigned).description = "attached after signing";
+        const res = await verifyCommunityList({ communityList: withUnsigned });
+        expect(res).to.deep.equal({
+            valid: false,
+            reason: messages.ERR_COMMUNITY_LIST_RECORD_INCLUDES_SIGNABLE_FIELD_NOT_IN_SIGNED_PROPERTY_NAMES
+        });
+    });
+
+    it("rejects a record with a reserved runtime field", async () => {
+        const withReserved = <CommunityListIpfsType>{ ...clone(validRecord), cid: "QmYbcXBSAWNqNRVsdmx3PFTHk3JfSXJfWQprvWkpRTqoHe" };
+        expect(await verifyCommunityList({ communityList: withReserved })).to.deep.equal({
+            valid: false,
+            reason: messages.ERR_COMMUNITY_LIST_RECORD_INCLUDES_RESERVED_FIELD
+        });
+    });
+
+    it("rejects a record whose author carries a reserved runtime field (e.g. nameResolved)", async () => {
+        const withReservedAuthor = clone(validRecord);
+        (<Record<string, unknown>>withReservedAuthor.author).nameResolved = true;
+        expect(await verifyCommunityList({ communityList: withReservedAuthor })).to.deep.equal({
+            valid: false,
+            reason: messages.ERR_COMMUNITY_LIST_AUTHOR_INCLUDES_RESERVED_FIELD
+        });
+    });
+
+    it("rejects a record whose entry carries a reserved runtime field (e.g. address)", async () => {
+        const withReservedEntry = clone(validRecord);
+        (<Record<string, unknown>>withReservedEntry.communities[0]).address = mockCommunityListEntries[0].publicKey;
+        expect(await verifyCommunityList({ communityList: withReservedEntry })).to.deep.equal({
+            valid: false,
+            reason: messages.ERR_COMMUNITY_LIST_ENTRY_INCLUDES_RESERVED_FIELD
+        });
+    });
+
+    it("rejects a record with duplicate entry publicKeys", async () => {
+        const withDup = clone(validRecord);
+        withDup.communities = [withDup.communities[0], clone(withDup.communities[0])];
+        expect(await verifyCommunityList({ communityList: withDup })).to.deep.equal({
+            valid: false,
+            reason: messages.ERR_COMMUNITY_LIST_HAS_DUPLICATE_COMMUNITY_PUBLIC_KEY
+        });
+    });
+});


### PR DESCRIPTION
Implements `CommunityList` (formerly "multisub") end to end, docs and code in one PR.

Closes #21. Closes #342.

## Design (revised from the original issue #21 IPNS design, see the revision comment there)

A `CommunityList` is an **immutable, signed IPFS file addressed by CID**, like a comment. Mutable IPNS lists were rejected as a rug-pull risk: apps ship list addresses as defaults, and a single IPNS update could redirect every installed client to arbitrary communities with nobody in the loop. With CIDs, each revision is a new CID re-reviewed at adoption time; clients never auto-follow. Spec: `docs/protocol/community-lists.md`.

## What's in the PR

- **Spec**: `docs/protocol/community-lists.md` rewritten for the immutable design, including the `author` field (#342): same wire schema as `publication.author`, runtime identity derived from `signature.publicKey`, lazy `author.nameResolved`, and never any `author.community` (lists are never published to a community, so there is no challenge flow and no community-assigned author state).
- **Implementation** (`src/community-list/`): one `CommunityList` class.
  - `pkc.createCommunityList({signer, ...props})` + `publish()` (sign + IPFS add, returns the cid) / `stop()` (abort). Any key can sign, including the curator's personal author key; one key can sign any number of lists.
  - `pkc.createCommunityList({cid})` + `update()` / `stop()`: fetch + verify with retries, emit `update`, then keep driving `author.nameResolved` until the verdict is definitive (resolves to signer = true; different key or no resolver for the TLD = false; transient failures retry), emit `update` again, then **stop itself**. One-shot `pkc.getCommunityList({cid})` doesn't wait for the verdict (it warms the pkc-wide cache).
  - Signing/verification in `src/signer/signatures.ts` (`signCommunityList`, `verifyCommunityList`): loose load schemas preserving extra signed props, reserved-field guards (`cid`/`shortCid` on the record, `address`/`shortAddress` on entries, the publication author reserved list on `author`), unsigned-signable-field check (#249 class), duplicate entry `publicKey` rejection, 2 MB cap on publish and on load (download-limit guarded before parsing).
- **RPC**: `publishCommunityList` / `fetchCommunityList`. Signing stays client-side; the raw signed string crosses the wire so the server adds the exact signed bytes, and the client checks the returned cid against the bytes it signed (and on fetch, checks the returned bytes against the cid) so the server is never trusted with record validity.
- **README**: `Multisub`/`MultisubEdit`/`PKCDefaults` schema fossils replaced with the `CommunityList` schema and API sections.
- **Tests** (`test/node-and-browser/community-list/`): lifecycle, validation and verification suites plus dedicated `author.nameResolved` coverage (true/false/definitive-false/transient, cache warmup, wire purity), passing under `remote-kubo-rpc`, `local-kubo-rpc`, `remote-libp2pjs` and `remote-ipfs-gateway`. The `remote-pkc-rpc` config requires a test server built from this branch (the new RPC methods).

## Not in scope (per spec non-goals)

Mutability/IPNS, `edit()`, third-party edits, revision-chain field, pagination, `PKCDefaults`. Discovery of newer revisions is out of protocol (future IPNS author profiles and communities).