### PR TITLE
perf(community): drive kubo/helia updates from gossip pushes instead of a 1s poll (#308 #307)

### DIFF
--- a/src/clients/base-client-manager.ts
+++ b/src/clients/base-client-manager.ts
@@ -621,7 +621,12 @@ export class BaseClientsManager {
     // directly at the /ipfs/ CID, i.e. the key that signs the content).
     async resolveIpnsToCidP2P(
         ipnsName: string,
-        loadOpts: { timeoutMs: number; abortSignal?: AbortSignal }
+        // `nocache: true` forces a network revalidation even on the libp2p-js resolver (whose
+        // default below is to let its gossip-fed routing-layer cache serve, issue #301). The
+        // community update loop sets it on safety-net ticks, which exist precisely for pushed
+        // records the cache never received. It is spread AFTER the per-client default, so the
+        // caller's value wins.
+        loadOpts: { timeoutMs: number; abortSignal?: AbortSignal; nocache?: boolean }
     ): Promise<{ cid: string; ipnsHops: string[] }> {
         const log = Logger("pkc-js:clients-manager:resolveIpnsToCidP2P");
         throwIfAbortSignalAborted(loadOpts.abortSignal);

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -52,6 +52,17 @@ import type { IpnsRecordArrival, IpnsRecordArrivalListener } from "../helia/type
 
 export const MAX_FILE_SIZE_BYTES_FOR_COMMUNITY_IPFS = 1024 * 1024; // 1mb
 
+// Floor on how often a timer-fired safety-net tick may force a network revalidation of the
+// community's IPNS record. At the production updateInterval (60s) every tick revalidates, so
+// this changes nothing there; it only engages for sub-30s intervals (every test pkc runs 500ms),
+// where forcing the network on each tick would turn every idle community into a constant
+// multi-peer fetcher AND flip the loop's duty cycle from parked-in-waiting-retry to
+// mid-fetching-ipns — which is what tripped the browser CI legs' state-sampling assertions
+// (post.updatingState races against the community tick's phase). Worst-case staleness after a
+// missed push at an aggressive interval is therefore ~30s, still 10x under riding out kubo
+// 0.43's default 300s record ttl the way the pre-#311 cache-gated poll did.
+const FORCED_IPNS_NETWORK_REVALIDATION_MIN_INTERVAL_MS = 30_000;
+
 export class CommunityClientsManager extends PKCClientsManager {
     override clients!: {
         ipfsGateways: { [ipfsGatewayUrl: string]: CommunityIpfsGatewayClient };
@@ -85,6 +96,10 @@ export class CommunityClientsManager extends PKCClientsManager {
     // so the resolve that follows must revalidate against the network (nocache). An
     // arrival-woken cycle keeps the cache read — the arrival IS the newly cached record.
     private _nextResolveRevalidatesNetwork = false;
+    // Time of the last resolve that actually forced the network (plus the loop start, whose
+    // first updateOnce resolves against the network anyway — no subscription exists yet, so the
+    // cache gate is off). Feeds the FORCED_IPNS_NETWORK_REVALIDATION_MIN_INTERVAL_MS floor.
+    private _lastForcedIpnsNetworkRevalidationAtMs = 0;
     private _wakeUpdateLoopForIpnsArrival?: () => void;
 
     constructor(community: CommunityClientsManager["_community"]) {
@@ -377,6 +392,9 @@ export class CommunityClientsManager extends PKCClientsManager {
                     e
                 );
             }
+            // The first updateOnce always resolves against the network (no topic subscription
+            // exists yet, so the cache gate is off), so the revalidation floor counts from here.
+            this._lastForcedIpnsNetworkRevalidationAtMs = Date.now();
         }
 
         while (this._community.state === "updating" && !this._community._getStopAbortSignal()?.aborted) {
@@ -527,9 +545,12 @@ export class CommunityClientsManager extends PKCClientsManager {
         if (this._wakeUpdateLoopForIpnsArrival === wakeForArrival) this._wakeUpdateLoopForIpnsArrival = undefined;
         // A timer-fired park end is the safety net's tick: it exists precisely for pushes that
         // never arrived, which the cache gate cannot observe — the next resolve must go to the
-        // network (see _nextResolveRevalidatesNetwork). The abort outcome also lands here, but
-        // the loop exits before another resolve runs, so the flag value is moot.
-        this._nextResolveRevalidatesNetwork = !wokenByArrival;
+        // network (see _nextResolveRevalidatesNetwork), bounded by the revalidation floor so a
+        // sub-30s updateInterval does not force the network on every tick. The abort outcome
+        // also lands here, but the loop exits before another resolve runs, so the flag value is
+        // moot.
+        this._nextResolveRevalidatesNetwork =
+            !wokenByArrival && Date.now() - this._lastForcedIpnsNetworkRevalidationAtMs >= FORCED_IPNS_NETWORK_REVALIDATION_MIN_INTERVAL_MS;
     }
 
     // fetching community ipns here
@@ -784,15 +805,17 @@ export class CommunityClientsManager extends PKCClientsManager {
         if ("_helia" in kuboRpcOrHelia) {
             this.updateLibp2pJsClientState("fetching-ipns", kuboRpcOrHelia._libp2pJsClientsOptions.key);
         } else this.updateKuboRpcState("fetching-ipns", kuboRpcOrHelia.url);
+        // A cycle woken by the safety-net timer (not by an arrival) must revalidate on the
+        // network: the routing-layer cache gate cannot observe a push that never arrived, and
+        // would otherwise serve the stale record for its whole remaining ttl (300s at kubo
+        // 0.43's default) instead of the max(updateInterval, revalidation floor) the safety net
+        // promises. No-op for the kubo-RPC resolver, which always resolves with nocache: true.
+        const forceNetworkRevalidation = this._nextResolveRevalidatesNetwork;
+        if (forceNetworkRevalidation) this._lastForcedIpnsNetworkRevalidationAtMs = Date.now();
         const { cid: latestCommunityCid, ipnsHops } = await this.resolveIpnsToCidP2P(ipnsName, {
             timeoutMs: this._pkc._timeouts["community-ipns"],
             abortSignal: this._community._getStopAbortSignal(),
-            // A cycle woken by the safety-net timer (not by an arrival) must revalidate on the
-            // network: the routing-layer cache gate cannot observe a push that never arrived,
-            // and would otherwise serve the stale record for its whole remaining ttl (300s at
-            // kubo 0.43's default) instead of the one updateInterval the safety net promises.
-            // No-op for the kubo-RPC resolver, which always resolves with nocache: true.
-            ...(this._nextResolveRevalidatesNetwork ? { nocache: true } : {})
+            ...(forceNetworkRevalidation ? { nocache: true } : {})
         });
         // ipnsHops[0] is the anchor (== ipnsName), ipnsHops.at(-1) is the terminal name whose
         // record points at the CID, i.e. the key that signs the community content. For a

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -414,7 +414,7 @@ export class CommunityClientsManager extends PKCClientsManager {
                     // Jittered per iteration so a directory of communities started together does
                     // not run its safety-net polls in lockstep (issue #307).
                     const safetyNetMs = this._pkc.updateInterval * (0.75 + Math.random() * 0.5);
-                    await this._sleepUntilIpnsArrivalOrTimeoutOrAbort(safetyNetMs, this._community._getStopAbortSignal());
+                    await this._sleepUntilIpnsArrivalOrTimeoutOrAbort({ ms: safetyNetMs, signal: this._community._getStopAbortSignal() });
                 } else {
                     const updateInterval = areWeConnectedToKuboOrHelia ? 1000 : this._pkc.updateInterval; // if we're on kubo we should resolve IPNS every second
                     await sleepUntilTimeoutOrAbort(updateInterval, this._community._getStopAbortSignal());
@@ -500,12 +500,18 @@ export class CommunityClientsManager extends PKCClientsManager {
         const desiredTopics = new Set(ipnsNamesToWatch.map(ipnsNameToIpnsOverPubsubTopic));
         for (const topic of this._subscribedIpnsArrivalTopics)
             if (!desiredTopics.has(topic)) {
-                client.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals.unsubscribe(topic, this._ipnsArrivalListener);
+                client.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals.unsubscribe({
+                    pubsubTopic: topic,
+                    listener: this._ipnsArrivalListener
+                });
                 this._subscribedIpnsArrivalTopics.delete(topic);
             }
         for (const topic of desiredTopics)
             if (!this._subscribedIpnsArrivalTopics.has(topic)) {
-                client.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals.subscribe(topic, this._ipnsArrivalListener);
+                client.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals.subscribe({
+                    pubsubTopic: topic,
+                    listener: this._ipnsArrivalListener
+                });
                 this._subscribedIpnsArrivalTopics.add(topic);
             }
     }
@@ -513,7 +519,10 @@ export class CommunityClientsManager extends PKCClientsManager {
     private _clearIpnsArrivalSubscriptions() {
         if (this._ipnsArrivalClient && this._ipnsArrivalListener)
             for (const topic of this._subscribedIpnsArrivalTopics)
-                this._ipnsArrivalClient.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals.unsubscribe(topic, this._ipnsArrivalListener);
+                this._ipnsArrivalClient.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals.unsubscribe({
+                    pubsubTopic: topic,
+                    listener: this._ipnsArrivalListener
+                });
         this._subscribedIpnsArrivalTopics.clear();
         this._ipnsArrivalClient = undefined;
         this._pendingIpnsArrivalCids.clear();
@@ -527,14 +536,14 @@ export class CommunityClientsManager extends PKCClientsManager {
     // consumed immediately instead of being lost — unless that very updateOnce consumed it (the
     // loop's own cache write reports the record it is fetching before recording it as loaded, so
     // only this post-updateOnce re-check can drop it; see _consumePendingIpnsArrivals).
-    private async _sleepUntilIpnsArrivalOrTimeoutOrAbort(ms: number, signal?: AbortSignal): Promise<void> {
+    private async _sleepUntilIpnsArrivalOrTimeoutOrAbort({ ms, signal }: { ms: number; signal?: AbortSignal }): Promise<void> {
         if (this._consumePendingIpnsArrivals()) {
             // Arrival-driven cycle: the arrival IS the freshly cached record, so the resolve
             // that follows may serve it from the routing-layer cache.
             this._nextResolveRevalidatesNetwork = false;
             return;
         }
-        const { promise, wake } = interruptibleSleep(ms, signal);
+        const { promise, wake } = interruptibleSleep({ ms, signal });
         let wokenByArrival = false;
         const wakeForArrival = () => {
             wokenByArrival = true;

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -28,6 +28,7 @@ import {
     isStringDomain,
     pubsubTopicToDhtKey,
     sleepUntilTimeoutOrAbort,
+    interruptibleSleep,
     throwIfAbortSignalAborted,
     timestamp
 } from "../util.js";
@@ -66,13 +67,17 @@ export class CommunityClientsManager extends PKCClientsManager {
     _updateCidsAlreadyLoaded: LimitedSet<string> = new LimitedSet<string>(30); // we will keep track of the last 50 community update cids that we loaded
 
     // Event-driven update loop plumbing (issue #308), used only when the default record resolver
-    // is a libp2p-js client. _ipnsArrivalPending survives an arrival that lands while updateOnce
-    // is mid-flight, so the loop re-runs immediately instead of parking for a full safety-net
-    // period and missing the record it was just told about.
+    // is a libp2p-js client. Pending arrivals survive an arrival that lands while updateOnce is
+    // mid-flight, so the loop re-runs immediately instead of parking for a full safety-net
+    // period and missing the record it was just told about. Pending CIDs (not a boolean) because
+    // the loop's OWN direct-fetch cache write fires the arrival listener mid-updateOnce, before
+    // the consumed cid is recorded anywhere — only the park, running after updateOnce, can tell
+    // that self-arrival apart from a genuinely unconsumed push (see _consumePendingIpnsArrivals).
     private _subscribedIpnsArrivalTopics = new Set<string>();
     private _ipnsArrivalListener?: IpnsRecordArrivalListener;
     private _ipnsArrivalClient?: Libp2pJsClient;
-    private _ipnsArrivalPending = false;
+    private _pendingIpnsArrivalCids = new Set<string>();
+    private _pendingIpnsArrivalHopWake = false;
     private _wakeUpdateLoopForIpnsArrival?: () => void;
 
     constructor(community: CommunityClientsManager["_community"]) {
@@ -387,18 +392,36 @@ export class CommunityClientsManager extends PKCClientsManager {
     // Wake the update loop when a record NEWER than anything already consumed lands in the
     // routing-layer cache (gossip push, direct-fetch cache write, or fallback fetch — all
     // newer-only writers). A terminal record whose /ipfs/ value was already consumed is not
-    // news: communities re-publish records with a bumped sequence but an unchanged CID, and
-    // updateOnce's own direct-fetch cache write reports the record it just consumed, which
-    // this filter keeps from waking the loop it came from. An /ipns/ value is an intermediate
-    // hop of a delegated chain; a newer hop record always warrants a walk.
+    // news: communities re-publish records with a bumped sequence but an unchanged CID. The
+    // filter here only catches cids already recorded; the loop's OWN direct-fetch cache write
+    // fires mid-updateOnce, BEFORE the cid it is consuming reaches _updateCidsAlreadyLoaded
+    // (line ~770) or updateCid — that self-arrival passes here and is dropped by the park's
+    // post-updateOnce re-check instead (_consumePendingIpnsArrivals). An /ipns/ value is an
+    // intermediate hop of a delegated chain; a newer hop record always warrants a walk.
     private _onIpnsRecordArrival(arrival: IpnsRecordArrival) {
         const value = arrival.record.value;
-        if (isIpfsPath(value)) {
-            const cid = value.split("/")[2];
-            if (cid && (this._updateCidsAlreadyLoaded.has(cid) || this._community.updateCid === cid)) return;
-        }
-        this._ipnsArrivalPending = true;
+        const cid = isIpfsPath(value) ? value.split("/")[2] : undefined;
+        if (cid) {
+            if (this._updateCidsAlreadyLoaded.has(cid) || this._community.updateCid === cid) return;
+            this._pendingIpnsArrivalCids.add(cid);
+        } else this._pendingIpnsArrivalHopWake = true;
         this._wakeUpdateLoopForIpnsArrival?.();
+    }
+
+    // Consume the pending arrivals, dropping every cid the updateOnce that just ran consumed
+    // (or that any earlier cycle consumed — a gossip replay). Returns whether anything genuinely
+    // new remains, in which case the caller must skip its park and re-run updateOnce now. All
+    // pending state is cleared on a true return: the immediate updateOnce re-run is the reaction
+    // to it, and keeping it would re-trigger on the next park even when that re-run failed on a
+    // non-retriable record (the arrival will not re-fire — the record is already the newest
+    // cached one — so a stale entry here would spin the loop hot against a broken record).
+    private _consumePendingIpnsArrivals(): boolean {
+        for (const cid of this._pendingIpnsArrivalCids)
+            if (this._updateCidsAlreadyLoaded.has(cid) || this._community.updateCid === cid) this._pendingIpnsArrivalCids.delete(cid);
+        if (this._pendingIpnsArrivalCids.size === 0 && !this._pendingIpnsArrivalHopWake) return false;
+        this._pendingIpnsArrivalCids.clear();
+        this._pendingIpnsArrivalHopWake = false;
+        return true;
     }
 
     // Keep the arrival subscriptions in sync with the hops the last resolve walked: one topic
@@ -431,31 +454,22 @@ export class CommunityClientsManager extends PKCClientsManager {
                 this._ipnsArrivalClient.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals.unsubscribe(topic, this._ipnsArrivalListener);
         this._subscribedIpnsArrivalTopics.clear();
         this._ipnsArrivalClient = undefined;
-        this._ipnsArrivalPending = false;
+        this._pendingIpnsArrivalCids.clear();
+        this._pendingIpnsArrivalHopWake = false;
     }
 
     // Park until a pushed record arrival, the (jittered) safety-net timeout, or the stop signal,
-    // whichever fires first. The timer and abort listener are detached on EVERY outcome so
-    // nothing leaks on the long-lived stop signal (the issue #145 pattern); an arrival that
-    // fired while updateOnce was mid-flight is consumed immediately instead of being lost.
+    // whichever fires first (interruptibleSleep detaches its timer and abort listener on every
+    // outcome, the issue #145 pattern). An arrival that fired while updateOnce was mid-flight is
+    // consumed immediately instead of being lost — unless that very updateOnce consumed it (the
+    // loop's own cache write reports the record it is fetching before recording it as loaded, so
+    // only this post-updateOnce re-check can drop it; see _consumePendingIpnsArrivals).
     private async _sleepUntilIpnsArrivalOrTimeoutOrAbort(ms: number, signal?: AbortSignal): Promise<void> {
-        if (this._ipnsArrivalPending) {
-            this._ipnsArrivalPending = false;
-            return;
-        }
-        await new Promise<void>((resolve) => {
-            if (signal?.aborted) return resolve();
-            const settle = () => {
-                clearTimeout(timer);
-                signal?.removeEventListener("abort", settle);
-                if (this._wakeUpdateLoopForIpnsArrival === settle) this._wakeUpdateLoopForIpnsArrival = undefined;
-                resolve();
-            };
-            const timer = setTimeout(settle, ms);
-            signal?.addEventListener("abort", settle, { once: true });
-            this._wakeUpdateLoopForIpnsArrival = settle;
-        });
-        this._ipnsArrivalPending = false;
+        if (this._consumePendingIpnsArrivals()) return;
+        const { promise, wake } = interruptibleSleep(ms, signal);
+        this._wakeUpdateLoopForIpnsArrival = wake;
+        await promise;
+        if (this._wakeUpdateLoopForIpnsArrival === wake) this._wakeUpdateLoopForIpnsArrival = undefined;
     }
 
     // fetching community ipns here

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -483,20 +483,23 @@ export class CommunityClientsManager extends PKCClientsManager {
     // Keep the arrival subscriptions in sync with the hops the last resolve walked: one topic
     // per IPNS name in the chain, so a delegated community wakes on a push to ANY hop. Runs
     // before the FIRST updateOnce (so a record pushed mid-first-fetch is not missed) and after
-    // every updateOnce, because a key migration or delegation change swaps the hops. Before
-    // anything resolved, a non-domain address IS the IPNS name the first resolve will walk
-    // (fetchNewUpdateForCommunity seeds ipnsName from it verbatim), so it is watchable
-    // immediately; only a never-resolved domain has no derivable topic yet.
+    // every updateOnce, because a key migration or delegation change swaps the hops, and from
+    // wherever else the identity is decided (_resyncIpnsArrivalSubscriptionsIfArmed). Before
+    // anything resolved, the name the first resolve will walk is derivable for every instance
+    // but a never-resolved domain: the pinned publicKey (_pinnedIpnsName) or, failing that, a
+    // non-domain address verbatim, exactly as fetchNewUpdateForCommunity seeds ipnsName.
     private _syncIpnsArrivalSubscriptions(client: Libp2pJsClient) {
         if (!this._ipnsArrivalListener) this._ipnsArrivalListener = (arrival) => this._onIpnsRecordArrival(arrival);
         this._ipnsArrivalClient = client;
+        const preResolveIpnsName =
+            this._community.ipnsName ??
+            this._pinnedIpnsName() ??
+            (!isStringDomain(this._community.address) ? this._community.address : undefined);
         const ipnsNamesToWatch = this._community.ipnsHops?.length
             ? this._community.ipnsHops
-            : this._community.ipnsName
-              ? [this._community.ipnsName]
-              : !isStringDomain(this._community.address)
-                ? [this._community.address]
-                : [];
+            : preResolveIpnsName
+              ? [preResolveIpnsName]
+              : [];
         const desiredTopics = new Set(ipnsNamesToWatch.map(ipnsNameToIpnsOverPubsubTopic));
         for (const topic of this._subscribedIpnsArrivalTopics)
             if (!desiredTopics.has(topic)) {
@@ -514,6 +517,21 @@ export class CommunityClientsManager extends PKCClientsManager {
                 });
                 this._subscribedIpnsArrivalTopics.add(topic);
             }
+    }
+
+    // Re-derive the arrival subscriptions from the community's current identity, if the update
+    // loop armed them. The loop owns their lifetime (armed before its first cycle, cleared when
+    // it ends), so a one-shot fetch outside a loop must never create any.
+    private _resyncIpnsArrivalSubscriptionsIfArmed() {
+        if (!this._ipnsArrivalClient) return;
+        try {
+            this._syncIpnsArrivalSubscriptions(this._ipnsArrivalClient);
+        } catch (e) {
+            Logger("pkc-js:remote-community:update").error(
+                `Failed to sync IPNS record arrival subscriptions of community ${this._community.address}`,
+                e
+            );
+        }
     }
 
     private _clearIpnsArrivalSubscriptions() {
@@ -552,6 +570,15 @@ export class CommunityClientsManager extends PKCClientsManager {
         this._wakeUpdateLoopForIpnsArrival = wakeForArrival;
         await promise;
         if (this._wakeUpdateLoopForIpnsArrival === wakeForArrival) this._wakeUpdateLoopForIpnsArrival = undefined;
+        if (wokenByArrival) {
+            // The updateOnce that follows is the reaction to everything pending. Keeping the
+            // entries would fast-return the NEXT park into an identical re-run whenever that
+            // cycle fails without changing the chain (a hop arrival delegating beyond
+            // MAX_IPNS_HOPS is non-retriable and leaves ipnsHops as it was): two error events
+            // per push instead of one. Same rule _consumePendingIpnsArrivals applies on a hit.
+            this._pendingIpnsArrivalCids.clear();
+            this._pendingIpnsArrivalHopTargets.clear();
+        }
         // A timer-fired park end is the safety net's tick: it exists precisely for pushes that
         // never arrived, which the cache gate cannot observe — the next resolve must go to the
         // network (see _nextResolveRevalidatesNetwork), bounded by the revalidation floor so a
@@ -599,6 +626,41 @@ export class CommunityClientsManager extends PKCClientsManager {
         return [...chainKeys];
     }
 
+    // Switch the community to the key its name now resolves to: drop every piece of state that
+    // described the old key (it may be compromised), point the update loop's push channel at
+    // the new key, and restart the in-flight fetch.
+    private _applyKeyMigration({ communityName, newPublicKey }: { communityName: string; newPublicKey: string }) {
+        const log = Logger("pkc-js:community-client-manager:_applyKeyMigration");
+        log("Key migration detected for", communityName, "old:", this._community.publicKey, "new:", newPublicKey);
+        const previousPublicKey = this._community.publicKey;
+        const error = new PKCError("ERR_COMMUNITY_NAME_RESOLVES_TO_DIFFERENT_PUBLIC_KEY", {
+            communityName,
+            previousPublicKey,
+            newPublicKey
+        });
+
+        // Clear all data immediately (old data may be from compromised key)
+        this._community._clearDataForKeyMigration(newPublicKey);
+        this._updateCidsAlreadyLoaded.clear();
+        this._community.nameResolved = true;
+        // The pending arrivals describe the old key's records, and with the loaded set and
+        // updateCid just cleared nothing downstream filters them (a wasted old-key cycle). The
+        // loop must also watch the NEW key's topic from now on, not from when its record is
+        // first fetched: until then an old-key republish would keep waking it (issue #308).
+        this._pendingIpnsArrivalCids.clear();
+        this._pendingIpnsArrivalHopTargets.clear();
+        this._resyncIpnsArrivalSubscriptionsIfArmed();
+
+        // Abort in-flight fetch (using old key) by aborting the stop controller,
+        // then immediately create a new one so the update loop continues.
+        this._community._abortStopOperations("Key migration: name resolved to different public key");
+        this._community._createStopAbortController();
+
+        // Emit update so UI drops stale data right away
+        this._community.emit("update", this._community);
+        this._community.emit("error", error);
+    }
+
     private _resolveNameInBackground(name: string) {
         const log = Logger("pkc-js:community-client-manager:_resolveNameInBackground");
         const setNameResolvedAndEmitUpdate = (newNameResolved: boolean) => {
@@ -634,27 +696,7 @@ export class CommunityClientsManager extends PKCClientsManager {
                     }
                     // Key change detected: name now points to a different key.
                     // Most likely: cached publicKey is stale after community key migration.
-                    log("Key migration detected for", name, "old:", this._community.publicKey, "new:", resolved);
-                    const previousPublicKey = this._community.publicKey;
-                    const error = new PKCError("ERR_COMMUNITY_NAME_RESOLVES_TO_DIFFERENT_PUBLIC_KEY", {
-                        communityName: name,
-                        previousPublicKey,
-                        newPublicKey: resolved
-                    });
-
-                    // Clear all data immediately (old data may be from compromised key)
-                    this._community._clearDataForKeyMigration(resolved);
-                    this._updateCidsAlreadyLoaded.clear();
-                    this._community.nameResolved = true;
-
-                    // Abort in-flight fetch (using old key) by aborting the stop controller,
-                    // then immediately create a new one so the update loop continues.
-                    this._community._abortStopOperations("Key migration: name resolved to different public key");
-                    this._community._createStopAbortController();
-
-                    // Emit update so UI drops stale data right away
-                    this._community.emit("update", this._community);
-                    this._community.emit("error", error);
+                    this._applyKeyMigration({ communityName: name, newPublicKey: resolved });
                 } else if (resolved) {
                     setNameResolvedAndEmitUpdate(true);
                 }
@@ -705,22 +747,34 @@ export class CommunityClientsManager extends PKCClientsManager {
         });
     }
 
+    // The IPNS name every fetch pins to WITHOUT resolving anything, once one is known: a
+    // publicKey given alongside a domain address, a loaded anchor claim, or a verified name.
+    // A record with an anchor claim routes through the identity (the anchor chain) no matter
+    // how the instance was addressed (#257): the anchor is the rotation-safe pointer, so a
+    // reader must never stay pinned to the minter it happened to reach the record through.
+    // Shared by fetchNewUpdateForCommunity and the arrival subscription derivation so a
+    // domain+publicKey community is watchable before its first resolve, like a raw-key one.
+    private _pinnedIpnsName(): string | undefined {
+        const isDomain = isStringDomain(this._community.address);
+        const hasAnchorClaim = Boolean(this._community.anchor);
+        if (
+            this._community.publicKey &&
+            (isDomain || hasAnchorClaim || (!isDomain && this._community.name && this._community.nameResolved === true))
+        )
+            return this._community.publicKey;
+        return undefined;
+    }
+
     async fetchNewUpdateForCommunity(communityAddress: string): Promise<ResultOfFetchingCommunity> {
         return this._withInflightCommunityFetch(communityAddress, async () => {
             let ipnsName: string | null;
             const isDomain = isStringDomain(communityAddress);
 
-            // A record with an anchor claim routes through the identity (the anchor chain) no matter
-            // how the instance was addressed (#257): the anchor is the rotation-safe pointer, so a
-            // reader must never stay pinned to the minter it happened to reach the record through.
-            const hasAnchorClaim = Boolean(this._community.anchor);
-            if (
-                this._community.publicKey &&
-                (isDomain || hasAnchorClaim || (!isDomain && this._community.name && this._community.nameResolved === true))
-            ) {
+            const pinnedIpnsName = this._pinnedIpnsName();
+            if (pinnedIpnsName) {
                 // Once a domain has been verified against a public key, keep fetching through the current public key
                 // even if the immutable address on the instance is a raw IPNS key.
-                ipnsName = this._community.publicKey;
+                ipnsName = pinnedIpnsName;
                 if (isDomain) this._resolveNameInBackground(communityAddress);
             } else {
                 // Name only or publicKey only: use existing resolution flow
@@ -748,6 +802,10 @@ export class CommunityClientsManager extends PKCClientsManager {
                 this._community.ipnsHops = [ipnsName];
                 this._community.ipnsPubsubTopic = ipnsNameToIpnsOverPubsubTopic(ipnsName);
                 this._community.ipnsPubsubTopicRoutingCid = pubsubTopicToDhtKey(this._community.ipnsPubsubTopic);
+                // A freshly resolved domain now has a watchable topic: arm it for the rest of this
+                // cycle instead of only after updateOnce returns, so a record pushed while the
+                // cycle fetches and verifies is recorded rather than dropped at the source.
+                this._resyncIpnsArrivalSubscriptionsIfArmed();
             }
 
             if (this._community.updateCid) this._updateCidsAlreadyLoaded.add(this._community.updateCid);
@@ -820,6 +878,11 @@ export class CommunityClientsManager extends PKCClientsManager {
         // 0.43's default) instead of the max(updateInterval, revalidation floor) the safety net
         // promises. No-op for the kubo-RPC resolver, which always resolves with nocache: true.
         const forceNetworkRevalidation = this._nextResolveRevalidatesNetwork;
+        // Consumed by the cycle's FIRST attempt only: updateOnce retries this fetch (forever,
+        // with backoff) on retriable errors such as a CID fetch timeout after a successful
+        // resolve, and those attempts must ride the cache as the 1s poll's retries did instead
+        // of re-resolving over the network on every backoff step.
+        this._nextResolveRevalidatesNetwork = false;
         if (forceNetworkRevalidation) this._lastForcedIpnsNetworkRevalidationAtMs = Date.now();
         const { cid: latestCommunityCid, ipnsHops } = await this.resolveIpnsToCidP2P(ipnsName, {
             timeoutMs: this._pkc._timeouts["community-ipns"],

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -46,6 +46,8 @@ import { CID } from "multiformats/cid"; // re-sourced from kubo-rpc-client (iden
 import { getAuthorNameFromRuntime } from "../publications/publication-author.js";
 
 import { type CommunityGatewayFetch, selectWinningGatewayCommunity } from "./community-gateway-selection.js";
+import type { Libp2pJsClient } from "../helia/libp2pjsClient.js";
+import type { IpnsRecordArrival, IpnsRecordArrivalListener } from "../helia/types.js";
 
 export const MAX_FILE_SIZE_BYTES_FOR_COMMUNITY_IPFS = 1024 * 1024; // 1mb
 
@@ -62,6 +64,16 @@ export class CommunityClientsManager extends PKCClientsManager {
     private _suppressUpdatingStateForNameResolution = 0;
     _ipnsLoadingOperation?: RetryOperation = undefined;
     _updateCidsAlreadyLoaded: LimitedSet<string> = new LimitedSet<string>(30); // we will keep track of the last 50 community update cids that we loaded
+
+    // Event-driven update loop plumbing (issue #308), used only when the default record resolver
+    // is a libp2p-js client. _ipnsArrivalPending survives an arrival that lands while updateOnce
+    // is mid-flight, so the loop re-runs immediately instead of parking for a full safety-net
+    // period and missing the record it was just told about.
+    private _subscribedIpnsArrivalTopics = new Set<string>();
+    private _ipnsArrivalListener?: IpnsRecordArrivalListener;
+    private _ipnsArrivalClient?: Libp2pJsClient;
+    private _ipnsArrivalPending = false;
+    private _wakeUpdateLoopForIpnsArrival?: () => void;
 
     constructor(community: CommunityClientsManager["_community"]) {
         super(community._pkc);
@@ -326,7 +338,15 @@ export class CommunityClientsManager extends PKCClientsManager {
 
         const areWeConnectedToKuboOrHelia =
             Object.keys(this._pkc.clients.kuboRpcClients).length > 0 || Object.keys(this._pkc.clients.libp2pJsClients).length > 0;
-        const updateInterval = areWeConnectedToKuboOrHelia ? 1000 : this._pkc.updateInterval; // if we're on helia or kubo we should resolve IPNS every second
+        const defaultIpfsClient = areWeConnectedToKuboOrHelia ? this.getDefaultKuboRpcClientOrHelia() : undefined;
+        // Push-driven only for the libp2p-js resolver (issue #308): its routing-layer cache is
+        // fed by gossipsub (issue #301), so a localStore write IS the "new record arrived"
+        // signal, and the loop only needs a slow jittered safety-net poll for pushes it missed
+        // (mesh partition, record published while we had no subscribers). The kubo-RPC resolver
+        // keeps the 1s poll: kubo's namesys cache is not observable from here, so pkc has no
+        // push signal for it yet (issue #308 tracks giving it the same treatment); gateways
+        // already poll at pkc.updateInterval.
+        const defaultLibp2pJsClient = defaultIpfsClient && "_helia" in defaultIpfsClient ? defaultIpfsClient : undefined;
 
         while (this._community.state === "updating" && !this._community._getStopAbortSignal()?.aborted) {
             try {
@@ -334,12 +354,26 @@ export class CommunityClientsManager extends PKCClientsManager {
             } catch (e) {
                 log.error(`Failed to update community ${this._community.address} for this iteration, will retry later`, e);
             } finally {
-                // Re-read the stop signal each iteration; sleepUntilTimeoutOrAbort detaches its abort
-                // listener on both outcomes so it never leaks on the long-lived signal (see issue #145).
-                await sleepUntilTimeoutOrAbort(updateInterval, this._community._getStopAbortSignal());
+                // Re-read the stop signal each iteration; both waits detach their listeners on
+                // every outcome so nothing leaks on the long-lived signal (see issue #145).
+                if (defaultLibp2pJsClient) {
+                    try {
+                        this._syncIpnsArrivalSubscriptions(defaultLibp2pJsClient);
+                    } catch (e) {
+                        log.error(`Failed to sync IPNS record arrival subscriptions of community ${this._community.address}`, e);
+                    }
+                    // Jittered per iteration so a directory of communities started together does
+                    // not run its safety-net polls in lockstep (issue #307).
+                    const safetyNetMs = this._pkc.updateInterval * (0.75 + Math.random() * 0.5);
+                    await this._sleepUntilIpnsArrivalOrTimeoutOrAbort(safetyNetMs, this._community._getStopAbortSignal());
+                } else {
+                    const updateInterval = areWeConnectedToKuboOrHelia ? 1000 : this._pkc.updateInterval; // if we're on kubo we should resolve IPNS every second
+                    await sleepUntilTimeoutOrAbort(updateInterval, this._community._getStopAbortSignal());
+                }
             }
         }
 
+        this._clearIpnsArrivalSubscriptions();
         this._community._clearStopAbortController();
         log("Community", this._community.address, "is no longer updating");
     }
@@ -347,6 +381,81 @@ export class CommunityClientsManager extends PKCClientsManager {
     async stopUpdatingLoop() {
         this._ipnsLoadingOperation?.stop();
         this._updateCidsAlreadyLoaded.clear();
+        this._clearIpnsArrivalSubscriptions();
+    }
+
+    // Wake the update loop when a record NEWER than anything already consumed lands in the
+    // routing-layer cache (gossip push, direct-fetch cache write, or fallback fetch — all
+    // newer-only writers). A terminal record whose /ipfs/ value was already consumed is not
+    // news: communities re-publish records with a bumped sequence but an unchanged CID, and
+    // updateOnce's own direct-fetch cache write reports the record it just consumed, which
+    // this filter keeps from waking the loop it came from. An /ipns/ value is an intermediate
+    // hop of a delegated chain; a newer hop record always warrants a walk.
+    private _onIpnsRecordArrival(arrival: IpnsRecordArrival) {
+        const value = arrival.record.value;
+        if (isIpfsPath(value)) {
+            const cid = value.split("/")[2];
+            if (cid && (this._updateCidsAlreadyLoaded.has(cid) || this._community.updateCid === cid)) return;
+        }
+        this._ipnsArrivalPending = true;
+        this._wakeUpdateLoopForIpnsArrival?.();
+    }
+
+    // Keep the arrival subscriptions in sync with the hops the last resolve walked: one topic
+    // per IPNS name in the chain, so a delegated community wakes on a push to ANY hop. Runs
+    // after every updateOnce because a key migration or delegation change swaps the hops.
+    private _syncIpnsArrivalSubscriptions(client: Libp2pJsClient) {
+        if (!this._ipnsArrivalListener) this._ipnsArrivalListener = (arrival) => this._onIpnsRecordArrival(arrival);
+        this._ipnsArrivalClient = client;
+        const ipnsNamesToWatch = this._community.ipnsHops?.length
+            ? this._community.ipnsHops
+            : this._community.ipnsName
+              ? [this._community.ipnsName]
+              : [];
+        const desiredTopics = new Set(ipnsNamesToWatch.map(ipnsNameToIpnsOverPubsubTopic));
+        for (const topic of this._subscribedIpnsArrivalTopics)
+            if (!desiredTopics.has(topic)) {
+                client.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals.unsubscribe(topic, this._ipnsArrivalListener);
+                this._subscribedIpnsArrivalTopics.delete(topic);
+            }
+        for (const topic of desiredTopics)
+            if (!this._subscribedIpnsArrivalTopics.has(topic)) {
+                client.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals.subscribe(topic, this._ipnsArrivalListener);
+                this._subscribedIpnsArrivalTopics.add(topic);
+            }
+    }
+
+    private _clearIpnsArrivalSubscriptions() {
+        if (this._ipnsArrivalClient && this._ipnsArrivalListener)
+            for (const topic of this._subscribedIpnsArrivalTopics)
+                this._ipnsArrivalClient.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals.unsubscribe(topic, this._ipnsArrivalListener);
+        this._subscribedIpnsArrivalTopics.clear();
+        this._ipnsArrivalClient = undefined;
+        this._ipnsArrivalPending = false;
+    }
+
+    // Park until a pushed record arrival, the (jittered) safety-net timeout, or the stop signal,
+    // whichever fires first. The timer and abort listener are detached on EVERY outcome so
+    // nothing leaks on the long-lived stop signal (the issue #145 pattern); an arrival that
+    // fired while updateOnce was mid-flight is consumed immediately instead of being lost.
+    private async _sleepUntilIpnsArrivalOrTimeoutOrAbort(ms: number, signal?: AbortSignal): Promise<void> {
+        if (this._ipnsArrivalPending) {
+            this._ipnsArrivalPending = false;
+            return;
+        }
+        await new Promise<void>((resolve) => {
+            if (signal?.aborted) return resolve();
+            const settle = () => {
+                clearTimeout(timer);
+                signal?.removeEventListener("abort", settle);
+                if (this._wakeUpdateLoopForIpnsArrival === settle) this._wakeUpdateLoopForIpnsArrival = undefined;
+                resolve();
+            };
+            const timer = setTimeout(settle, ms);
+            signal?.addEventListener("abort", settle, { once: true });
+            this._wakeUpdateLoopForIpnsArrival = settle;
+        });
+        this._ipnsArrivalPending = false;
     }
 
     // fetching community ipns here

--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -69,15 +69,22 @@ export class CommunityClientsManager extends PKCClientsManager {
     // Event-driven update loop plumbing (issue #308), used only when the default record resolver
     // is a libp2p-js client. Pending arrivals survive an arrival that lands while updateOnce is
     // mid-flight, so the loop re-runs immediately instead of parking for a full safety-net
-    // period and missing the record it was just told about. Pending CIDs (not a boolean) because
-    // the loop's OWN direct-fetch cache write fires the arrival listener mid-updateOnce, before
-    // the consumed cid is recorded anywhere — only the park, running after updateOnce, can tell
-    // that self-arrival apart from a genuinely unconsumed push (see _consumePendingIpnsArrivals).
+    // period and missing the record it was just told about. Pending CIDs / hop targets (not a
+    // boolean) because the loop's OWN direct-fetch cache writes fire the arrival listener
+    // mid-updateOnce, before the consumed cid (or walked hop) is recorded anywhere — only the
+    // park, running after updateOnce, can tell those self-arrivals apart from a genuinely
+    // unconsumed push (see _consumePendingIpnsArrivals).
     private _subscribedIpnsArrivalTopics = new Set<string>();
     private _ipnsArrivalListener?: IpnsRecordArrivalListener;
     private _ipnsArrivalClient?: Libp2pJsClient;
     private _pendingIpnsArrivalCids = new Set<string>();
-    private _pendingIpnsArrivalHopWake = false;
+    private _pendingIpnsArrivalHopTargets = new Set<string>();
+    // Set when the park ends by its safety-net timer rather than an arrival wake: the tick
+    // exists to catch pushes that never arrived, which the routing-layer cache gate by
+    // definition cannot observe (the cache still holds the old record, fresh inside its ttl),
+    // so the resolve that follows must revalidate against the network (nocache). An
+    // arrival-woken cycle keeps the cache read — the arrival IS the newly cached record.
+    private _nextResolveRevalidatesNetwork = false;
     private _wakeUpdateLoopForIpnsArrival?: () => void;
 
     constructor(community: CommunityClientsManager["_community"]) {
@@ -353,6 +360,25 @@ export class CommunityClientsManager extends PKCClientsManager {
         // already poll at pkc.updateInterval.
         const defaultLibp2pJsClient = defaultIpfsClient && "_helia" in defaultIpfsClient ? defaultIpfsClient : undefined;
 
+        // Arm the arrival subscription BEFORE the first updateOnce: the first cycle spans the
+        // resolve, the community IPFS fetch, parsing and signature verification — seconds on a
+        // cold client — and a record pushed while it is mid-flight would otherwise fire no
+        // listener and be recorded nowhere, waiting for the first safety-net tick (45-75s at
+        // the production interval) where the old 1s poll picked it up in a second. The topic is
+        // derivable pre-resolve for every non-domain address (ipnsName === address, see
+        // _syncIpnsArrivalSubscriptions' fallback); a never-resolved domain address arms right
+        // after its first updateOnce in the finally below, as before.
+        if (defaultLibp2pJsClient) {
+            try {
+                this._syncIpnsArrivalSubscriptions(defaultLibp2pJsClient);
+            } catch (e) {
+                log.error(
+                    `Failed to arm IPNS record arrival subscriptions of community ${this._community.address} before its first update`,
+                    e
+                );
+            }
+        }
+
         while (this._community.state === "updating" && !this._community._getStopAbortSignal()?.aborted) {
             try {
                 await this.updateOnce();
@@ -391,42 +417,58 @@ export class CommunityClientsManager extends PKCClientsManager {
 
     // Wake the update loop when a record NEWER than anything already consumed lands in the
     // routing-layer cache (gossip push, direct-fetch cache write, or fallback fetch — all
-    // newer-only writers). A terminal record whose /ipfs/ value was already consumed is not
-    // news: communities re-publish records with a bumped sequence but an unchanged CID. The
-    // filter here only catches cids already recorded; the loop's OWN direct-fetch cache write
-    // fires mid-updateOnce, BEFORE the cid it is consuming reaches _updateCidsAlreadyLoaded
-    // (line ~770) or updateCid — that self-arrival passes here and is dropped by the park's
-    // post-updateOnce re-check instead (_consumePendingIpnsArrivals). An /ipns/ value is an
-    // intermediate hop of a delegated chain; a newer hop record always warrants a walk.
+    // newer-only writers). A record whose value was already consumed is not news: communities
+    // re-publish records with a bumped sequence but an unchanged value — an unchanged /ipfs/
+    // CID for a terminal record, an unchanged /ipns/ delegation target for an anchor's record
+    // (kubo republishes on a timer, so an undiscriminating hop wake would re-run updateOnce at
+    // the anchor's republish cadence — the #308 churn — on every delegated community). The
+    // filters here only catch values already recorded; the loop's OWN direct-fetch cache
+    // writes fire mid-updateOnce, BEFORE the cid it is consuming reaches
+    // _updateCidsAlreadyLoaded (line ~790) / updateCid or the walked hop reaches ipnsHops —
+    // those self-arrivals pass here and are dropped by the park's post-updateOnce re-check
+    // instead (_consumePendingIpnsArrivals). A hop record delegating OUTSIDE the walked chain
+    // is a delegation change and always warrants a walk. Any other value shape is unsupported
+    // (resolveIpnsToCidP2P would throw on it), so it cannot advance the loop and wakes nothing.
     private _onIpnsRecordArrival(arrival: IpnsRecordArrival) {
         const value = arrival.record.value;
-        const cid = isIpfsPath(value) ? value.split("/")[2] : undefined;
-        if (cid) {
+        if (isIpfsPath(value)) {
+            const cid = value.split("/")[2];
             if (this._updateCidsAlreadyLoaded.has(cid) || this._community.updateCid === cid) return;
             this._pendingIpnsArrivalCids.add(cid);
-        } else this._pendingIpnsArrivalHopWake = true;
+        } else if (isIpnsPath(value)) {
+            const hopTarget = value.split("/")[2];
+            if (this._community.ipnsHops?.includes(hopTarget)) return;
+            this._pendingIpnsArrivalHopTargets.add(hopTarget);
+        } else return;
         this._wakeUpdateLoopForIpnsArrival?.();
     }
 
     // Consume the pending arrivals, dropping every cid the updateOnce that just ran consumed
-    // (or that any earlier cycle consumed — a gossip replay). Returns whether anything genuinely
-    // new remains, in which case the caller must skip its park and re-run updateOnce now. All
-    // pending state is cleared on a true return: the immediate updateOnce re-run is the reaction
-    // to it, and keeping it would re-trigger on the next park even when that re-run failed on a
-    // non-retriable record (the arrival will not re-fire — the record is already the newest
-    // cached one — so a stale entry here would spin the loop hot against a broken record).
+    // and every hop target on the chain it walked (or that any earlier cycle consumed/walked —
+    // a gossip replay). Returns whether anything genuinely new remains, in which case the
+    // caller must skip its park and re-run updateOnce now. All pending state is cleared on a
+    // true return: the immediate updateOnce re-run is the reaction to it, and keeping it would
+    // re-trigger on the next park even when that re-run failed on a non-retriable record (the
+    // arrival will not re-fire — the record is already the newest cached one — so a stale
+    // entry here would spin the loop hot against a broken record).
     private _consumePendingIpnsArrivals(): boolean {
         for (const cid of this._pendingIpnsArrivalCids)
             if (this._updateCidsAlreadyLoaded.has(cid) || this._community.updateCid === cid) this._pendingIpnsArrivalCids.delete(cid);
-        if (this._pendingIpnsArrivalCids.size === 0 && !this._pendingIpnsArrivalHopWake) return false;
+        for (const hopTarget of this._pendingIpnsArrivalHopTargets)
+            if (this._community.ipnsHops?.includes(hopTarget)) this._pendingIpnsArrivalHopTargets.delete(hopTarget);
+        if (this._pendingIpnsArrivalCids.size === 0 && this._pendingIpnsArrivalHopTargets.size === 0) return false;
         this._pendingIpnsArrivalCids.clear();
-        this._pendingIpnsArrivalHopWake = false;
+        this._pendingIpnsArrivalHopTargets.clear();
         return true;
     }
 
     // Keep the arrival subscriptions in sync with the hops the last resolve walked: one topic
     // per IPNS name in the chain, so a delegated community wakes on a push to ANY hop. Runs
-    // after every updateOnce because a key migration or delegation change swaps the hops.
+    // before the FIRST updateOnce (so a record pushed mid-first-fetch is not missed) and after
+    // every updateOnce, because a key migration or delegation change swaps the hops. Before
+    // anything resolved, a non-domain address IS the IPNS name the first resolve will walk
+    // (fetchNewUpdateForCommunity seeds ipnsName from it verbatim), so it is watchable
+    // immediately; only a never-resolved domain has no derivable topic yet.
     private _syncIpnsArrivalSubscriptions(client: Libp2pJsClient) {
         if (!this._ipnsArrivalListener) this._ipnsArrivalListener = (arrival) => this._onIpnsRecordArrival(arrival);
         this._ipnsArrivalClient = client;
@@ -434,7 +476,9 @@ export class CommunityClientsManager extends PKCClientsManager {
             ? this._community.ipnsHops
             : this._community.ipnsName
               ? [this._community.ipnsName]
-              : [];
+              : !isStringDomain(this._community.address)
+                ? [this._community.address]
+                : [];
         const desiredTopics = new Set(ipnsNamesToWatch.map(ipnsNameToIpnsOverPubsubTopic));
         for (const topic of this._subscribedIpnsArrivalTopics)
             if (!desiredTopics.has(topic)) {
@@ -455,7 +499,8 @@ export class CommunityClientsManager extends PKCClientsManager {
         this._subscribedIpnsArrivalTopics.clear();
         this._ipnsArrivalClient = undefined;
         this._pendingIpnsArrivalCids.clear();
-        this._pendingIpnsArrivalHopWake = false;
+        this._pendingIpnsArrivalHopTargets.clear();
+        this._nextResolveRevalidatesNetwork = false;
     }
 
     // Park until a pushed record arrival, the (jittered) safety-net timeout, or the stop signal,
@@ -465,11 +510,26 @@ export class CommunityClientsManager extends PKCClientsManager {
     // loop's own cache write reports the record it is fetching before recording it as loaded, so
     // only this post-updateOnce re-check can drop it; see _consumePendingIpnsArrivals).
     private async _sleepUntilIpnsArrivalOrTimeoutOrAbort(ms: number, signal?: AbortSignal): Promise<void> {
-        if (this._consumePendingIpnsArrivals()) return;
+        if (this._consumePendingIpnsArrivals()) {
+            // Arrival-driven cycle: the arrival IS the freshly cached record, so the resolve
+            // that follows may serve it from the routing-layer cache.
+            this._nextResolveRevalidatesNetwork = false;
+            return;
+        }
         const { promise, wake } = interruptibleSleep(ms, signal);
-        this._wakeUpdateLoopForIpnsArrival = wake;
+        let wokenByArrival = false;
+        const wakeForArrival = () => {
+            wokenByArrival = true;
+            wake();
+        };
+        this._wakeUpdateLoopForIpnsArrival = wakeForArrival;
         await promise;
-        if (this._wakeUpdateLoopForIpnsArrival === wake) this._wakeUpdateLoopForIpnsArrival = undefined;
+        if (this._wakeUpdateLoopForIpnsArrival === wakeForArrival) this._wakeUpdateLoopForIpnsArrival = undefined;
+        // A timer-fired park end is the safety net's tick: it exists precisely for pushes that
+        // never arrived, which the cache gate cannot observe — the next resolve must go to the
+        // network (see _nextResolveRevalidatesNetwork). The abort outcome also lands here, but
+        // the loop exits before another resolve runs, so the flag value is moot.
+        this._nextResolveRevalidatesNetwork = !wokenByArrival;
     }
 
     // fetching community ipns here
@@ -726,7 +786,13 @@ export class CommunityClientsManager extends PKCClientsManager {
         } else this.updateKuboRpcState("fetching-ipns", kuboRpcOrHelia.url);
         const { cid: latestCommunityCid, ipnsHops } = await this.resolveIpnsToCidP2P(ipnsName, {
             timeoutMs: this._pkc._timeouts["community-ipns"],
-            abortSignal: this._community._getStopAbortSignal()
+            abortSignal: this._community._getStopAbortSignal(),
+            // A cycle woken by the safety-net timer (not by an arrival) must revalidate on the
+            // network: the routing-layer cache gate cannot observe a push that never arrived,
+            // and would otherwise serve the stale record for its whole remaining ttl (300s at
+            // kubo 0.43's default) instead of the one updateInterval the safety net promises.
+            // No-op for the kubo-RPC resolver, which always resolves with nocache: true.
+            ...(this._nextResolveRevalidatesNetwork ? { nocache: true } : {})
         });
         // ipnsHops[0] is the anchor (== ipnsName), ipnsHops.at(-1) is the terminal name whose
         // record points at the CID, i.e. the key that signs the community content. For a

--- a/src/community/remote-community.ts
+++ b/src/community/remote-community.ts
@@ -484,6 +484,13 @@ export class RemoteCommunity extends TypedEmitter<CommunityEvents> implements Om
         // Update to new key and IPNS routing props
         this.publicKey = newPublicKey;
         this.ipnsName = newPublicKey;
+        // The resolved delegation chain described the OLD key's record; keeping it would leave the
+        // update loop's IPNS arrival subscriptions (derived from ipnsHops, preferred over ipnsName)
+        // watching the old key's gossip topics, so the migrated key's record pushes could not wake
+        // the loop (issue #308). Default to the single-hop chain, the same shape
+        // fetchNewUpdateForCommunity seeds for a fresh ipnsName; the next successful resolve
+        // replaces it with the full walked chain.
+        this.ipnsHops = [newPublicKey];
         this.ipnsPubsubTopic = ipnsNameToIpnsOverPubsubTopic(newPublicKey);
         this.ipnsPubsubTopicRoutingCid = pubsubTopicToDhtKey(this.ipnsPubsubTopic);
         this._assertHasIdentity();

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -4,7 +4,6 @@ import { withBitswap } from "@helia/bitswap";
 import { ipns } from "@helia/ipns";
 import { unmarshalIPNSRecord, multihashToIPNSRoutingKey } from "ipns";
 import type { IPNSRecord } from "ipns";
-import { toString as uint8ArrayToString } from "uint8arrays/to-string";
 import { ipnsValidator } from "ipns/validator";
 import { gossipsub } from "@libp2p/gossipsub";
 import { identify } from "@libp2p/identify";
@@ -39,7 +38,7 @@ import {
 } from "./util.js";
 import type { IpnsPubsubLocalStore } from "./util.js";
 import { createDefaultDialTransportGater } from "./dial-transport-filter.js";
-import { ipnsNameToIpnsOverPubsubTopic } from "../util.js";
+import { binaryKeyToPubsubTopic, ipnsNameToIpnsOverPubsubTopic } from "../util.js";
 
 const log = Logger("pkc-js:libp2p-js");
 
@@ -434,13 +433,15 @@ export async function createLibp2pJsClientOrUseExistingOne(
         // locally", with none of the ordering hazards of listening to raw pubsub messages
         // (which fire before handleRecord has validated and cached the record). The topic key is
         // derivable from the routing key alone: routingKey = '/ipns/' + multihash bytes and the
-        // gossip topic is '/record/' + base64url(routingKey) (see ipnsNameToIpnsOverPubsubTopic).
-        // A listener failure or an unmarshal failure must never fail the put itself.
+        // gossip topic is binaryKeyToPubsubTopic(routingKey) — the same encoding the subscriber
+        // side derives through ipnsNameToIpnsOverPubsubTopic, so publisher and subscriber cannot
+        // silently diverge. A listener failure or an unmarshal failure must never fail the put
+        // itself.
         const ipnsRecordArrivalListeners = new Map<string, Set<IpnsRecordArrivalListener>>();
         const originalLocalStorePut = ipnsPubsubLocalStore.put.bind(ipnsPubsubLocalStore);
         ipnsPubsubLocalStore.put = async (routingKey, marshalledRecord, options) => {
             await originalLocalStorePut(routingKey, marshalledRecord, options);
-            const pubsubTopic = "/record/" + uint8ArrayToString(routingKey, "base64url");
+            const pubsubTopic = binaryKeyToPubsubTopic(routingKey);
             const listeners = ipnsRecordArrivalListeners.get(pubsubTopic);
             if (!listeners || listeners.size === 0) return;
             let record: IPNSRecord;

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -3,6 +3,8 @@ import { libp2pDefaults, withLibp2p } from "@helia/libp2p";
 import { withBitswap } from "@helia/bitswap";
 import { ipns } from "@helia/ipns";
 import { unmarshalIPNSRecord, multihashToIPNSRoutingKey } from "ipns";
+import type { IPNSRecord } from "ipns";
+import { toString as uint8ArrayToString } from "uint8arrays/to-string";
 import { ipnsValidator } from "ipns/validator";
 import { gossipsub } from "@libp2p/gossipsub";
 import { identify } from "@libp2p/identify";
@@ -22,7 +24,7 @@ import type { AddResult, NameResolveOptions as KuboNameResolveOptions } from "ku
 import type { IpfsHttpClientPubsubMessage, ParsedPKCOptions } from "../types.js";
 
 import { EventEmitter } from "events";
-import type { HeliaWithLibp2pPubsub } from "./types.js";
+import type { HeliaWithLibp2pPubsub, IpnsRecordArrivalListener } from "./types.js";
 import { PKCError } from "../pkc-error.js";
 import { Libp2pJsClient } from "./libp2pjsClient.js";
 import {
@@ -423,6 +425,39 @@ export async function createLibp2pJsClientOrUseExistingOne(
         // would re-fetch on every resolve once its record's ttl first expired. Bounded by the set
         // of IPNS names this helia instance resolves (communities the app follows).
         const ipnsRecordNetworkValidatedAtMs = new Map<string, number>();
+
+        // Push signal for IPNS names (issue #308): every accepted-newer record converges on the
+        // pubsub router's localStore.put — gossipsub delivery (handleRecord), the direct-fetch
+        // cache write (cacheIpnsRecordInPubsubLocalStore), and the fallback router.get() fetch
+        // all write through it, and none of them writes a record older than the cached one.
+        // Wrapping put therefore yields exactly "a newer record for this name is now held
+        // locally", with none of the ordering hazards of listening to raw pubsub messages
+        // (which fire before handleRecord has validated and cached the record). The topic key is
+        // derivable from the routing key alone: routingKey = '/ipns/' + multihash bytes and the
+        // gossip topic is '/record/' + base64url(routingKey) (see ipnsNameToIpnsOverPubsubTopic).
+        // A listener failure or an unmarshal failure must never fail the put itself.
+        const ipnsRecordArrivalListeners = new Map<string, Set<IpnsRecordArrivalListener>>();
+        const originalLocalStorePut = ipnsPubsubLocalStore.put.bind(ipnsPubsubLocalStore);
+        ipnsPubsubLocalStore.put = async (routingKey, marshalledRecord, options) => {
+            await originalLocalStorePut(routingKey, marshalledRecord, options);
+            const pubsubTopic = "/record/" + uint8ArrayToString(routingKey, "base64url");
+            const listeners = ipnsRecordArrivalListeners.get(pubsubTopic);
+            if (!listeners || listeners.size === 0) return;
+            let record: IPNSRecord;
+            try {
+                record = unmarshalIPNSRecord(marshalledRecord);
+            } catch (e) {
+                log.error("Failed to unmarshal a cached IPNS record for the arrival listeners of topic", pubsubTopic, e);
+                return;
+            }
+            for (const listener of [...listeners]) {
+                try {
+                    listener({ pubsubTopic, record });
+                } catch (e) {
+                    log.error("An IPNS record arrival listener threw for topic", pubsubTopic, e);
+                }
+            }
+        };
 
         // Side-channel awaitable warmup: gossipsub's pubsub.subscribe(topic) is sync and returns
         // void, so we can't make it awaitable without breaking @helia/ipns and other internal
@@ -873,6 +908,19 @@ export async function createLibp2pJsClientOrUseExistingOne(
             ): Promise<AddResult> {
                 throw Error("Helia 'add' is not supported at the moment in pkc-js API");
             },
+            ipnsRecordArrivals: {
+                subscribe: (pubsubTopic: string, listener: IpnsRecordArrivalListener) => {
+                    const listeners = ipnsRecordArrivalListeners.get(pubsubTopic) ?? new Set<IpnsRecordArrivalListener>();
+                    listeners.add(listener);
+                    ipnsRecordArrivalListeners.set(pubsubTopic, listeners);
+                },
+                unsubscribe: (pubsubTopic: string, listener: IpnsRecordArrivalListener) => {
+                    const listeners = ipnsRecordArrivalListeners.get(pubsubTopic);
+                    if (!listeners) return;
+                    listeners.delete(listener);
+                    if (listeners.size === 0) ipnsRecordArrivalListeners.delete(pubsubTopic);
+                }
+            },
             async stop(options) {
                 const clientFromMap = libp2pJsClients[pkcOptions.key];
                 if (!clientFromMap) return; // already been stopped
@@ -882,6 +930,10 @@ export async function createLibp2pJsClientOrUseExistingOne(
                     // Remove from the lookup map BEFORE awaiting helia.stop() so a concurrent
                     // createLibp2pJsClientOrUseExistingOne() can't grab a mid-stopping client.
                     delete libp2pJsClients[pkcOptions.key];
+
+                    // Update loops unsubscribe their own arrival listeners on stop; clearing here
+                    // covers loops torn down after the shared client's final release.
+                    ipnsRecordArrivalListeners.clear();
 
                     // Tear down the IPNS pubsub router's internal subscription state.
                     // PubSubIPNSRouting (@helia/ipns) implements Startable and tracks its own

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -910,12 +910,12 @@ export async function createLibp2pJsClientOrUseExistingOne(
                 throw Error("Helia 'add' is not supported at the moment in pkc-js API");
             },
             ipnsRecordArrivals: {
-                subscribe: (pubsubTopic: string, listener: IpnsRecordArrivalListener) => {
+                subscribe: ({ pubsubTopic, listener }: { pubsubTopic: string; listener: IpnsRecordArrivalListener }) => {
                     const listeners = ipnsRecordArrivalListeners.get(pubsubTopic) ?? new Set<IpnsRecordArrivalListener>();
                     listeners.add(listener);
                     ipnsRecordArrivalListeners.set(pubsubTopic, listeners);
                 },
-                unsubscribe: (pubsubTopic: string, listener: IpnsRecordArrivalListener) => {
+                unsubscribe: ({ pubsubTopic, listener }: { pubsubTopic: string; listener: IpnsRecordArrivalListener }) => {
                     const listeners = ipnsRecordArrivalListeners.get(pubsubTopic);
                     if (!listeners) return;
                     listeners.delete(listener);

--- a/src/helia/types.ts
+++ b/src/helia/types.ts
@@ -6,6 +6,17 @@ import type { PubsubRoutingComponents } from "@helia/ipns";
 import type { GossipSub } from "@libp2p/gossipsub";
 import type { Fetch } from "@libp2p/fetch";
 import type { Identify } from "@libp2p/identify";
+import type { IPNSRecord } from "ipns";
+
+// A validated IPNS record newer than the locally held one just landed in the routing-layer cache
+// for `pubsubTopic` — via a gossipsub push (handleRecord), the direct-fetch cache write, or a
+// fallback router.get() fetch. All three converge on the pubsub router's localStore.put, which is
+// where these arrivals are observed (issue #308).
+export interface IpnsRecordArrival {
+    pubsubTopic: string;
+    record: IPNSRecord;
+}
+export type IpnsRecordArrivalListener = (arrival: IpnsRecordArrival) => void;
 
 export interface HeliaWithKuboRpcClientFunctions extends Pick<NonNullable<KuboRpcClient["_client"]>, "add" | "cat" | "pubsub" | "stop"> {
     add: KuboRpcClient["_client"]["add"];
@@ -21,6 +32,14 @@ export interface HeliaWithKuboRpcClientFunctions extends Pick<NonNullable<KuboRp
     ): ReturnType<KuboRpcClient["_client"]["cat"]>;
     pubsub: KuboRpcClient["_client"]["pubsub"];
     stop: KuboRpcClient["_client"]["stop"];
+    // Push signal for IPNS names (issue #308), pkc-only with no kubo-rpc-client equivalent: the
+    // community update loop subscribes per IPNS pubsub topic to react to pushed records instead
+    // of polling name.resolve every second. Listeners fire AFTER the record is validated and
+    // persisted in the routing-layer cache, so a resolve issued from a listener observes it.
+    ipnsRecordArrivals: {
+        subscribe(pubsubTopic: string, listener: IpnsRecordArrivalListener): void;
+        unsubscribe(pubsubTopic: string, listener: IpnsRecordArrivalListener): void;
+    };
     // Test-only override of BITSWAP_SESSION_STALLED_GET_FAILOVER_MS, read by cat() at each block
     // get. The issue #189 guard test (at most one routing query per DAG) sets it beyond its own
     // timeout: on slow CI runners a block can legitimately stall, and the failover's broadcast

--- a/src/helia/types.ts
+++ b/src/helia/types.ts
@@ -37,8 +37,8 @@ export interface HeliaWithKuboRpcClientFunctions extends Pick<NonNullable<KuboRp
     // of polling name.resolve every second. Listeners fire AFTER the record is validated and
     // persisted in the routing-layer cache, so a resolve issued from a listener observes it.
     ipnsRecordArrivals: {
-        subscribe(pubsubTopic: string, listener: IpnsRecordArrivalListener): void;
-        unsubscribe(pubsubTopic: string, listener: IpnsRecordArrivalListener): void;
+        subscribe(args: { pubsubTopic: string; listener: IpnsRecordArrivalListener }): void;
+        unsubscribe(args: { pubsubTopic: string; listener: IpnsRecordArrivalListener }): void;
     };
     // Test-only override of BITSWAP_SESSION_STALLED_GET_FAILOVER_MS, read by cat() at each block
     // get. The issue #189 guard test (at most one routing query per DAG) sets it beyond its own

--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -870,6 +870,24 @@ export async function cacheIpnsRecordInPubsubLocalStore({
 // ipns-publishing.ts), so this matches what a well-formed community record would have carried.
 const DEFAULT_CACHED_IPNS_RECORD_TTL_MS = 60_000;
 
+// Deterministic per-name jitter over the cached record's serve window (issue #307). A directory
+// app fetches all N of its community records in the same second and they all carry the same ttl,
+// so without jitter all N cache entries expire in the same instant and every name misses the
+// cache in the same update-loop pass: N=64 launches 250-320 near-simultaneous /libp2p/fetch
+// streams against a 64-stream outbound cap, once per ttl window. Scaling each name's effective
+// ttl by a factor derived from its routing key (FNV-1a, uniform-ish in [0.75, 1.0)) de-correlates
+// the expiries while never serving a record beyond its own ttl. Deterministic per name on
+// purpose: a factor re-rolled per read would make freshness flappy and bias the effective ttl
+// toward the floor as reads accumulate.
+export function ipnsCacheTtlJitterFactor(routingKey: Uint8Array): number {
+    let hash = 0x811c9dc5;
+    for (let i = 0; i < routingKey.length; i++) {
+        hash ^= routingKey[i];
+        hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    return 0.75 + (hash / 0x1_0000_0000) * 0.25;
+}
+
 // Read the record cached at the pubsub routing layer and return it only while it may still be
 // served WITHOUT a network revalidation (issue #301). Freshness follows the IPNS spec's ttl
 // semantics: a record may be served from cache for `ttl` after it was last confirmed current.
@@ -904,7 +922,10 @@ export async function readFreshCachedIpnsRecordFromPubsubLocalStore({
     }
     const record = unmarshalIPNSRecord(recordBytes);
     const ttlMs = record.ttl !== undefined ? Number(record.ttl / 1_000_000n) : DEFAULT_CACHED_IPNS_RECORD_TTL_MS;
+    // Effective ttl is jittered per name (issue #307) so names cached together don't all miss
+    // the cache together; the factor only ever shortens the window, never extends it.
+    const effectiveTtlMs = ttlMs * ipnsCacheTtlJitterFactor(routingKey);
     const lastConfirmedCurrentAtMs = Math.max(created.getTime(), lastNetworkValidatedAtMs ?? 0);
-    if (Date.now() - lastConfirmedCurrentAtMs >= ttlMs) return undefined;
+    if (Date.now() - lastConfirmedCurrentAtMs >= effectiveTtlMs) return undefined;
     return record;
 }

--- a/src/test/test-util.ts
+++ b/src/test/test-util.ts
@@ -1683,7 +1683,12 @@ export async function createNewIpns() {
     // ONLY controls the helper's own post-publish name.resolve() sanity check (which syncs Kubo's
     // cache for RPC tests) — it does NOT change what name.publish does. Set it false when
     // publishing a hop whose target isn't resolvable yet, so that resolve check doesn't fail.
-    const publishToIpnsValue = async (value: string, opts?: { verifyResolves?: boolean }) => {
+    // `ttl` (kubo duration string, e.g. "10s") overrides kubo's default record ttl, which is 5
+    // MINUTES on kubo 0.43, not the 60s a LocalCommunity publishes (publishInterval * 3). The
+    // ttl bounds how long the libp2p-js resolver may serve a name from its routing-layer cache
+    // without revalidating (issue #301/#307), so any test that must observe a cache expiry
+    // inside its own timeout has to shorten it here instead of waiting out kubo's default.
+    const publishToIpnsValue = async (value: string, opts?: { verifyResolves?: boolean; ttl?: string }) => {
         const verifyResolves = opts?.verifyResolves ?? true;
         // Wrapped in retry because Kubo can transiently ETIMEDOUT in CI
         await new Promise<void>((resolve, reject) => {
@@ -1697,7 +1702,8 @@ export async function createNewIpns() {
                 try {
                     await ipfsClient._client.name.publish(value, {
                         key: signer.address,
-                        allowOffline: true
+                        allowOffline: true,
+                        ...(opts?.ttl ? { ttl: opts.ttl } : {})
                     });
                     resolve();
                 } catch (error) {
@@ -1739,9 +1745,9 @@ export async function createNewIpns() {
         });
     };
 
-    const publishToIpns = async (content: string) => {
+    const publishToIpns = async (content: string, opts?: { verifyResolves?: boolean; ttl?: string }) => {
         const cid = await addStringToIpfs(content);
-        await publishToIpnsValue(cid);
+        await publishToIpnsValue(cid, opts);
     };
 
     return {
@@ -1824,7 +1830,11 @@ async function getTemplateCommunityRecord(pkc: PKC): Promise<CommunityIpfsType> 
     return result;
 }
 
-export async function publishCommunityRecordWithExtraProp(opts?: { includeExtraPropInSignedPropertyNames: boolean; extraProps: Object }) {
+export async function publishCommunityRecordWithExtraProp(opts?: {
+    includeExtraPropInSignedPropertyNames?: boolean;
+    extraProps?: Object;
+    ttl?: string;
+}) {
     const ipnsObj = await createNewIpns();
     const communityRecord = JSON.parse(JSON.stringify(await getTemplateCommunityRecord(ipnsObj.pkc)));
     communityRecord.pubsubTopic = ipnsObj.signer.address;
@@ -1840,7 +1850,7 @@ export async function publishCommunityRecordWithExtraProp(opts?: { includeExtraP
         Logger("pkc-js:test-util:publishCommunityRecordWithExtraProp")
     );
 
-    await ipnsObj.publishToIpns(JSON.stringify(communityRecord));
+    await ipnsObj.publishToIpns(JSON.stringify(communityRecord), opts?.ttl ? { ttl: opts.ttl } : undefined);
 
     return { communityRecord, ipnsObj };
 }

--- a/src/test/test-util.ts
+++ b/src/test/test-util.ts
@@ -44,6 +44,7 @@ import {
     cleanUpBeforePublishing,
     _signPubsubMsg,
     signChallengeVerification,
+    signCommentUpdate,
     signCommunity
 } from "../signer/signatures.js";
 import { BasePages, PostsPages, RepliesPages } from "../pages/pages.js";
@@ -1951,6 +1952,85 @@ export async function createStaticCommunityRecordForComment(opts?: {
     } finally {
         await ipnsObj.pkc.destroy();
         if (shouldDestroyCommentPKC) await commentPKC.destroy();
+    }
+}
+
+// Publish a STATIC community under a fresh IPNS key whose preloaded posts page embeds one post
+// (author-signed CommentIpfs + a CommentUpdate signed by the community key) and whose postUpdates
+// points at a real UnixFS folder on the test Kubo holding that post's CommentUpdate at
+// <folderCid>/<postCid>/update. The record is published exactly once and nothing ever publishes
+// to this key again, so an update loop watching it is deterministic: no gossip arrivals from
+// concurrent suites, no new records — the literal "community is not publishing new community
+// records" scenario the state-order suites pin. Built for those suites (PR #311 flake class):
+// the shared live communities (signers[0]) receive publishes from every concurrently-running
+// suite, and since the update loop became arrival-driven each of those publishes starts a fetch
+// cycle at a random moment, racing any exact state-sequence assertion.
+export async function publishStaticCommunityWithPostInPages() {
+    const ipnsObj = await createNewIpns();
+    const communityAddress = ipnsObj.signer.address;
+    const commentPKC = await mockPKCNoDataPathWithOnlyKuboClient();
+    try {
+        const commentToPublish = await commentPKC.createComment({
+            signer: await commentPKC.createSigner(),
+            communityAddress,
+            title: `Static post in pages - ${Date.now()}`,
+            content: `Static content - ${Date.now()}`
+        });
+        if (!commentToPublish.raw.pubsubMessageToPublish) {
+            // Directly set _community from in-memory data so signing doesn't fetch the community
+            // record over the network (same trick as createStaticCommunityRecordForComment).
+            (commentToPublish as unknown as Record<string, unknown>)["_community"] = {
+                address: communityAddress,
+                publicKey: communityAddress,
+                encryption: encryptionForSigner(ipnsObj.signer),
+                pubsubTopic: communityAddress
+            };
+            await commentToPublish._signPublicationWithCommunityFields();
+        }
+
+        // The SAME serialization is added to IPFS and embedded in the page, so the cid the page
+        // verifier recomputes from the embedded comment matches commentUpdate.cid.
+        const commentIpfs = { ...commentToPublish.raw.pubsubMessageToPublish, depth: 0 };
+        if (!commentIpfs.protocolVersion) throw Error("The comment to embed in the static community must carry a protocolVersion");
+        const commentIpfsJson = JSON.stringify(commentIpfs);
+        const commentCid = await addStringToIpfs(commentIpfsJson);
+
+        const commentUpdateWithoutSignature = {
+            cid: commentCid,
+            upvoteCount: 0,
+            downvoteCount: 0,
+            replyCount: 0,
+            updatedAt: timestamp(),
+            protocolVersion: commentIpfs.protocolVersion
+        };
+        const commentUpdate = {
+            ...commentUpdateWithoutSignature,
+            signature: await signCommentUpdate({ update: commentUpdateWithoutSignature, signer: ipnsObj.signer })
+        };
+
+        // postUpdates folder on the test Kubo: <folderCid>/<postCid>/update.
+        const kuboClient = ipnsObj.pkc._clientsManager.getDefaultKuboRpcClient()._client;
+        let folderCid: string | undefined;
+        for await (const addedEntry of kuboClient.addAll([{ path: `${commentCid}/update`, content: JSON.stringify(commentUpdate) }], {
+            wrapWithDirectory: true
+        }))
+            if (addedEntry.path === "") folderCid = addedEntry.cid.toString();
+        if (!folderCid) throw Error("Failed to derive the postUpdates folder cid from the wrapped kubo add");
+
+        const communityRecord = <CommunityIpfsType>{
+            ...(await getTemplateCommunityRecord(ipnsObj.pkc)),
+            posts: { pages: { hot: { comments: [{ comment: JSON.parse(commentIpfsJson), commentUpdate }] } } },
+            postUpdates: { "86400": folderCid },
+            pubsubTopic: communityAddress,
+            encryption: encryptionForSigner(ipnsObj.signer),
+            updatedAt: timestamp()
+        };
+        communityRecord.signature = await signCommunity({ community: communityRecord, signer: ipnsObj.signer });
+        await ipnsObj.publishToIpns(JSON.stringify(communityRecord));
+
+        return { communityAddress, commentCid, communityRecord, ipnsObj };
+    } finally {
+        await commentPKC.destroy();
     }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -81,7 +81,7 @@ export function throwIfAbortSignalAborted(signal?: AbortSignal): void {
 // `wake` is idempotent and safe to call after the sleep already settled. Single implementation of
 // this settle pattern so hardening it reaches every caller (the event-driven update loop's park
 // included) instead of only one hand-rolled copy.
-export function interruptibleSleep(ms: number, signal?: AbortSignal): { promise: Promise<void>; wake: () => void } {
+export function interruptibleSleep({ ms, signal }: { ms: number; signal?: AbortSignal }): { promise: Promise<void>; wake: () => void } {
     let wake: () => void = () => undefined;
     const promise = new Promise<void>((resolve) => {
         if (signal?.aborted) return resolve();
@@ -100,7 +100,7 @@ export function interruptibleSleep(ms: number, signal?: AbortSignal): { promise:
 // Sleep for `ms`, resolving early if `signal` aborts. Used by the community update loops'
 // inter-iteration sleep and the comment parallel-connect timer.
 export function sleepUntilTimeoutOrAbort(ms: number, signal?: AbortSignal): Promise<void> {
-    return interruptibleSleep(ms, signal).promise;
+    return interruptibleSleep({ ms, signal }).promise;
 }
 
 // Race `promise` against `signal` aborting, rejecting with an AbortError if the signal fires first.

--- a/src/util.ts
+++ b/src/util.ts
@@ -74,22 +74,33 @@ export function throwIfAbortSignalAborted(signal?: AbortSignal): void {
     throw createAbortError();
 }
 
-// Sleep for `ms`, resolving early if `signal` aborts. The abort listener is detached on BOTH
-// outcomes (timer elapsed or aborted), so it never leaks on a long-lived signal — `{ once: true }`
-// alone only removes it when abort fires, which leaks one listener per call on the normal
-// timer-elapsed path (see issues #145, #146). Used by the community update loops' inter-iteration
-// sleep and the comment parallel-connect timer.
-export function sleepUntilTimeoutOrAbort(ms: number, signal?: AbortSignal): Promise<void> {
-    return new Promise<void>((resolve) => {
+// Sleep for `ms`, resolving early if `signal` aborts or `wake` is called. The timer and abort
+// listener are detached on EVERY outcome (timer elapsed, aborted, or woken), so nothing leaks on
+// a long-lived signal — `{ once: true }` alone only removes the abort listener when abort fires,
+// which leaks one listener per call on the normal timer-elapsed path (see issues #145, #146).
+// `wake` is idempotent and safe to call after the sleep already settled. Single implementation of
+// this settle pattern so hardening it reaches every caller (the event-driven update loop's park
+// included) instead of only one hand-rolled copy.
+export function interruptibleSleep(ms: number, signal?: AbortSignal): { promise: Promise<void>; wake: () => void } {
+    let wake: () => void = () => undefined;
+    const promise = new Promise<void>((resolve) => {
         if (signal?.aborted) return resolve();
-        const onAbortOrTimeout = () => {
+        const settle = () => {
             clearTimeout(timer);
-            signal?.removeEventListener("abort", onAbortOrTimeout);
+            signal?.removeEventListener("abort", settle);
             resolve();
         };
-        const timer = setTimeout(onAbortOrTimeout, ms);
-        signal?.addEventListener("abort", onAbortOrTimeout, { once: true });
+        const timer = setTimeout(settle, ms);
+        signal?.addEventListener("abort", settle, { once: true });
+        wake = settle;
     });
+    return { promise, wake };
+}
+
+// Sleep for `ms`, resolving early if `signal` aborts. Used by the community update loops'
+// inter-iteration sleep and the comment parallel-connect timer.
+export function sleepUntilTimeoutOrAbort(ms: number, signal?: AbortSignal): Promise<void> {
+    return interruptibleSleep(ms, signal).promise;
 }
 
 // Race `promise` against `signal` aborting, rejecting with an AbortError if the signal fires first.

--- a/test/benchmarks/comment-update-fetch-bench.test.ts
+++ b/test/benchmarks/comment-update-fetch-bench.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { describe, it, beforeAll, afterAll, expect, onTestFinished, vi } from "vitest";
 import {
     getAvailablePKCConfigsToTestAgainst,
     publishRandomPost,
@@ -83,7 +83,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             const clientFunctions = libp2pJsClient.heliaWithKuboRpcClientFunctions;
             const catCalls: { path: string; bytes: number }[] = [];
             const originalCat = clientFunctions.cat.bind(clientFunctions);
-            clientFunctions.cat = ((...args: Parameters<typeof originalCat>) => {
+            const catSpy = vi.spyOn(clientFunctions, "cat").mockImplementation((...args) => {
                 const call = { path: String(args[0]), bytes: 0 };
                 catCalls.push(call);
                 const iterable = originalCat(...args);
@@ -94,7 +94,8 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                         yield chunk;
                     }
                 })();
-            }) as typeof clientFunctions.cat;
+            });
+            onTestFinished(() => catSpy.mockRestore());
 
             // ---- setup: K posts, all set updating and settled ----
             const publishedPosts: Comment[] = [];

--- a/test/benchmarks/comment-update-fetch-bench.test.ts
+++ b/test/benchmarks/comment-update-fetch-bench.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import {
+    getAvailablePKCConfigsToTestAgainst,
+    publishRandomPost,
+    mockPKCNoDataPathWithOnlyKuboClient
+} from "../../dist/node/test/test-util.js";
+import signers from "../fixtures/signers.js";
+
+import type { PKC as PKCType } from "../../dist/node/pkc/pkc.js";
+import type { Comment } from "../../dist/node/publications/comment/comment.js";
+import type { RemoteCommunity } from "../../dist/node/community/remote-community.js";
+
+// Measurement harness for the comment-side follow-up to issue #308: how much of the comment
+// update pipeline's work is redundant once community updates are push-driven. NOT part of any CI
+// glob; run manually against the local test server:
+//
+//   node test/run-test-config.js --pkc-config remote-libp2pjs test/benchmarks/comment-update-fetch-bench.test.ts
+//
+// Comments carry no polling timer of their own: handleUpdateEventFromCommunity runs once per
+// community update event. The suspected waste is what each such invocation does for a post whose
+// CommentUpdate did NOT change:
+//   - a post found in the community's preloaded pages with an unchanged updatedAt still falls
+//     into useCommunityPostUpdatesToFetchCommentUpdateForPost (the pages hit only short-circuits
+//     when the pages copy is strictly NEWER), and
+//   - the postUpdates folder-cid dedupe only engages when _commentUpdateIpfsPath was set by a
+//     previous postUpdates fetch, which a post served from pages never sets,
+// so every community update can cost each updating post a full postUpdates path walk (cat of
+// <folderCid>/<postCid>/update), a signature verification, and a discard.
+//
+// Method: K posts are published to the live test community and set updating on a libp2p-js pkc.
+// A filler post is published every FILLER_INTERVAL_MS so the community record keeps changing for
+// reasons unrelated to the K posts. Over the window we count community update events, cat() calls
+// on the measuring client classified as postUpdates path walks (path contains '/'), how many of
+// the K posts ever received an actually-newer CommentUpdate, and comment updatingstatechange
+// churn. postUpdates walks per (community update x post) approaching 1 with zero newer
+// CommentUpdates is the measured waste.
+const POST_COUNT = Number(process.env.PKC_BENCH_POSTS) > 0 ? Number(process.env.PKC_BENCH_POSTS) : 8;
+const WINDOW_MS = Number(process.env.PKC_BENCH_WINDOW_MS) > 0 ? Number(process.env.PKC_BENCH_WINDOW_MS) : 120_000;
+const FILLER_INTERVAL_MS = 15_000;
+
+getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"] }).map((config) => {
+    describe(`comment update fetch cost benchmark (issue #308 follow-up) - ${config.name}`, () => {
+        let pkc: PKCType;
+        let publisherPkc: Awaited<ReturnType<typeof mockPKCNoDataPathWithOnlyKuboClient>>;
+        const commentsToStop: Comment[] = [];
+        let communityInstance: RemoteCommunity | undefined;
+
+        beforeAll(async () => {
+            // updateInterval is the event-driven loop's safety-net period; use the production
+            // default so community updates arrive via gossip push, not fast polling.
+            pkc = await config.pkcInstancePromise({ pkcOptions: { updateInterval: 60_000 } });
+            // Publishing runs on a separate kubo-backed pkc so the measuring client's cat()
+            // counts are not polluted by the publishing flow's own fetches.
+            publisherPkc = await mockPKCNoDataPathWithOnlyKuboClient({});
+        }, 120_000);
+        afterAll(async () => {
+            for (const comment of commentsToStop.splice(0)) {
+                try {
+                    await comment.stop();
+                } catch {
+                    // already stopped
+                }
+            }
+            if (communityInstance)
+                try {
+                    await communityInstance.stop();
+                } catch {
+                    // already stopped
+                }
+            await publisherPkc.destroy();
+            await pkc.destroy();
+        }, 300_000);
+
+        const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+        it(`postUpdates fetch cost of ${POST_COUNT} idle updating posts over ${WINDOW_MS / 1000}s of unrelated community activity`, async () => {
+            const communityAddress = signers[0].address;
+
+            // ---- setup: K posts that will then sit idle for the whole window ----
+            const publishedPosts: Comment[] = [];
+            for (let i = 0; i < POST_COUNT; i++) publishedPosts.push(await publishRandomPost({ communityAddress, pkc: publisherPkc }));
+
+            // ---- instrumentation on the measuring client, BEFORE any updating starts ----
+            const libp2pJsClient = pkc.clients.libp2pJsClients[Object.keys(pkc.clients.libp2pJsClients)[0]];
+            const clientFunctions = libp2pJsClient.heliaWithKuboRpcClientFunctions;
+            const catCalls: { path: string; atMs: number }[] = [];
+            const originalCat = clientFunctions.cat.bind(clientFunctions);
+            clientFunctions.cat = ((...args: Parameters<typeof originalCat>) => {
+                catCalls.push({ path: String(args[0]), atMs: Date.now() });
+                return originalCat(...args);
+            }) as typeof clientFunctions.cat;
+
+            let communityUpdateEvents = 0;
+            communityInstance = (await pkc.createCommunity({ address: communityAddress })) as RemoteCommunity;
+            communityInstance.on("update", () => communityUpdateEvents++);
+            await communityInstance.update();
+
+            let commentUpdatingStateChanges = 0;
+            let newerCommentUpdatesReceived = 0;
+            await Promise.all(
+                publishedPosts.map(async (publishedPost) => {
+                    const comment = await pkc.createComment({ cid: publishedPost.cid! });
+                    commentsToStop.push(comment);
+                    comment.on("updatingstatechange", () => commentUpdatingStateChanges++);
+                    const firstUpdate = new Promise<void>((resolve) =>
+                        comment.once("update", () => {
+                            resolve();
+                        })
+                    );
+                    await comment.update();
+                    await firstUpdate;
+                })
+            );
+
+            // ---- steady-state window: only unrelated filler activity changes the record ----
+            await sleep(3000);
+            catCalls.length = 0;
+            communityUpdateEvents = 0;
+            commentUpdatingStateChanges = 0;
+            for (const comment of commentsToStop) comment.on("update", () => newerCommentUpdatesReceived++);
+            const cpuBefore = process.cpuUsage();
+            const windowStart = Date.now();
+
+            const fillerLoop = (async () => {
+                while (Date.now() - windowStart < WINDOW_MS - FILLER_INTERVAL_MS) {
+                    await sleep(FILLER_INTERVAL_MS);
+                    try {
+                        await publishRandomPost({ communityAddress, pkc: publisherPkc });
+                    } catch (e) {
+                        console.error("filler post publish failed, continuing", e);
+                    }
+                }
+            })();
+            await sleep(WINDOW_MS);
+            await fillerLoop;
+            const windowSec = (Date.now() - windowStart) / 1000;
+            const cpuAfter = process.cpuUsage(cpuBefore);
+
+            const postUpdatesWalks = catCalls.filter((c) => c.path.includes("/"));
+            const report = {
+                posts: POST_COUNT,
+                windowSec: Number(windowSec.toFixed(1)),
+                communityUpdateEvents,
+                postUpdatesPathFetches: {
+                    total: postUpdatesWalks.length,
+                    perCommunityUpdatePerPost: Number(
+                        (postUpdatesWalks.length / Math.max(1, communityUpdateEvents) / POST_COUNT).toFixed(2)
+                    )
+                },
+                otherCatFetches: catCalls.length - postUpdatesWalks.length,
+                newerCommentUpdatesReceived,
+                commentUpdatingStateChanges,
+                clientCpu: {
+                    userMs: Math.round(cpuAfter.user / 1000),
+                    systemMs: Math.round(cpuAfter.system / 1000)
+                }
+            };
+            console.log(`comment update fetch benchmark report:\n${JSON.stringify(report, null, 4)}`);
+
+            expect(communityUpdateEvents, "the filler posts must have produced community updates in the window").to.be.greaterThan(0);
+        }, 900_000);
+    });
+});

--- a/test/benchmarks/comment-update-fetch-bench.test.ts
+++ b/test/benchmarks/comment-update-fetch-bench.test.ts
@@ -2,55 +2,57 @@ import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import {
     getAvailablePKCConfigsToTestAgainst,
     publishRandomPost,
-    mockPKCNoDataPathWithOnlyKuboClient
+    mockPKCNoDataPathWithOnlyKuboClient,
+    resolveWhenConditionIsTrue
 } from "../../dist/node/test/test-util.js";
 import signers from "../fixtures/signers.js";
+import fs from "node:fs";
+import path from "node:path";
 
 import type { PKC as PKCType } from "../../dist/node/pkc/pkc.js";
 import type { Comment } from "../../dist/node/publications/comment/comment.js";
 import type { RemoteCommunity } from "../../dist/node/community/remote-community.js";
 
-// Measurement harness for the comment-side follow-up to issue #308: how much of the comment
-// update pipeline's work is redundant once community updates are push-driven. NOT part of any CI
-// glob; run manually against the local test server:
+// Measurement harness for issue #312: the network and compute cost of the comment update
+// pipeline for posts whose CommentUpdate does NOT change. NOT part of any CI glob; run manually
+// against the local test server:
 //
 //   node test/run-test-config.js --pkc-config remote-libp2pjs test/benchmarks/comment-update-fetch-bench.test.ts
 //
-// Comments carry no polling timer of their own: handleUpdateEventFromCommunity runs once per
-// community update event. The suspected waste is what each such invocation does for a post whose
-// CommentUpdate did NOT change:
-//   - a post found in the community's preloaded pages with an unchanged updatedAt still falls
-//     into useCommunityPostUpdatesToFetchCommentUpdateForPost (the pages hit only short-circuits
-//     when the pages copy is strictly NEWER), and
-//   - the postUpdates folder-cid dedupe only engages when _commentUpdateIpfsPath was set by a
-//     previous postUpdates fetch, which a post served from pages never sets,
-// so every community update can cost each updating post a full postUpdates path walk (cat of
-// <folderCid>/<postCid>/update), a signature verification, and a discard.
+// Comments carry no polling timer (handleUpdateEventFromCommunity runs once per community update
+// event); the waste is that each invocation walks <folderCid>/<postCid>/update over the network,
+// parses, and signature-verifies for posts that did not change (see issue #312 for the two
+// dedupe gaps).
 //
-// Method: K posts are published to the live test community and set updating on a libp2p-js pkc.
-// A filler post is published every FILLER_INTERVAL_MS so the community record keeps changing for
-// reasons unrelated to the K posts. Over the window we count community update events, cat() calls
-// on the measuring client classified as postUpdates path walks (path contains '/'), how many of
-// the K posts ever received an actually-newer CommentUpdate, and comment updatingstatechange
-// churn. postUpdates walks per (community update x post) approaching 1 with zero newer
-// CommentUpdates is the measured waste.
+// DIFFERENTIAL DESIGN for attribution: the publisher pkc that drives community updates (filler
+// posts) lives in the same process, so raw process counters would blame its challenge-exchange
+// work on the comment pipeline. The bench therefore runs two equal phases at the same filler
+// cadence: phase A with K idle posts updating, phase B with those posts stopped (only the
+// community instance still updating). Publisher and community-loop costs appear in both phases
+// and cancel; the per-community-update DELTA is what the K idle posts cost.
+//
+// Metrics per phase, all captured on the measuring libp2p-js client:
+//   - postUpdates path walks (cat calls whose path contains a '/') and the bytes their streams
+//     actually delivered
+//   - total cat calls and bytes (community records included)
+//   - process CPU (user+system)
+//   - community update events, and how many posts received an actually-newer CommentUpdate
+//     WITHIN the phase (the initial CommentUpdate consumption is settled before phase A starts)
 const POST_COUNT = Number(process.env.PKC_BENCH_POSTS) > 0 ? Number(process.env.PKC_BENCH_POSTS) : 8;
-const WINDOW_MS = Number(process.env.PKC_BENCH_WINDOW_MS) > 0 ? Number(process.env.PKC_BENCH_WINDOW_MS) : 120_000;
+const PHASE_MS = Number(process.env.PKC_BENCH_PHASE_MS) > 0 ? Number(process.env.PKC_BENCH_PHASE_MS) : 75_000;
 const FILLER_INTERVAL_MS = 15_000;
 
 getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"] }).map((config) => {
-    describe(`comment update fetch cost benchmark (issue #308 follow-up) - ${config.name}`, () => {
+    describe(`comment update fetch cost benchmark (issue #312) - ${config.name}`, () => {
         let pkc: PKCType;
         let publisherPkc: Awaited<ReturnType<typeof mockPKCNoDataPathWithOnlyKuboClient>>;
         const commentsToStop: Comment[] = [];
         let communityInstance: RemoteCommunity | undefined;
 
         beforeAll(async () => {
-            // updateInterval is the event-driven loop's safety-net period; use the production
-            // default so community updates arrive via gossip push, not fast polling.
+            // Production updateInterval so community updates arrive via gossip push (issue #308),
+            // not the test default's 500ms safety-net polling.
             pkc = await config.pkcInstancePromise({ pkcOptions: { updateInterval: 60_000 } });
-            // Publishing runs on a separate kubo-backed pkc so the measuring client's cat()
-            // counts are not polluted by the publishing flow's own fetches.
             publisherPkc = await mockPKCNoDataPathWithOnlyKuboClient({});
         }, 120_000);
         afterAll(async () => {
@@ -73,91 +75,130 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
 
         const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-        it(`postUpdates fetch cost of ${POST_COUNT} idle updating posts over ${WINDOW_MS / 1000}s of unrelated community activity`, async () => {
+        it(`attributable cost of ${POST_COUNT} idle updating posts across two ${PHASE_MS / 1000}s phases`, async () => {
             const communityAddress = signers[0].address;
 
-            // ---- setup: K posts that will then sit idle for the whole window ----
-            const publishedPosts: Comment[] = [];
-            for (let i = 0; i < POST_COUNT; i++) publishedPosts.push(await publishRandomPost({ communityAddress, pkc: publisherPkc }));
-
-            // ---- instrumentation on the measuring client, BEFORE any updating starts ----
+            // ---- instrumentation on the measuring client, before anything updates ----
             const libp2pJsClient = pkc.clients.libp2pJsClients[Object.keys(pkc.clients.libp2pJsClients)[0]];
             const clientFunctions = libp2pJsClient.heliaWithKuboRpcClientFunctions;
-            const catCalls: { path: string; atMs: number }[] = [];
+            const catCalls: { path: string; bytes: number }[] = [];
             const originalCat = clientFunctions.cat.bind(clientFunctions);
             clientFunctions.cat = ((...args: Parameters<typeof originalCat>) => {
-                catCalls.push({ path: String(args[0]), atMs: Date.now() });
-                return originalCat(...args);
+                const call = { path: String(args[0]), bytes: 0 };
+                catCalls.push(call);
+                const iterable = originalCat(...args);
+                // Count the bytes the stream actually delivers, passing chunks through.
+                return (async function* () {
+                    for await (const chunk of iterable) {
+                        call.bytes += chunk.length;
+                        yield chunk;
+                    }
+                })();
             }) as typeof clientFunctions.cat;
 
+            // ---- setup: K posts, all set updating and settled ----
+            const publishedPosts: Comment[] = [];
+            for (let i = 0; i < POST_COUNT; i++) publishedPosts.push(await publishRandomPost({ communityAddress, pkc: publisherPkc }));
             let communityUpdateEvents = 0;
             communityInstance = (await pkc.createCommunity({ address: communityAddress })) as RemoteCommunity;
             communityInstance.on("update", () => communityUpdateEvents++);
             await communityInstance.update();
-
-            let commentUpdatingStateChanges = 0;
-            let newerCommentUpdatesReceived = 0;
+            let newerCommentUpdatesInPhase = 0;
             await Promise.all(
                 publishedPosts.map(async (publishedPost) => {
                     const comment = await pkc.createComment({ cid: publishedPost.cid! });
                     commentsToStop.push(comment);
-                    comment.on("updatingstatechange", () => commentUpdatingStateChanges++);
-                    const firstUpdate = new Promise<void>((resolve) =>
-                        comment.once("update", () => {
-                            resolve();
-                        })
-                    );
                     await comment.update();
-                    await firstUpdate;
+                    // Settle past BOTH update events (CommentIpfs load and the first
+                    // CommentUpdate), so phase counters only ever see in-phase changes.
+                    await resolveWhenConditionIsTrue({ toUpdate: comment, predicate: async () => typeof comment.updatedAt === "number" });
+                    comment.on("update", () => newerCommentUpdatesInPhase++);
                 })
             );
-
-            // ---- steady-state window: only unrelated filler activity changes the record ----
             await sleep(3000);
-            catCalls.length = 0;
-            communityUpdateEvents = 0;
-            commentUpdatingStateChanges = 0;
-            for (const comment of commentsToStop) comment.on("update", () => newerCommentUpdatesReceived++);
-            const cpuBefore = process.cpuUsage();
-            const windowStart = Date.now();
 
-            const fillerLoop = (async () => {
-                while (Date.now() - windowStart < WINDOW_MS - FILLER_INTERVAL_MS) {
+            // One phase: reset counters, publish fillers at a fixed cadence for PHASE_MS,
+            // return what accumulated. Identical mechanics in both phases so the publisher's
+            // own cost cancels in the delta.
+            const runPhase = async (label: string) => {
+                catCalls.length = 0;
+                communityUpdateEvents = 0;
+                newerCommentUpdatesInPhase = 0;
+                const cpuBefore = process.cpuUsage();
+                const phaseStart = Date.now();
+                while (Date.now() - phaseStart < PHASE_MS - FILLER_INTERVAL_MS) {
                     await sleep(FILLER_INTERVAL_MS);
                     try {
                         await publishRandomPost({ communityAddress, pkc: publisherPkc });
                     } catch (e) {
-                        console.error("filler post publish failed, continuing", e);
+                        console.error(`${label}: filler post publish failed, continuing`, e);
                     }
                 }
-            })();
-            await sleep(WINDOW_MS);
-            await fillerLoop;
-            const windowSec = (Date.now() - windowStart) / 1000;
-            const cpuAfter = process.cpuUsage(cpuBefore);
+                await sleep(Math.max(0, PHASE_MS - (Date.now() - phaseStart)));
+                await sleep(3000); // let in-flight handlers drain before reading counters
+                const cpu = process.cpuUsage(cpuBefore);
+                const walks = catCalls.filter((c) => c.path.includes("/"));
+                return {
+                    label,
+                    phaseSec: Number(((Date.now() - phaseStart) / 1000).toFixed(1)),
+                    communityUpdates: communityUpdateEvents,
+                    postUpdatesWalks: walks.length,
+                    postUpdatesWalkBytes: walks.reduce((sum, c) => sum + c.bytes, 0),
+                    totalCatCalls: catCalls.length,
+                    totalCatBytes: catCalls.reduce((sum, c) => sum + c.bytes, 0),
+                    newerCommentUpdatesInPhase,
+                    cpuMs: Math.round((cpu.user + cpu.system) / 1000)
+                };
+            };
 
-            const postUpdatesWalks = catCalls.filter((c) => c.path.includes("/"));
+            const withPosts = await runPhase("with-idle-posts");
+            for (const comment of commentsToStop.splice(0)) await comment.stop();
+            const withoutPosts = await runPhase("without-posts");
+
+            const perUpdate = (metric: number, updates: number) => metric / Math.max(1, updates);
+            const attributablePerCommunityUpdate = {
+                postUpdatesWalks: Number(
+                    (
+                        perUpdate(withPosts.postUpdatesWalks, withPosts.communityUpdates) -
+                        perUpdate(withoutPosts.postUpdatesWalks, withoutPosts.communityUpdates)
+                    ).toFixed(2)
+                ),
+                postUpdatesWalkKB: Number(
+                    (
+                        (perUpdate(withPosts.postUpdatesWalkBytes, withPosts.communityUpdates) -
+                            perUpdate(withoutPosts.postUpdatesWalkBytes, withoutPosts.communityUpdates)) /
+                        1000
+                    ).toFixed(2)
+                ),
+                cpuMs: Number(
+                    (
+                        perUpdate(withPosts.cpuMs, withPosts.communityUpdates) -
+                        perUpdate(withoutPosts.cpuMs, withoutPosts.communityUpdates)
+                    ).toFixed(0)
+                )
+            };
+
             const report = {
                 posts: POST_COUNT,
-                windowSec: Number(windowSec.toFixed(1)),
-                communityUpdateEvents,
-                postUpdatesPathFetches: {
-                    total: postUpdatesWalks.length,
-                    perCommunityUpdatePerPost: Number(
-                        (postUpdatesWalks.length / Math.max(1, communityUpdateEvents) / POST_COUNT).toFixed(2)
-                    )
-                },
-                otherCatFetches: catCalls.length - postUpdatesWalks.length,
-                newerCommentUpdatesReceived,
-                commentUpdatingStateChanges,
-                clientCpu: {
-                    userMs: Math.round(cpuAfter.user / 1000),
-                    systemMs: Math.round(cpuAfter.system / 1000)
+                fillerIntervalMs: FILLER_INTERVAL_MS,
+                withPosts,
+                withoutPosts,
+                attributablePerCommunityUpdate,
+                attributablePerCommunityUpdatePerPost: {
+                    postUpdatesWalks: Number((attributablePerCommunityUpdate.postUpdatesWalks / POST_COUNT).toFixed(2)),
+                    postUpdatesWalkKB: Number((attributablePerCommunityUpdate.postUpdatesWalkKB / POST_COUNT).toFixed(2)),
+                    cpuMs: Number((attributablePerCommunityUpdate.cpuMs / POST_COUNT).toFixed(1))
                 }
             };
             console.log(`comment update fetch benchmark report:\n${JSON.stringify(report, null, 4)}`);
+            const outDir = path.join(process.cwd(), ".tmp");
+            fs.mkdirSync(outDir, { recursive: true });
+            const outPath = path.join(outDir, `comment-update-bench-${new Date().toISOString().replace(/[:.]/g, "-")}.json`);
+            fs.writeFileSync(outPath, JSON.stringify(report, null, 4));
+            console.log(`report written to ${outPath}`);
 
-            expect(communityUpdateEvents, "the filler posts must have produced community updates in the window").to.be.greaterThan(0);
+            expect(withPosts.communityUpdates, "phase A must have community updates").to.be.greaterThan(0);
+            expect(withoutPosts.communityUpdates, "phase B must have community updates").to.be.greaterThan(0);
         }, 900_000);
     });
 });

--- a/test/benchmarks/update-loop-bench.test.ts
+++ b/test/benchmarks/update-loop-bench.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import {
+    getAvailablePKCConfigsToTestAgainst,
+    publishCommunityRecordWithExtraProp,
+    addStringToIpfs
+} from "../../dist/node/test/test-util.js";
+import { signCommunity } from "../../dist/node/signer/signatures.js";
+import { timestamp } from "../../dist/node/util.js";
+import fs from "node:fs";
+import path from "node:path";
+
+import type { PKC as PKCType } from "../../dist/node/pkc/pkc.js";
+import type { RemoteCommunity } from "../../dist/node/community/remote-community.js";
+
+// Before/after benchmark for issues #308 (1s update-loop churn on the libp2p-js path) and #307
+// (once-per-ttl thundering herd when a directory of names expires in lockstep). NOT part of any
+// CI glob (CI runs test/node, test/node-and-browser, test/browser, test/challenges); run it
+// manually against the local test server, once on master and once on the fix branch:
+//
+//   node test/run-test-config.js --pkc-config remote-libp2pjs test/benchmarks/update-loop-bench.test.ts
+//
+// It stands up N static communities (records published with a 60s ttl, matching what real
+// communities publish: publishInterval * 3), updates all of them from one libp2p-js pkc, and
+// measures over a steady-state window:
+//   - updatingstatechange events (the #308 churn metric)
+//   - IPNS record network fetch operations via the libp2p fetch service, bucketed per second so
+//     the #307 expiry burst shape is visible (clustered before, spread after)
+//   - gossipsub messages received (the push channel's traffic)
+//   - client process CPU time over the window
+//   - the serving kubo daemon's bandwidth delta (RPC stats.bw)
+//   - delivery latency of a record published mid-window (guards the redesign against trading
+//     churn for staleness)
+// Results are printed and written to .tmp/update-loop-bench-<timestamp>.json for the PR table.
+//
+// Tune with PKC_BENCH_COMMUNITIES (default 32) and PKC_BENCH_WINDOW_MS (default 150000; keep it
+// above 2 ttl windows so at least one expiry boundary lands inside the measurement).
+const COMMUNITY_COUNT = Number(process.env.PKC_BENCH_COMMUNITIES) > 0 ? Number(process.env.PKC_BENCH_COMMUNITIES) : 32;
+const WINDOW_MS = Number(process.env.PKC_BENCH_WINDOW_MS) > 0 ? Number(process.env.PKC_BENCH_WINDOW_MS) : 150_000;
+const RECORD_TTL = "60s";
+
+getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"] }).map((config) => {
+    describe(`update loop benchmark (issues #308/#307) - ${config.name}`, () => {
+        let pkc: PKCType;
+        const staticRecords: Awaited<ReturnType<typeof publishCommunityRecordWithExtraProp>>[] = [];
+        const communities: RemoteCommunity[] = [];
+
+        beforeAll(async () => {
+            pkc = await config.pkcInstancePromise();
+        }, 60_000);
+        afterAll(async () => {
+            for (const community of communities.splice(0)) {
+                try {
+                    await community.stop();
+                } catch {
+                    // already stopped
+                }
+            }
+            for (const staticRecord of staticRecords.splice(0)) await staticRecord.ipnsObj.pkc.destroy();
+            await pkc.destroy();
+        }, 300_000);
+
+        const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+        // Republish a community record under its IPNS key with an explicit ttl, so cached records
+        // expire on the same schedule real community records do (publishInterval * 3 = 60s), which
+        // is what makes the #307 lockstep expiry reproducible in the window.
+        const publishRecordWithTtl = async (
+            staticRecord: Awaited<ReturnType<typeof publishCommunityRecordWithExtraProp>>,
+            record: (typeof staticRecords)[number]["communityRecord"]
+        ) => {
+            const cid = await addStringToIpfs(JSON.stringify(record));
+            const kuboRpcClient = staticRecord.ipnsObj.pkc._clientsManager.getDefaultKuboRpcClient();
+            await kuboRpcClient._client.name.publish(cid, {
+                key: staticRecord.ipnsObj.signer.address,
+                allowOffline: true,
+                ttl: RECORD_TTL
+            });
+        };
+
+        it(`steady-state update-loop cost at ${COMMUNITY_COUNT} communities over ${WINDOW_MS / 1000}s`, async () => {
+            // ---- setup: N static communities, records carrying a 60s ttl ----
+            const setupBatchSize = 8;
+            for (let batchStart = 0; batchStart < COMMUNITY_COUNT; batchStart += setupBatchSize) {
+                await Promise.all(
+                    Array.from({ length: Math.min(setupBatchSize, COMMUNITY_COUNT - batchStart) }, async () => {
+                        const staticRecord = await publishCommunityRecordWithExtraProp();
+                        await publishRecordWithTtl(staticRecord, staticRecord.communityRecord);
+                        staticRecords.push(staticRecord);
+                    })
+                );
+            }
+
+            // ---- instrumentation on the single libp2p-js client ----
+            const libp2pJsClient = pkc.clients.libp2pJsClients[Object.keys(pkc.clients.libp2pJsClients)[0]];
+            const fetchService = libp2pJsClient._helia.libp2p.services.fetch;
+            const fetchTimestamps: number[] = [];
+            const originalFetch = fetchService.fetch.bind(fetchService);
+            fetchService.fetch = ((...args: Parameters<typeof originalFetch>) => {
+                fetchTimestamps.push(Date.now());
+                return originalFetch(...args);
+            }) as typeof fetchService.fetch;
+
+            let pubsubMessagesReceived = 0;
+            const onPubsubMessage = () => pubsubMessagesReceived++;
+            libp2pJsClient._helia.libp2p.services.pubsub.addEventListener("message", onPubsubMessage);
+
+            let updatingStateChanges = 0;
+            let updateEvents = 0;
+
+            // ---- start updating all communities and wait for every first update ----
+            await Promise.all(
+                staticRecords.map(async (staticRecord) => {
+                    const community = (await pkc.createCommunity({
+                        address: staticRecord.ipnsObj.signer.address
+                    })) as RemoteCommunity;
+                    communities.push(community);
+                    community.on("updatingstatechange", () => updatingStateChanges++);
+                    community.on("update", () => updateEvents++);
+                    const firstUpdate = new Promise<void>((resolve) => community.once("update", () => resolve()));
+                    await community.update();
+                    await firstUpdate;
+                })
+            );
+
+            // ---- steady-state measurement window ----
+            await sleep(3000); // let first-update tails settle
+            updatingStateChanges = 0;
+            updateEvents = 0;
+            pubsubMessagesReceived = 0;
+            fetchTimestamps.length = 0;
+            const cpuBefore = process.cpuUsage();
+            const bwBefore = await readServingDaemonBandwidth();
+            const windowStart = Date.now();
+
+            // Mid-window, publish a newer record for one community and time its delivery.
+            let deliveryLatencyMs: number | undefined;
+            const midWindowDelivery = (async () => {
+                await sleep(Math.floor(WINDOW_MS / 2));
+                const target = staticRecords[0];
+                const newerRecord = JSON.parse(JSON.stringify(target.communityRecord)) as typeof target.communityRecord;
+                newerRecord.updatedAt = Math.max(newerRecord.updatedAt + 1, timestamp());
+                newerRecord.signature = await signCommunity({ community: newerRecord, signer: target.ipnsObj.signer });
+                const targetCommunity = communities[0];
+                const delivered = new Promise<void>((resolve) => {
+                    const onUpdate = () => {
+                        if (targetCommunity.updatedAt === newerRecord.updatedAt) {
+                            targetCommunity.removeListener("update", onUpdate);
+                            deliveryLatencyMs = Date.now() - publishedAt;
+                            resolve();
+                        }
+                    };
+                    targetCommunity.on("update", onUpdate);
+                });
+                const publishedAt = Date.now();
+                await publishRecordWithTtl(target, newerRecord);
+                await delivered;
+            })();
+
+            await sleep(WINDOW_MS);
+            const windowEndedAt = Date.now();
+            const cpuAfter = process.cpuUsage(cpuBefore);
+            const bwAfter = await readServingDaemonBandwidth();
+            libp2pJsClient._helia.libp2p.services.pubsub.removeEventListener("message", onPubsubMessage);
+
+            // Give the mid-window delivery until the end of the run to land, then require it.
+            let deliveredInTime = true;
+            await Promise.race([
+                midWindowDelivery,
+                sleep(120_000).then(() => {
+                    deliveredInTime = false;
+                })
+            ]);
+
+            // ---- report ----
+            const windowSec = (windowEndedAt - windowStart) / 1000;
+            const fetchBuckets = new Map<number, number>();
+            for (const ts of fetchTimestamps) {
+                const second = Math.floor((ts - windowStart) / 1000);
+                fetchBuckets.set(second, (fetchBuckets.get(second) ?? 0) + 1);
+            }
+            const busiestFetchSeconds = [...fetchBuckets.entries()]
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 5)
+                .map(([second, count]) => ({ atSecond: second, fetchOps: count }));
+
+            const report = {
+                communities: COMMUNITY_COUNT,
+                windowSec: Number(windowSec.toFixed(1)),
+                recordTtl: RECORD_TTL,
+                updatingStateChanges: {
+                    total: updatingStateChanges,
+                    perSecond: Number((updatingStateChanges / windowSec).toFixed(2)),
+                    perCommunityPerSecond: Number((updatingStateChanges / windowSec / COMMUNITY_COUNT).toFixed(3))
+                },
+                updateEvents,
+                ipnsNetworkFetchOps: {
+                    total: fetchTimestamps.length,
+                    perSecond: Number((fetchTimestamps.length / windowSec).toFixed(2)),
+                    maxInOneSecond: busiestFetchSeconds[0]?.fetchOps ?? 0,
+                    busiestSeconds: busiestFetchSeconds
+                },
+                pubsubMessagesReceived,
+                clientCpu: {
+                    userMs: Math.round(cpuAfter.user / 1000),
+                    systemMs: Math.round(cpuAfter.system / 1000),
+                    percentOfWindow: Number((((cpuAfter.user + cpuAfter.system) / 1000 / (windowSec * 1000)) * 100).toFixed(2))
+                },
+                servingKuboBandwidth:
+                    bwBefore && bwAfter
+                        ? {
+                              deltaTotalInMB: Number((Number(bwAfter.totalIn - bwBefore.totalIn) / 1e6).toFixed(2)),
+                              deltaTotalOutMB: Number((Number(bwAfter.totalOut - bwBefore.totalOut) / 1e6).toFixed(2))
+                          }
+                        : undefined,
+                newerRecordDeliveryLatencyMs: deliveryLatencyMs
+            };
+
+            console.log(`update-loop benchmark report:\n${JSON.stringify(report, null, 4)}`);
+            const outDir = path.join(process.cwd(), ".tmp");
+            fs.mkdirSync(outDir, { recursive: true });
+            const outPath = path.join(outDir, `update-loop-bench-${new Date().toISOString().replace(/[:.]/g, "-")}.json`);
+            fs.writeFileSync(outPath, JSON.stringify(report, null, 4));
+            console.log(`report written to ${outPath}`);
+
+            expect(updateEvents, "every community must have consumed its record during the window setup").to.be.greaterThanOrEqual(0);
+            expect(deliveredInTime, "the record published mid-window must reach its community before the run ends").to.equal(true);
+        }, 900_000);
+
+        // The serving daemon is the one every createNewIpns-backed publisher targets; its
+        // stats.bw covers the libp2p traffic the bench client generates against it (record
+        // fetches, bitswap, gossipsub). Undefined when the RPC is unavailable, so the bench
+        // still reports everything else.
+        const readServingDaemonBandwidth = async (): Promise<{ totalIn: bigint; totalOut: bigint } | undefined> => {
+            try {
+                const kuboRpcClient = staticRecords[0].ipnsObj.pkc._clientsManager.getDefaultKuboRpcClient();
+                for await (const stat of kuboRpcClient._client.stats.bw()) return { totalIn: stat.totalIn, totalOut: stat.totalOut };
+                return undefined;
+            } catch {
+                return undefined;
+            }
+        };
+    });
+});

--- a/test/benchmarks/update-loop-bench.test.ts
+++ b/test/benchmarks/update-loop-bench.test.ts
@@ -45,7 +45,11 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
         const communities: RemoteCommunity[] = [];
 
         beforeAll(async () => {
-            pkc = await config.pkcInstancePromise();
+            // Production default, not test-util's updateInterval: 500 — the event-driven loop
+            // uses updateInterval as its safety-net period, so the bench must run with the value
+            // real apps run with. Master's kubo/helia loop hardcodes 1s and ignores this option,
+            // so baseline numbers are unaffected by the override.
+            pkc = await config.pkcInstancePromise({ pkcOptions: { updateInterval: 60_000 } });
         }, 60_000);
         afterAll(async () => {
             for (const community of communities.splice(0)) {

--- a/test/benchmarks/update-loop-bench.test.ts
+++ b/test/benchmarks/update-loop-bench.test.ts
@@ -165,20 +165,33 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             const cpuAfter = process.cpuUsage(cpuBefore);
             const bwAfter = await readServingDaemonBandwidth();
             libp2pJsClient._helia.libp2p.services.pubsub.removeEventListener("message", onPubsubMessage);
+            // Snapshot every counter at the boundary: the fetch wrapper and community listeners
+            // stay live while the delivery wait below runs, and the report divides by windowSec,
+            // so post-window activity must not leak into the per-second rates.
+            const windowUpdatingStateChanges = updatingStateChanges;
+            const windowUpdateEvents = updateEvents;
+            const windowPubsubMessagesReceived = pubsubMessagesReceived;
+            const windowFetchTimestamps = fetchTimestamps.filter((ts) => ts <= windowEndedAt);
 
-            // Give the mid-window delivery until the end of the run to land, then require it.
+            // Give the mid-window delivery until the end of the run to land, then require it. The
+            // losing timer is cleared so no 120s handle outlives the run.
             let deliveredInTime = true;
+            let deliveryTimer: ReturnType<typeof setTimeout> | undefined;
             await Promise.race([
                 midWindowDelivery,
-                sleep(120_000).then(() => {
-                    deliveredInTime = false;
+                new Promise<void>((resolve) => {
+                    deliveryTimer = setTimeout(() => {
+                        deliveredInTime = false;
+                        resolve();
+                    }, 120_000);
                 })
             ]);
+            clearTimeout(deliveryTimer);
 
             // ---- report ----
             const windowSec = (windowEndedAt - windowStart) / 1000;
             const fetchBuckets = new Map<number, number>();
-            for (const ts of fetchTimestamps) {
+            for (const ts of windowFetchTimestamps) {
                 const second = Math.floor((ts - windowStart) / 1000);
                 fetchBuckets.set(second, (fetchBuckets.get(second) ?? 0) + 1);
             }
@@ -192,18 +205,18 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 windowSec: Number(windowSec.toFixed(1)),
                 recordTtl: RECORD_TTL,
                 updatingStateChanges: {
-                    total: updatingStateChanges,
-                    perSecond: Number((updatingStateChanges / windowSec).toFixed(2)),
-                    perCommunityPerSecond: Number((updatingStateChanges / windowSec / COMMUNITY_COUNT).toFixed(3))
+                    total: windowUpdatingStateChanges,
+                    perSecond: Number((windowUpdatingStateChanges / windowSec).toFixed(2)),
+                    perCommunityPerSecond: Number((windowUpdatingStateChanges / windowSec / COMMUNITY_COUNT).toFixed(3))
                 },
-                updateEvents,
+                updateEvents: windowUpdateEvents,
                 ipnsNetworkFetchOps: {
-                    total: fetchTimestamps.length,
-                    perSecond: Number((fetchTimestamps.length / windowSec).toFixed(2)),
+                    total: windowFetchTimestamps.length,
+                    perSecond: Number((windowFetchTimestamps.length / windowSec).toFixed(2)),
                     maxInOneSecond: busiestFetchSeconds[0]?.fetchOps ?? 0,
                     busiestSeconds: busiestFetchSeconds
                 },
-                pubsubMessagesReceived,
+                pubsubMessagesReceived: windowPubsubMessagesReceived,
                 clientCpu: {
                     userMs: Math.round(cpuAfter.user / 1000),
                     systemMs: Math.round(cpuAfter.system / 1000),

--- a/test/benchmarks/update-loop-bench.test.ts
+++ b/test/benchmarks/update-loop-bench.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { describe, it, beforeAll, afterAll, expect, onTestFinished, vi } from "vitest";
 import {
     getAvailablePKCConfigsToTestAgainst,
     publishCommunityRecordWithExtraProp,
@@ -68,10 +68,13 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
         // Republish a community record under its IPNS key with an explicit ttl, so cached records
         // expire on the same schedule real community records do (publishInterval * 3 = 60s), which
         // is what makes the #307 lockstep expiry reproducible in the window.
-        const publishRecordWithTtl = async (
-            staticRecord: Awaited<ReturnType<typeof publishCommunityRecordWithExtraProp>>,
-            record: (typeof staticRecords)[number]["communityRecord"]
-        ) => {
+        const publishRecordWithTtl = async ({
+            staticRecord,
+            record
+        }: {
+            staticRecord: Awaited<ReturnType<typeof publishCommunityRecordWithExtraProp>>;
+            record: (typeof staticRecords)[number]["communityRecord"];
+        }) => {
             const cid = await addStringToIpfs(JSON.stringify(record));
             const kuboRpcClient = staticRecord.ipnsObj.pkc._clientsManager.getDefaultKuboRpcClient();
             await kuboRpcClient._client.name.publish(cid, {
@@ -88,7 +91,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 await Promise.all(
                     Array.from({ length: Math.min(setupBatchSize, COMMUNITY_COUNT - batchStart) }, async () => {
                         const staticRecord = await publishCommunityRecordWithExtraProp();
-                        await publishRecordWithTtl(staticRecord, staticRecord.communityRecord);
+                        await publishRecordWithTtl({ staticRecord, record: staticRecord.communityRecord });
                         staticRecords.push(staticRecord);
                     })
                 );
@@ -99,10 +102,11 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             const fetchService = libp2pJsClient._helia.libp2p.services.fetch;
             const fetchTimestamps: number[] = [];
             const originalFetch = fetchService.fetch.bind(fetchService);
-            fetchService.fetch = ((...args: Parameters<typeof originalFetch>) => {
+            const fetchSpy = vi.spyOn(fetchService, "fetch").mockImplementation((...args) => {
                 fetchTimestamps.push(Date.now());
                 return originalFetch(...args);
-            }) as typeof fetchService.fetch;
+            });
+            onTestFinished(() => fetchSpy.mockRestore());
 
             let pubsubMessagesReceived = 0;
             const onPubsubMessage = () => pubsubMessagesReceived++;
@@ -156,7 +160,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                     targetCommunity.on("update", onUpdate);
                 });
                 const publishedAt = Date.now();
-                await publishRecordWithTtl(target, newerRecord);
+                await publishRecordWithTtl({ staticRecord: target, record: newerRecord });
                 await delivered;
             })();
 

--- a/test/node-and-browser/community/update-freshness.test.ts
+++ b/test/node-and-browser/community/update-freshness.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { getAvailablePKCConfigsToTestAgainst, publishCommunityRecordWithExtraProp } from "../../../dist/node/test/test-util.js";
+import { signCommunity } from "../../../dist/node/signer/signatures.js";
+import { timestamp } from "../../../dist/node/util.js";
+
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { RemoteCommunity } from "../../../dist/node/community/remote-community.js";
+
+// Transport-agnostic freshness pins for the community update loop.
+//
+// Everything else in the suite that checks "did the subscriber see the change" waits on
+// resolveWhenConditionIsTrue, which has no internal timeout and is bounded only by the 120s
+// vitest default. That answers "does it arrive at all" and says nothing about how fast, or
+// about whether updatedAt can go backwards. Two properties that no other test pins:
+//
+//   1. Delivery is FAST. After PR #311 the libp2p-js loop parks on gossip pushes with a slow
+//      jittered safety-net poll, so a broken push channel degrades update latency from ~20ms
+//      to a minute or more WITHOUT failing any functional test: the safety net still delivers,
+//      just late. A latency bound is the only thing that separates "push works" from "push is
+//      dead and the safety net is carrying us".
+//   2. updatedAt never goes backwards, and consecutive generations each land. Strict
+//      monotonicity was previously asserted only on LOCAL communities
+//      (test/node/community/update.community.test.ts); on the remote subscriber path
+//      update.community.test.ts only asserted `!==`, so a community that regressed to an older
+//      record would have passed.
+//
+// Both properties are transport-independent, so this suite runs against BOTH the libp2p-js
+// (helia) and kubo-RPC resolvers. They deliver by different mechanisms — gossip push for
+// libp2p-js, a 1s poll for kubo-RPC (src/community/community-client-manager.ts) — but the
+// observable contract is the same, and pinning it on both is what stops the two paths from
+// silently diverging.
+//
+// Gateways are excluded on purpose: they poll at pkc.updateInterval by design, which this
+// suite pins to the production 60s, so a sub-25s delivery bound does not describe them.
+getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs", "remote-kubo-rpc"] }).map((config) => {
+    describe(`community update freshness - ${config.name}`, () => {
+        let pkc: PKCType;
+        const communitiesToStop: RemoteCommunity[] = [];
+        const staticRecordsToCleanUp: Awaited<ReturnType<typeof publishCommunityRecordWithExtraProp>>[] = [];
+
+        // The production default. test-util's mockPKC defaults to updateInterval: 500, which on
+        // the libp2p-js path makes the safety net poll twice a second — that masks a dead push
+        // channel completely and would make the latency bound below meaningless.
+        const PRODUCTION_UPDATE_INTERVAL_MS = 60_000;
+
+        // Generous enough for publish overhead (addStringToIpfs + name.publish + the helper's
+        // verify-resolve) plus delivery on a loaded CI runner, and still far under every
+        // fallback path: the libp2p-js safety net cannot fire before
+        // updateInterval * 0.75 = 45s, and even then it only revalidates once the routing-layer
+        // cache has expired, which for a kubo-published record is 225s+ (kubo 0.43 publishes a
+        // 300s ttl). So a delivery inside this budget can only have come from the push channel
+        // on libp2p-js, or from the 1s poll on kubo-RPC.
+        const DELIVERY_BUDGET_MS = 25_000;
+
+        beforeAll(async () => {
+            pkc = await config.pkcInstancePromise({ pkcOptions: { updateInterval: PRODUCTION_UPDATE_INTERVAL_MS } });
+        });
+        afterAll(async () => {
+            for (const community of communitiesToStop.splice(0)) {
+                try {
+                    await community.stop();
+                } catch {
+                    // already stopped
+                }
+            }
+            for (const staticRecord of staticRecordsToCleanUp.splice(0)) await staticRecord.ipnsObj.pkc.destroy();
+            await pkc.destroy();
+        });
+
+        // Each call publishes a fresh static record under a fresh IPNS key, so every test drives
+        // its own update loop instead of attaching as a mirror to a loop another test started.
+        const startUpdatingStaticCommunityAndAwaitFirstUpdate = async () => {
+            const staticRecord = await publishCommunityRecordWithExtraProp();
+            staticRecordsToCleanUp.push(staticRecord);
+            const community = (await pkc.createCommunity({ address: staticRecord.ipnsObj.signer.address })) as RemoteCommunity;
+            communitiesToStop.push(community);
+            const firstUpdate = new Promise<void>((resolve) => community.once("update", () => resolve()));
+            await community.update();
+            await firstUpdate;
+            return { community, staticRecord };
+        };
+
+        // Mint and publish the next generation of a static community record: a strictly greater
+        // updatedAt, re-signed, so it lands under a different CID (an unchanged CID is dropped by
+        // the loop's _updateCidsAlreadyLoaded filter and would never produce an update event).
+        const publishNextGeneration = async (
+            staticRecord: Awaited<ReturnType<typeof publishCommunityRecordWithExtraProp>>,
+            previousUpdatedAt: number
+        ) => {
+            const nextRecord = JSON.parse(JSON.stringify(staticRecord.communityRecord)) as typeof staticRecord.communityRecord;
+            nextRecord.updatedAt = Math.max(previousUpdatedAt + 1, timestamp());
+            nextRecord.signature = await signCommunity({ community: nextRecord, signer: staticRecord.ipnsObj.signer });
+            await staticRecord.ipnsObj.publishToIpns(JSON.stringify(nextRecord));
+            return nextRecord;
+        };
+
+        // Resolve once the community reaches `targetUpdatedAt`, or after `budgetMs`. The losing
+        // timer is always cleared so no long handle outlives the test, and the listener is always
+        // detached (issue #145's pattern applied to the test side).
+        const awaitUpdatedAtWithin = async (community: RemoteCommunity, targetUpdatedAt: number, budgetMs: number) => {
+            const startedAt = Date.now();
+            let timer: ReturnType<typeof setTimeout> | undefined;
+            let onUpdate!: () => void;
+            const delivered = new Promise<boolean>((resolve) => {
+                onUpdate = () => {
+                    if (community.updatedAt === targetUpdatedAt) resolve(true);
+                };
+                community.on("update", onUpdate);
+                if (community.updatedAt === targetUpdatedAt) resolve(true); // may already have landed
+                timer = setTimeout(() => resolve(false), budgetMs);
+            });
+            const deliveredInTime = await delivered;
+            clearTimeout(timer);
+            community.removeListener("update", onUpdate);
+            return { deliveredInTime, elapsedMs: Date.now() - startedAt };
+        };
+
+        it("a newer record reaches an updating community well inside the safety-net period", async () => {
+            const { community, staticRecord } = await startUpdatingStaticCommunityAndAwaitFirstUpdate();
+            const previousUpdatedAt = community.updatedAt!;
+
+            // Clock starts before the publish so the budget covers publish overhead too; the
+            // record can be gossiped before publishToIpns even returns, so measuring from after
+            // it would understate nothing but risks a negative window.
+            const startedAt = Date.now();
+            const newerRecord = await publishNextGeneration(staticRecord, previousUpdatedAt);
+            const { deliveredInTime } = await awaitUpdatedAtWithin(
+                community,
+                newerRecord.updatedAt,
+                DELIVERY_BUDGET_MS - (Date.now() - startedAt)
+            );
+            const latencyMs = Date.now() - startedAt;
+
+            expect(
+                deliveredInTime,
+                `a newer community record must reach the updating community within ${DELIVERY_BUDGET_MS}ms; on the libp2p-js path a miss here means the gossip push channel is dead and only the safety-net poll is delivering (issue #308)`
+            ).to.equal(true);
+            expect(latencyMs, "delivery must not be riding the safety-net poll").to.be.below(DELIVERY_BUDGET_MS);
+        }, 240_000);
+
+        it("consecutive record generations each arrive and updatedAt never goes backwards", async () => {
+            const { community, staticRecord } = await startUpdatingStaticCommunityAndAwaitFirstUpdate();
+
+            // Every update event's updatedAt, for the backwards check. Not every event carries a
+            // new record (a background name resolution emits one too), so the invariant across
+            // the whole stream is non-decreasing; the strict increase is asserted per generation.
+            const observedUpdatedAts: number[] = [];
+            const recordObserved = () => {
+                if (typeof community.updatedAt === "number") observedUpdatedAts.push(community.updatedAt);
+            };
+            community.on("update", recordObserved);
+            recordObserved();
+
+            try {
+                let previousUpdatedAt = community.updatedAt!;
+                const generations = 3;
+                for (let generation = 1; generation <= generations; generation++) {
+                    const nextRecord = await publishNextGeneration(staticRecord, previousUpdatedAt);
+                    const { deliveredInTime } = await awaitUpdatedAtWithin(community, nextRecord.updatedAt, DELIVERY_BUDGET_MS);
+                    expect(
+                        deliveredInTime,
+                        `generation ${generation} of ${generations} must reach the updating community; a loop that delivers the first change and then stops waking is exactly the #308 regression this pins`
+                    ).to.equal(true);
+                    expect(
+                        community.updatedAt,
+                        `generation ${generation} must strictly advance updatedAt (was ${previousUpdatedAt})`
+                    ).to.be.greaterThan(previousUpdatedAt);
+                    previousUpdatedAt = community.updatedAt!;
+                }
+
+                for (let i = 1; i < observedUpdatedAts.length; i++)
+                    expect(
+                        observedUpdatedAts[i],
+                        `updatedAt must never go backwards on an updating community; saw [${observedUpdatedAts.join(", ")}]`
+                    ).to.be.at.least(observedUpdatedAts[i - 1]);
+            } finally {
+                community.removeListener("update", recordObserved);
+            }
+        }, 300_000);
+    });
+});

--- a/test/node-and-browser/community/update-freshness.test.ts
+++ b/test/node-and-browser/community/update-freshness.test.ts
@@ -43,13 +43,12 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs",
         // channel completely and would make the latency bound below meaningless.
         const PRODUCTION_UPDATE_INTERVAL_MS = 60_000;
 
-        // Generous enough for publish overhead (addStringToIpfs + name.publish + the helper's
-        // verify-resolve) plus delivery on a loaded CI runner, and still far under every
-        // fallback path: the libp2p-js safety net cannot fire before
-        // updateInterval * 0.75 = 45s, and even then it only revalidates once the routing-layer
-        // cache has expired, which for a kubo-published record is 225s+ (kubo 0.43 publishes a
-        // 300s ttl). So a delivery inside this budget can only have come from the push channel
-        // on libp2p-js, or from the 1s poll on kubo-RPC.
+        // Generous enough for delivery on a loaded CI runner, and still under the fallback
+        // path: the libp2p-js safety net cannot fire before updateInterval * 0.75 = 45s. So a
+        // delivery inside this budget can only have come from the push channel on libp2p-js,
+        // or from the 1s poll on kubo-RPC. Always measured from AFTER the publish (see
+        // awaitUpdatedAtWithin's callers): publish overhead on a loaded runner must eat into
+        // neither the budget nor the safety-net margin.
         const DELIVERY_BUDGET_MS = 25_000;
 
         beforeAll(async () => {
@@ -119,23 +118,20 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs",
             const { community, staticRecord } = await startUpdatingStaticCommunityAndAwaitFirstUpdate();
             const previousUpdatedAt = community.updatedAt!;
 
-            // Clock starts before the publish so the budget covers publish overhead too; the
-            // record can be gossiped before publishToIpns even returns, so measuring from after
-            // it would understate nothing but risks a negative window.
-            const startedAt = Date.now();
+            // The budget clock starts AFTER the publish (matching the generations test below):
+            // publishNextGeneration does addStringToIpfs plus a retried name.publish plus the
+            // helper's verify-resolve poll, so a budget started before it can go zero or
+            // negative on a loaded runner and fail here blaming the push channel when delivery
+            // was never given a chance. A record that lands before publishToIpns even returns
+            // is caught by awaitUpdatedAtWithin's immediate updatedAt check, so nothing is
+            // missed by starting late.
             const newerRecord = await publishNextGeneration(staticRecord, previousUpdatedAt);
-            const { deliveredInTime } = await awaitUpdatedAtWithin(
-                community,
-                newerRecord.updatedAt,
-                DELIVERY_BUDGET_MS - (Date.now() - startedAt)
-            );
-            const latencyMs = Date.now() - startedAt;
+            const { deliveredInTime, elapsedMs } = await awaitUpdatedAtWithin(community, newerRecord.updatedAt, DELIVERY_BUDGET_MS);
 
             expect(
                 deliveredInTime,
-                `a newer community record must reach the updating community within ${DELIVERY_BUDGET_MS}ms; on the libp2p-js path a miss here means the gossip push channel is dead and only the safety-net poll is delivering (issue #308)`
+                `a newer community record must reach the updating community within ${DELIVERY_BUDGET_MS}ms of being published (took over ${elapsedMs}ms); on the libp2p-js path a miss here means the gossip push channel is dead and only the safety-net poll is delivering (issue #308)`
             ).to.equal(true);
-            expect(latencyMs, "delivery must not be riding the safety-net poll").to.be.below(DELIVERY_BUDGET_MS);
         }, 240_000);
 
         it("consecutive record generations each arrive and updatedAt never goes backwards", async () => {

--- a/test/node-and-browser/community/update-freshness.test.ts
+++ b/test/node-and-browser/community/update-freshness.test.ts
@@ -82,10 +82,13 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs",
         // Mint and publish the next generation of a static community record: a strictly greater
         // updatedAt, re-signed, so it lands under a different CID (an unchanged CID is dropped by
         // the loop's _updateCidsAlreadyLoaded filter and would never produce an update event).
-        const publishNextGeneration = async (
-            staticRecord: Awaited<ReturnType<typeof publishCommunityRecordWithExtraProp>>,
-            previousUpdatedAt: number
-        ) => {
+        const publishNextGeneration = async ({
+            staticRecord,
+            previousUpdatedAt
+        }: {
+            staticRecord: Awaited<ReturnType<typeof publishCommunityRecordWithExtraProp>>;
+            previousUpdatedAt: number;
+        }) => {
             const nextRecord = JSON.parse(JSON.stringify(staticRecord.communityRecord)) as typeof staticRecord.communityRecord;
             nextRecord.updatedAt = Math.max(previousUpdatedAt + 1, timestamp());
             nextRecord.signature = await signCommunity({ community: nextRecord, signer: staticRecord.ipnsObj.signer });
@@ -96,7 +99,15 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs",
         // Resolve once the community reaches `targetUpdatedAt`, or after `budgetMs`. The losing
         // timer is always cleared so no long handle outlives the test, and the listener is always
         // detached (issue #145's pattern applied to the test side).
-        const awaitUpdatedAtWithin = async (community: RemoteCommunity, targetUpdatedAt: number, budgetMs: number) => {
+        const awaitUpdatedAtWithin = async ({
+            community,
+            targetUpdatedAt,
+            budgetMs
+        }: {
+            community: RemoteCommunity;
+            targetUpdatedAt: number;
+            budgetMs: number;
+        }) => {
             const startedAt = Date.now();
             let timer: ReturnType<typeof setTimeout> | undefined;
             let onUpdate!: () => void;
@@ -125,8 +136,12 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs",
             // was never given a chance. A record that lands before publishToIpns even returns
             // is caught by awaitUpdatedAtWithin's immediate updatedAt check, so nothing is
             // missed by starting late.
-            const newerRecord = await publishNextGeneration(staticRecord, previousUpdatedAt);
-            const { deliveredInTime, elapsedMs } = await awaitUpdatedAtWithin(community, newerRecord.updatedAt, DELIVERY_BUDGET_MS);
+            const newerRecord = await publishNextGeneration({ staticRecord, previousUpdatedAt });
+            const { deliveredInTime, elapsedMs } = await awaitUpdatedAtWithin({
+                community,
+                targetUpdatedAt: newerRecord.updatedAt,
+                budgetMs: DELIVERY_BUDGET_MS
+            });
 
             expect(
                 deliveredInTime,
@@ -151,8 +166,12 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs",
                 let previousUpdatedAt = community.updatedAt!;
                 const generations = 3;
                 for (let generation = 1; generation <= generations; generation++) {
-                    const nextRecord = await publishNextGeneration(staticRecord, previousUpdatedAt);
-                    const { deliveredInTime } = await awaitUpdatedAtWithin(community, nextRecord.updatedAt, DELIVERY_BUDGET_MS);
+                    const nextRecord = await publishNextGeneration({ staticRecord, previousUpdatedAt });
+                    const { deliveredInTime } = await awaitUpdatedAtWithin({
+                        community,
+                        targetUpdatedAt: nextRecord.updatedAt,
+                        budgetMs: DELIVERY_BUDGET_MS
+                    });
                     expect(
                         deliveredInTime,
                         `generation ${generation} of ${generations} must reach the updating community; a loop that delivers the first change and then stops waking is exactly the #308 regression this pins`

--- a/test/node-and-browser/community/update-loop-event-driven.test.ts
+++ b/test/node-and-browser/community/update-loop-event-driven.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, beforeAll, afterAll, expect, vi } from "vitest";
-import { getAvailablePKCConfigsToTestAgainst, publishCommunityRecordWithExtraProp } from "../../../dist/node/test/test-util.js";
+import {
+    getAvailablePKCConfigsToTestAgainst,
+    isRunningInBrowser,
+    publishCommunityRecordWithExtraProp
+} from "../../../dist/node/test/test-util.js";
 import { signCommunity } from "../../../dist/node/signer/signatures.js";
 import { timestamp } from "../../../dist/node/util.js";
 
@@ -49,6 +53,17 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
         });
 
         const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+        // Node-only, and this is a load decision rather than a correctness one. The safety-net
+        // test below parks a real jittered period (45-75s observed) with a live updating
+        // community. CI runs the browser jobs with --parallel, which turns on fileParallelism, so
+        // all ~126 node-and-browser files share ONE page and one Helia node; adding a minute of
+        // extra concurrent load there measurably worsens a suite that is already flaky in that
+        // configuration (the issue #138 class: state-order assertions racing concurrent community
+        // loops — reproduced locally on the unmodified base commit too). The behavior under test
+        // is update-loop timing with no browser-specific component, so the three node libp2p-js
+        // jobs cover it.
+        const itSkipIfBrowser = isRunningInBrowser() ? it.skip : it;
 
         // kubo 0.43's name.publish default ttl is 300s, so the routing-layer cache would serve a
         // stale record for 225s+ (the ttl is jittered down to [0.75, 1.0) of itself, issue #307).
@@ -280,81 +295,85 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
         // failure (which costs another whole jittered park) does not turn a slow CI runner into a
         // red build; the test still fails outright if the safety net never fires at all, which is
         // the property being pinned.
-        it("a newer record still arrives via the safety-net poll when the push wake is lost", async () => {
-            type ManagerArrivalInternals = {
-                _subscribedIpnsArrivalTopics: Set<string>;
-                _syncIpnsArrivalSubscriptions(client: unknown): void;
-                _clearIpnsArrivalSubscriptions(): void;
-            };
-            let managerInternals: ManagerArrivalInternals | undefined;
-            let originalSync: ManagerArrivalInternals["_syncIpnsArrivalSubscriptions"] | undefined;
-            try {
-                const staticRecord = await publishCommunityRecordWithExtraProp({ ttl: SHORT_RECORD_TTL });
-                staticRecordsToCleanUp.push(staticRecord);
-                const community = (await pkc.createCommunity({
-                    address: staticRecord.ipnsObj.signer.address
-                })) as RemoteCommunity;
-                communitiesToStop.push(community);
-                const firstUpdate = new Promise<void>((resolve) => community.once("update", () => resolve()));
-                await community.update();
-                await firstUpdate;
-
-                // The loop runs on the TRACKED updating instance; the instance createCommunity
-                // returned may be a mirror attached to it. The update event also fires INSIDE
-                // updateOnce, while the loop syncs its arrival subscriptions immediately AFTER
-                // updateOnce returns, so poll instead of racing that ordering (same reason as the
-                // stop() test above).
-                const updatingInstance = community._updatingCommunityInstanceWithListeners?.community ?? community;
-                managerInternals = updatingInstance._clientsManager as unknown as ManagerArrivalInternals;
-                const subscribeDeadline = Date.now() + 10_000;
-                while (Date.now() < subscribeDeadline && managerInternals._subscribedIpnsArrivalTopics.size === 0) await sleep(100);
-                expect(
-                    managerInternals._subscribedIpnsArrivalTopics.size,
-                    "the loop must have registered an arrival subscription, otherwise this test is not suppressing anything"
-                ).to.be.greaterThan(0);
-
-                originalSync = managerInternals._syncIpnsArrivalSubscriptions;
-                managerInternals._syncIpnsArrivalSubscriptions = () => {};
-                managerInternals._clearIpnsArrivalSubscriptions();
-                expect(
-                    managerInternals._subscribedIpnsArrivalTopics.size,
-                    "the community under test must hold no arrival subscription once suppressed"
-                ).to.equal(0);
-
-                const newerRecord = JSON.parse(JSON.stringify(staticRecord.communityRecord)) as typeof staticRecord.communityRecord;
-                newerRecord.updatedAt = Math.max(newerRecord.updatedAt + 1, timestamp());
-                newerRecord.signature = await signCommunity({ community: newerRecord, signer: staticRecord.ipnsObj.signer });
-
-                const onUpdate = () => {
-                    if (community.updatedAt === newerRecord.updatedAt) deliveredResolve();
+        itSkipIfBrowser(
+            "a newer record still arrives via the safety-net poll when the push wake is lost",
+            async () => {
+                type ManagerArrivalInternals = {
+                    _subscribedIpnsArrivalTopics: Set<string>;
+                    _syncIpnsArrivalSubscriptions(client: unknown): void;
+                    _clearIpnsArrivalSubscriptions(): void;
                 };
-                let deliveredResolve!: () => void;
-                const delivered = new Promise<void>((resolve) => {
-                    deliveredResolve = resolve;
-                    community.on("update", onUpdate);
-                });
-                await staticRecord.ipnsObj.publishToIpns(JSON.stringify(newerRecord), { ttl: SHORT_RECORD_TTL });
+                let managerInternals: ManagerArrivalInternals | undefined;
+                let originalSync: ManagerArrivalInternals["_syncIpnsArrivalSubscriptions"] | undefined;
+                try {
+                    const staticRecord = await publishCommunityRecordWithExtraProp({ ttl: SHORT_RECORD_TTL });
+                    staticRecordsToCleanUp.push(staticRecord);
+                    const community = (await pkc.createCommunity({
+                        address: staticRecord.ipnsObj.signer.address
+                    })) as RemoteCommunity;
+                    communitiesToStop.push(community);
+                    const firstUpdate = new Promise<void>((resolve) => community.once("update", () => resolve()));
+                    await community.update();
+                    await firstUpdate;
 
-                let deliveredInTime = true;
-                let timer: ReturnType<typeof setTimeout> | undefined;
-                const timeout = new Promise<void>((resolve) => {
-                    timer = setTimeout(() => {
-                        deliveredInTime = false;
-                        resolve();
-                    }, 180_000);
-                });
-                await Promise.race([delivered, timeout]);
-                clearTimeout(timer);
-                community.removeListener("update", onUpdate);
-                expect(
-                    deliveredInTime,
-                    "with the push wake suppressed the jittered safety-net poll must still deliver the newer record; a miss here means a missed push strands the community until it is restarted"
-                ).to.equal(true);
-            } finally {
-                // Hand the loop its real sync back so the community resubscribes on its next
-                // iteration and afterAll's stop() unsubscribes a consistent set.
-                if (managerInternals && originalSync) managerInternals._syncIpnsArrivalSubscriptions = originalSync;
-            }
-        }, 240_000);
+                    // The loop runs on the TRACKED updating instance; the instance createCommunity
+                    // returned may be a mirror attached to it. The update event also fires INSIDE
+                    // updateOnce, while the loop syncs its arrival subscriptions immediately AFTER
+                    // updateOnce returns, so poll instead of racing that ordering (same reason as the
+                    // stop() test above).
+                    const updatingInstance = community._updatingCommunityInstanceWithListeners?.community ?? community;
+                    managerInternals = updatingInstance._clientsManager as unknown as ManagerArrivalInternals;
+                    const subscribeDeadline = Date.now() + 10_000;
+                    while (Date.now() < subscribeDeadline && managerInternals._subscribedIpnsArrivalTopics.size === 0) await sleep(100);
+                    expect(
+                        managerInternals._subscribedIpnsArrivalTopics.size,
+                        "the loop must have registered an arrival subscription, otherwise this test is not suppressing anything"
+                    ).to.be.greaterThan(0);
+
+                    originalSync = managerInternals._syncIpnsArrivalSubscriptions;
+                    managerInternals._syncIpnsArrivalSubscriptions = () => {};
+                    managerInternals._clearIpnsArrivalSubscriptions();
+                    expect(
+                        managerInternals._subscribedIpnsArrivalTopics.size,
+                        "the community under test must hold no arrival subscription once suppressed"
+                    ).to.equal(0);
+
+                    const newerRecord = JSON.parse(JSON.stringify(staticRecord.communityRecord)) as typeof staticRecord.communityRecord;
+                    newerRecord.updatedAt = Math.max(newerRecord.updatedAt + 1, timestamp());
+                    newerRecord.signature = await signCommunity({ community: newerRecord, signer: staticRecord.ipnsObj.signer });
+
+                    const onUpdate = () => {
+                        if (community.updatedAt === newerRecord.updatedAt) deliveredResolve();
+                    };
+                    let deliveredResolve!: () => void;
+                    const delivered = new Promise<void>((resolve) => {
+                        deliveredResolve = resolve;
+                        community.on("update", onUpdate);
+                    });
+                    await staticRecord.ipnsObj.publishToIpns(JSON.stringify(newerRecord), { ttl: SHORT_RECORD_TTL });
+
+                    let deliveredInTime = true;
+                    let timer: ReturnType<typeof setTimeout> | undefined;
+                    const timeout = new Promise<void>((resolve) => {
+                        timer = setTimeout(() => {
+                            deliveredInTime = false;
+                            resolve();
+                        }, 180_000);
+                    });
+                    await Promise.race([delivered, timeout]);
+                    clearTimeout(timer);
+                    community.removeListener("update", onUpdate);
+                    expect(
+                        deliveredInTime,
+                        "with the push wake suppressed the jittered safety-net poll must still deliver the newer record; a miss here means a missed push strands the community until it is restarted"
+                    ).to.equal(true);
+                } finally {
+                    // Hand the loop its real sync back so the community resubscribes on its next
+                    // iteration and afterAll's stop() unsubscribes a consistent set.
+                    if (managerInternals && originalSync) managerInternals._syncIpnsArrivalSubscriptions = originalSync;
+                }
+            },
+            240_000
+        );
     });
 });

--- a/test/node-and-browser/community/update-loop-event-driven.test.ts
+++ b/test/node-and-browser/community/update-loop-event-driven.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { describe, it, beforeAll, afterAll, expect, vi } from "vitest";
 import { getAvailablePKCConfigsToTestAgainst, publishCommunityRecordWithExtraProp } from "../../../dist/node/test/test-util.js";
 import { signCommunity } from "../../../dist/node/signer/signatures.js";
 import { timestamp } from "../../../dist/node/util.js";
@@ -85,6 +85,65 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 recordedStates.length,
                 `an idle updating community must not churn updatingstatechange; saw [${recordedStates.join(", ")}]`
             ).to.be.at.most(4);
+        }, 120_000);
+
+        it("stop() unsubscribes every gossip arrival listener the update loop registered", async () => {
+            // Spy BEFORE the loop starts so every subscribe the loop makes is captured. The
+            // arrival listener map lives on the SHARED libp2p-js client and outlives any one
+            // community, so a listener stop() fails to remove would retain the stopped
+            // community's whole manager graph for the life of the client.
+            const libp2pJsClient = pkc.clients.libp2pJsClients[Object.keys(pkc.clients.libp2pJsClients)[0]];
+            const arrivals = libp2pJsClient.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals;
+            const subscribeSpy = vi.spyOn(arrivals, "subscribe");
+            const unsubscribeSpy = vi.spyOn(arrivals, "unsubscribe");
+            try {
+                const { community } = await startUpdatingStaticCommunityAndAwaitFirstUpdate();
+
+                // The update loop (and so the arrival subscriptions) runs on the TRACKED
+                // updating instance; the instance createCommunity returned may be a mirror
+                // attached to it, whose own manager never runs a loop. Inspect the instance
+                // that actually loops. The update event also fires INSIDE updateOnce while
+                // the loop syncs subscriptions right after it returns, so poll briefly
+                // instead of racing that ordering.
+                const updatingInstance = community._updatingCommunityInstanceWithListeners?.community ?? community;
+                const managerInternals = updatingInstance._clientsManager as unknown as {
+                    _subscribedIpnsArrivalTopics: Set<string>;
+                };
+                const deadline = Date.now() + 10_000;
+                while (Date.now() < deadline && managerInternals._subscribedIpnsArrivalTopics.size === 0) await sleep(100);
+                expect(
+                    managerInternals._subscribedIpnsArrivalTopics.size,
+                    "the loop must have registered at least one arrival subscription after the first update"
+                ).to.be.greaterThan(0);
+                // Scope all spy assertions to THIS community's topics: the spies sit on the
+                // shared client, and another test's still-updating community may add its own
+                // (legitimately still-subscribed) calls while this test runs.
+                const communityTopics = [...managerInternals._subscribedIpnsArrivalTopics];
+                for (const topic of communityTopics)
+                    expect(
+                        subscribeSpy.mock.calls.some(([subscribedTopic]) => subscribedTopic === topic),
+                        `subscribe must have been called for the community's topic ${topic}`
+                    ).to.equal(true);
+
+                await community.stop();
+
+                expect(
+                    managerInternals._subscribedIpnsArrivalTopics.size,
+                    "stop() must clear the manager's arrival subscriptions"
+                ).to.equal(0);
+                // Every (topic, listener) pair this community subscribed must have been
+                // unsubscribed, so the shared client's listener map holds nothing of it.
+                for (const [topic, listener] of subscribeSpy.mock.calls) {
+                    if (!communityTopics.includes(topic)) continue;
+                    expect(
+                        unsubscribeSpy.mock.calls.some(([unsubTopic, unsubListener]) => unsubTopic === topic && unsubListener === listener),
+                        `stop() must unsubscribe the arrival listener it subscribed for topic ${topic}`
+                    ).to.equal(true);
+                }
+            } finally {
+                subscribeSpy.mockRestore();
+                unsubscribeSpy.mockRestore();
+            }
         }, 120_000);
 
         it("a newer record published while updating is still delivered", async () => {

--- a/test/node-and-browser/community/update-loop-event-driven.test.ts
+++ b/test/node-and-browser/community/update-loop-event-driven.test.ts
@@ -258,23 +258,36 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
         // a push was missed (mesh partition, a record published while we had no subscribers, or
         // a regression in the arrival plumbing itself).
         //
-        // Suppressing ipnsRecordArrivals.subscribe is the faithful way to model that: the loop
-        // registers no listener, so nothing can wake it early and only the jittered timeout can
-        // fire. Gossipsub itself keeps running underneath (the record may still land in the
-        // routing-layer cache), which is deliberate — this pins the loss of the WAKE SIGNAL, the
-        // failure mode PR #311 actually introduces, not a total pubsub outage.
+        // The suppression is scoped to THIS community's own manager, never to the shared client's
+        // ipnsRecordArrivals.subscribe. The libp2p-js client is shared by every pkc in the test
+        // run (test-util keys it by a constant so a browser tab does not accumulate Helia nodes),
+        // so stubbing subscribe there would mute the push channel for every other community for
+        // the ~50s this test parks — in the browser, where all suites share one page, that
+        // silently perturbs whichever state-order suites happen to run alongside it.
+        //
+        // Instead: stub the manager's own _syncIpnsArrivalSubscriptions so the loop stops
+        // re-registering, THEN drop the listener it already registered. That order matters — the
+        // loop re-syncs in its finally on every iteration, so clearing first would just be undone
+        // on the next pass. Gossipsub itself keeps running underneath (the record may still land
+        // in the routing-layer cache), which is deliberate: this pins the loss of the WAKE SIGNAL,
+        // the failure mode PR #311 actually introduces, not a total pubsub outage.
         //
         // The record carries a 10s ttl instead of kubo 0.43's 300s default so the bound holds on
         // both branches: whether or not gossip warmed the cache, the safety-net tick that fires
         // at updateInterval * [0.75, 1.25] (45-75s) is guaranteed to find the cache expired and
-        // revalidate against the network. 120s covers that plus the record fetch.
+        // revalidate against the network. Observed at 49.6s and 73.6s across local runs, i.e. the
+        // full jitter range. The budget is 180s rather than ~90s so that one transient resolve
+        // failure (which costs another whole jittered park) does not turn a slow CI runner into a
+        // red build; the test still fails outright if the safety net never fires at all, which is
+        // the property being pinned.
         it("a newer record still arrives via the safety-net poll when the push wake is lost", async () => {
-            const libp2pJsClient = pkc.clients.libp2pJsClients[Object.keys(pkc.clients.libp2pJsClients)[0]];
-            const arrivals = libp2pJsClient.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals;
-            // Spied before the loop starts so the loop never registers an arrival listener at all.
-            // The spy sits on the shared client, so it is restored in finally to avoid muting the
-            // push channel for anything else in this file.
-            const subscribeSpy = vi.spyOn(arrivals, "subscribe").mockImplementation(() => {});
+            type ManagerArrivalInternals = {
+                _subscribedIpnsArrivalTopics: Set<string>;
+                _syncIpnsArrivalSubscriptions(client: unknown): void;
+                _clearIpnsArrivalSubscriptions(): void;
+            };
+            let managerInternals: ManagerArrivalInternals | undefined;
+            let originalSync: ManagerArrivalInternals["_syncIpnsArrivalSubscriptions"] | undefined;
             try {
                 const staticRecord = await publishCommunityRecordWithExtraProp({ ttl: SHORT_RECORD_TTL });
                 staticRecordsToCleanUp.push(staticRecord);
@@ -286,15 +299,27 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 await community.update();
                 await firstUpdate;
 
-                // The update event fires INSIDE updateOnce, while the loop syncs its arrival
-                // subscriptions immediately AFTER updateOnce returns, so poll instead of racing
-                // that ordering (same reason as the stop() test above).
+                // The loop runs on the TRACKED updating instance; the instance createCommunity
+                // returned may be a mirror attached to it. The update event also fires INSIDE
+                // updateOnce, while the loop syncs its arrival subscriptions immediately AFTER
+                // updateOnce returns, so poll instead of racing that ordering (same reason as the
+                // stop() test above).
+                const updatingInstance = community._updatingCommunityInstanceWithListeners?.community ?? community;
+                managerInternals = updatingInstance._clientsManager as unknown as ManagerArrivalInternals;
                 const subscribeDeadline = Date.now() + 10_000;
-                while (Date.now() < subscribeDeadline && subscribeSpy.mock.calls.length === 0) await sleep(100);
+                while (Date.now() < subscribeDeadline && managerInternals._subscribedIpnsArrivalTopics.size === 0) await sleep(100);
                 expect(
-                    subscribeSpy.mock.calls.length,
-                    "the loop must have attempted to register an arrival listener, otherwise this test is not suppressing anything"
+                    managerInternals._subscribedIpnsArrivalTopics.size,
+                    "the loop must have registered an arrival subscription, otherwise this test is not suppressing anything"
                 ).to.be.greaterThan(0);
+
+                originalSync = managerInternals._syncIpnsArrivalSubscriptions;
+                managerInternals._syncIpnsArrivalSubscriptions = () => {};
+                managerInternals._clearIpnsArrivalSubscriptions();
+                expect(
+                    managerInternals._subscribedIpnsArrivalTopics.size,
+                    "the community under test must hold no arrival subscription once suppressed"
+                ).to.equal(0);
 
                 const newerRecord = JSON.parse(JSON.stringify(staticRecord.communityRecord)) as typeof staticRecord.communityRecord;
                 newerRecord.updatedAt = Math.max(newerRecord.updatedAt + 1, timestamp());
@@ -316,7 +341,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                     timer = setTimeout(() => {
                         deliveredInTime = false;
                         resolve();
-                    }, 120_000);
+                    }, 180_000);
                 });
                 await Promise.race([delivered, timeout]);
                 clearTimeout(timer);
@@ -326,7 +351,9 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                     "with the push wake suppressed the jittered safety-net poll must still deliver the newer record; a miss here means a missed push strands the community until it is restarted"
                 ).to.equal(true);
             } finally {
-                subscribeSpy.mockRestore();
+                // Hand the loop its real sync back so the community resubscribes on its next
+                // iteration and afterAll's stop() unsubscribes a consistent set.
+                if (managerInternals && originalSync) managerInternals._syncIpnsArrivalSubscriptions = originalSync;
             }
         }, 240_000);
     });

--- a/test/node-and-browser/community/update-loop-event-driven.test.ts
+++ b/test/node-and-browser/community/update-loop-event-driven.test.ts
@@ -5,7 +5,7 @@ import {
     publishCommunityRecordWithExtraProp
 } from "../../../dist/node/test/test-util.js";
 import { signCommunity } from "../../../dist/node/signer/signatures.js";
-import { timestamp } from "../../../dist/node/util.js";
+import { ipnsNameToIpnsOverPubsubTopic, timestamp } from "../../../dist/node/util.js";
 
 import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
 import type { RemoteCommunity } from "../../../dist/node/community/remote-community.js";
@@ -266,6 +266,143 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                     Date.now() - parkStartedAt,
                     "a delegation change must skip the park so the loop walks the new chain now"
                 ).to.be.below(2000);
+            });
+        });
+
+        // The arrival plumbing must follow the community's identity wherever the identity is
+        // decided, not only at the two loop-owned sync points (pre-first-cycle and post-
+        // updateOnce). Each case below is a state the old 1s poll covered for free and the
+        // event-driven loop must cover explicitly, exercised as unit sequences on idle
+        // managers so the ordering is deterministic.
+        describe("arrival subscriptions and pending arrivals follow identity changes", () => {
+            type ManagerIdentityInternals = {
+                _subscribedIpnsArrivalTopics: Set<string>;
+                _pendingIpnsArrivalHopTargets: Set<string>;
+                _nextResolveRevalidatesNetwork: boolean;
+                _syncIpnsArrivalSubscriptions(client: unknown): void;
+                _clearIpnsArrivalSubscriptions(): void;
+                _applyKeyMigration(args: { communityName: string; newPublicKey: string }): void;
+                _onIpnsRecordArrival(arrival: { pubsubTopic: string; record: { value: string } }): void;
+                _sleepUntilIpnsArrivalOrTimeoutOrAbort(args: { ms: number; signal?: AbortSignal }): Promise<void>;
+                resolveIpnsToCidP2P(ipnsName: string, opts: { nocache?: boolean }): Promise<unknown>;
+                fetchNewUpdateForCommunity(communityAddress: string): Promise<unknown>;
+            };
+            const libp2pJsClientOf = (instance: PKCType) =>
+                instance.clients.libp2pJsClients[Object.keys(instance.clients.libp2pJsClients)[0]];
+
+            it("a domain community created with a known publicKey arms that key's topic before its first update", async () => {
+                // createCommunity({ address: domain, publicKey }) skips name resolution: the first
+                // fetch pins to publicKey (fetchNewUpdateForCommunity). The pre-loop arm must derive
+                // the same name, otherwise the first cycle runs with no listener and a record
+                // pushed mid-first-fetch is dropped at the source until the first safety-net tick.
+                const signer = await pkc.createSigner();
+                const community = (await pkc.createCommunity({ address: "plebbit.bso", publicKey: signer.address })) as RemoteCommunity;
+                const manager = community._clientsManager as unknown as ManagerIdentityInternals;
+                try {
+                    manager._syncIpnsArrivalSubscriptions(libp2pJsClientOf(pkc));
+                    expect(
+                        [...manager._subscribedIpnsArrivalTopics],
+                        "the pre-loop arm must watch the pinned publicKey's topic for a domain+publicKey community"
+                    ).to.deep.equal([ipnsNameToIpnsOverPubsubTopic(signer.address)]);
+                } finally {
+                    manager._clearIpnsArrivalSubscriptions();
+                }
+            });
+
+            it("a key migration moves the arrival subscription to the new key and drops the old key's pending arrivals", async () => {
+                const oldSigner = await pkc.createSigner();
+                const newSigner = await pkc.createSigner();
+                const community = (await pkc.createCommunity({
+                    address: "migrating.bso",
+                    publicKey: oldSigner.address
+                })) as RemoteCommunity;
+                const manager = community._clientsManager as unknown as ManagerIdentityInternals;
+                try {
+                    manager._syncIpnsArrivalSubscriptions(libp2pJsClientOf(pkc));
+                    expect([...manager._subscribedIpnsArrivalTopics]).to.deep.equal([ipnsNameToIpnsOverPubsubTopic(oldSigner.address)]);
+                    // An old-key arrival queued before the migration fires: with updateCid and the
+                    // loaded set cleared by the migration nothing filters it, so unless the
+                    // migration drops it the next park fast-returns into a wasted old-key cycle.
+                    manager._onIpnsRecordArrival({
+                        pubsubTopic: ipnsNameToIpnsOverPubsubTopic(oldSigner.address),
+                        record: { value: "/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi" }
+                    });
+
+                    manager._applyKeyMigration({ communityName: "migrating.bso", newPublicKey: newSigner.address });
+
+                    expect(community.publicKey).to.equal(newSigner.address);
+                    expect(
+                        [...manager._subscribedIpnsArrivalTopics],
+                        "after a key migration the loop must watch ONLY the new key's topic, immediately, not after the new key's record is fetched"
+                    ).to.deep.equal([ipnsNameToIpnsOverPubsubTopic(newSigner.address)]);
+                    const parkStartedAt = Date.now();
+                    await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort({ ms: 400 });
+                    expect(
+                        Date.now() - parkStartedAt,
+                        "the old key's pending arrival must not survive the migration and fast-return the park"
+                    ).to.be.at.least(350);
+                } finally {
+                    manager._clearIpnsArrivalSubscriptions();
+                }
+            });
+
+            it("an arrival that wakes the park is consumed by that wake, so a cycle that fails to change the chain is not re-run", async () => {
+                // A hop record delegating outside the walked chain wakes the park; if the walk it
+                // triggers fails without updating ipnsHops (e.g. ERR_IPNS_MAX_HOPS_EXCEEDED, a
+                // non-retriable error), the still-pending hop target must not fast-return the next
+                // park into an identical failing walk: two error events per push instead of one.
+                const signer = await pkc.createSigner();
+                const community = (await pkc.createCommunity({ address: signer.address })) as RemoteCommunity;
+                const manager = community._clientsManager as unknown as ManagerIdentityInternals;
+                community.ipnsHops = ["anchorhopname", "minterhopname"];
+                const wokenPark = manager._sleepUntilIpnsArrivalOrTimeoutOrAbort({ ms: 10_000 });
+                await sleep(100);
+                manager._onIpnsRecordArrival({ pubsubTopic: "/record/anchor", record: { value: "/ipns/replacementminter" } });
+                const wokenParkStartedAt = Date.now();
+                await wokenPark;
+                expect(Date.now() - wokenParkStartedAt, "the arrival must wake the park").to.be.below(2000);
+
+                // The walk that followed failed: the chain is unchanged.
+                const parkStartedAt = Date.now();
+                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort({ ms: 400 });
+                expect(
+                    Date.now() - parkStartedAt,
+                    "the park that follows the woken cycle must sleep its full period: the arrival was already reacted to"
+                ).to.be.at.least(350);
+            });
+
+            it("a forced network revalidation is consumed by the first resolve attempt so retries within the cycle ride the cache", async () => {
+                // _nextResolveRevalidatesNetwork is set by a timer-fired park and read per
+                // resolve. updateOnce retries fetchNewUpdateForCommunity forever on retriable
+                // errors (e.g. a CID fetch timeout AFTER a successful resolve), and every attempt
+                // must not re-resolve IPNS over the network: master's retries re-read the cache.
+                const signer = await pkc.createSigner();
+                const community = (await pkc.createCommunity({ address: signer.address })) as RemoteCommunity;
+                const manager = community._clientsManager as unknown as ManagerIdentityInternals;
+                const resolveSpy = vi
+                    .spyOn(manager, "resolveIpnsToCidP2P")
+                    .mockImplementation((): Promise<never> => Promise.reject(new Error("simulated resolve failure")));
+                try {
+                    manager._nextResolveRevalidatesNetwork = true;
+                    for (let attempt = 0; attempt < 2; attempt++) {
+                        try {
+                            await manager.fetchNewUpdateForCommunity(signer.address);
+                        } catch {
+                            // every attempt fails at the resolve: only its options matter here
+                        }
+                    }
+                    expect(resolveSpy.mock.calls.length).to.equal(2);
+                    expect(
+                        resolveSpy.mock.calls[0][1].nocache,
+                        "the first attempt after a timer-fired park must revalidate on the network"
+                    ).to.equal(true);
+                    expect(
+                        resolveSpy.mock.calls[1][1].nocache,
+                        "the retry attempt within the same cycle must not force the network again"
+                    ).to.not.equal(true);
+                } finally {
+                    resolveSpy.mockRestore();
+                }
             });
         });
 

--- a/test/node-and-browser/community/update-loop-event-driven.test.ts
+++ b/test/node-and-browser/community/update-loop-event-driven.test.ts
@@ -142,7 +142,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 const communityTopics = [...managerInternals._subscribedIpnsArrivalTopics];
                 for (const topic of communityTopics)
                     expect(
-                        subscribeSpy.mock.calls.some(([subscribedTopic]) => subscribedTopic === topic),
+                        subscribeSpy.mock.calls.some(([subscribed]) => subscribed.pubsubTopic === topic),
                         `subscribe must have been called for the community's topic ${topic}`
                     ).to.equal(true);
 
@@ -154,10 +154,12 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 ).to.equal(0);
                 // Every (topic, listener) pair this community subscribed must have been
                 // unsubscribed, so the shared client's listener map holds nothing of it.
-                for (const [topic, listener] of subscribeSpy.mock.calls) {
+                for (const [{ pubsubTopic: topic, listener }] of subscribeSpy.mock.calls) {
                     if (!communityTopics.includes(topic)) continue;
                     expect(
-                        unsubscribeSpy.mock.calls.some(([unsubTopic, unsubListener]) => unsubTopic === topic && unsubListener === listener),
+                        unsubscribeSpy.mock.calls.some(
+                            ([unsubscribed]) => unsubscribed.pubsubTopic === topic && unsubscribed.listener === listener
+                        ),
                         `stop() must unsubscribe the arrival listener it subscribed for topic ${topic}`
                     ).to.equal(true);
                 }
@@ -180,7 +182,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
         describe("the park re-checks pending arrivals against post-update state", () => {
             type ManagerParkInternals = {
                 _onIpnsRecordArrival(arrival: { pubsubTopic: string; record: { value: string } }): void;
-                _sleepUntilIpnsArrivalOrTimeoutOrAbort(ms: number, signal?: AbortSignal): Promise<void>;
+                _sleepUntilIpnsArrivalOrTimeoutOrAbort(args: { ms: number; signal?: AbortSignal }): Promise<void>;
                 _updateCidsAlreadyLoaded: { add(cid: string): void };
             };
             const makeIdleManager = async () => {
@@ -200,7 +202,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 // updateOnce then finishes consuming exactly that record.
                 manager._updateCidsAlreadyLoaded.add(CID_A);
                 const parkStartedAt = Date.now();
-                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort(400);
+                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort({ ms: 400 });
                 expect(
                     Date.now() - parkStartedAt,
                     "the park must sleep its full period: its only pending arrival was consumed by the cycle that produced it"
@@ -212,7 +214,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 manager._onIpnsRecordArrival({ pubsubTopic: "/record/test", record: { value: `/ipfs/${CID_B}` } });
                 manager._updateCidsAlreadyLoaded.add(CID_A); // the cycle consumed something else
                 const parkStartedAt = Date.now();
-                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort(10_000);
+                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort({ ms: 10_000 });
                 expect(
                     Date.now() - parkStartedAt,
                     "a genuinely unconsumed arrival must skip the park so the loop reacts to the push"
@@ -223,7 +225,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 const { manager } = await makeIdleManager();
                 manager._onIpnsRecordArrival({ pubsubTopic: "/record/test", record: { value: "/ipns/someintermediatehopname" } });
                 const parkStartedAt = Date.now();
-                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort(10_000);
+                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort({ ms: 10_000 });
                 expect(
                     Date.now() - parkStartedAt,
                     "a hop record pointing outside any walked chain always warrants an immediate walk"
@@ -246,7 +248,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 // updateOnce then finishes having walked exactly that chain.
                 community.ipnsHops = ["anchorhopname", "minterhopname"];
                 const parkStartedAt = Date.now();
-                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort(400);
+                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort({ ms: 400 });
                 expect(
                     Date.now() - parkStartedAt,
                     "the park must sleep its full period: the pending hop arrival names a hop the cycle that produced it already walked (an anchor republish, not a delegation change)"
@@ -259,7 +261,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 // The anchor's record now delegates to a DIFFERENT minter: genuinely news.
                 manager._onIpnsRecordArrival({ pubsubTopic: "/record/anchor", record: { value: "/ipns/replacementminter" } });
                 const parkStartedAt = Date.now();
-                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort(10_000);
+                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort({ ms: 10_000 });
                 expect(
                     Date.now() - parkStartedAt,
                     "a delegation change must skip the park so the loop walks the new chain now"
@@ -454,7 +456,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                     _clearIpnsArrivalSubscriptions(): void;
                 };
                 let managerInternals: ManagerArrivalInternals | undefined;
-                let originalSync: ManagerArrivalInternals["_syncIpnsArrivalSubscriptions"] | undefined;
+                let syncSpy: { mockRestore(): void } | undefined;
                 try {
                     const staticRecord = await publishCommunityRecordWithExtraProp({ ttl: SHORT_RECORD_TTL });
                     staticRecordsToCleanUp.push(staticRecord);
@@ -480,8 +482,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                         "the loop must have registered an arrival subscription, otherwise this test is not suppressing anything"
                     ).to.be.greaterThan(0);
 
-                    originalSync = managerInternals._syncIpnsArrivalSubscriptions;
-                    managerInternals._syncIpnsArrivalSubscriptions = () => {};
+                    syncSpy = vi.spyOn(managerInternals, "_syncIpnsArrivalSubscriptions").mockImplementation(() => {});
                     managerInternals._clearIpnsArrivalSubscriptions();
                     expect(
                         managerInternals._subscribedIpnsArrivalTopics.size,
@@ -520,7 +521,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 } finally {
                     // Hand the loop its real sync back so the community resubscribes on its next
                     // iteration and afterAll's stop() unsubscribes a consistent set.
-                    if (managerInternals && originalSync) managerInternals._syncIpnsArrivalSubscriptions = originalSync;
+                    syncSpy?.mockRestore();
                 }
             },
             240_000

--- a/test/node-and-browser/community/update-loop-event-driven.test.ts
+++ b/test/node-and-browser/community/update-loop-event-driven.test.ts
@@ -310,60 +310,75 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
         // still holds the OLD record well inside its ttl (kubo 0.43 publishes 300s, jittered
         // down to no less than 225s, issue #307), so the tick does zero network work, serves
         // the stale cid, and parks again — a missed push then strands the community for the
-        // record's whole ttl instead of the one updateInterval the safety net promises (master's
-        // 1s poll was bounded by ~ttl too, but re-checked every second). A timer-fired (non-
-        // arrival) wake must therefore resolve with nocache: true. Oracle: spy the resolver's
-        // name.resolve options rather than racing a real 225s staleness window.
-        it("a safety-net tick revalidates against the network instead of riding the routing-layer cache", async () => {
-            const SAFETY_NET_INTERVAL_MS = 3000;
-            // Own pkc: the suite instance runs the production 60s interval, which would park
-            // this test for minutes per tick.
-            const shortIntervalPkc = await config.pkcInstancePromise({ pkcOptions: { updateInterval: SAFETY_NET_INTERVAL_MS } });
-            const libp2pJsClient = shortIntervalPkc.clients.libp2pJsClients[Object.keys(shortIntervalPkc.clients.libp2pJsClients)[0]];
-            const clientFunctions = libp2pJsClient.heliaWithKuboRpcClientFunctions;
-            const originalResolve = clientFunctions.name.resolve.bind(clientFunctions.name);
-            const safetyNetResolveNocacheValues: (boolean | undefined)[] = [];
-            let recording = false;
-            try {
-                const staticRecord = await publishCommunityRecordWithExtraProp();
-                staticRecordsToCleanUp.push(staticRecord);
-                const community = (await shortIntervalPkc.createCommunity({
-                    address: staticRecord.ipnsObj.signer.address
-                })) as RemoteCommunity;
-                const firstUpdate = new Promise<void>((resolve) => community.once("update", () => resolve()));
-                await community.update();
-                await firstUpdate;
+        // record's whole ttl instead of the bound the safety net promises (master's 1s poll was
+        // bounded by ~ttl too, but re-checked every second). Timer-fired (non-arrival) wakes
+        // must therefore resolve with nocache: true — bounded by the 30s revalidation floor, so
+        // a sub-30s updateInterval (every test pkc defaults to 500ms) does not force the
+        // network on each tick: unfloored, the loop's duty cycle flips from parked-in-
+        // waiting-retry to mid-fetching-ipns, which tripped the browser CI legs' state-sampling
+        // assertions. The promised staleness bound is max(updateInterval, floor). Oracle: spy
+        // the resolver's name.resolve options rather than racing a real 225s staleness window.
+        //
+        // Node only for the same load reason as the park test above: with the floor, observing
+        // two forced revalidations keeps an updating community live for ~65s on the shared
+        // browser page, and the logic has no browser-specific component.
+        itSkipIfBrowser(
+            "safety-net ticks revalidate against the network at the floored cadence instead of riding the cache",
+            async () => {
+                const SAFETY_NET_INTERVAL_MS = 3000;
+                // Own pkc: the suite instance runs the production 60s interval, which would park
+                // this test for minutes per tick.
+                const shortIntervalPkc = await config.pkcInstancePromise({ pkcOptions: { updateInterval: SAFETY_NET_INTERVAL_MS } });
+                const libp2pJsClient = shortIntervalPkc.clients.libp2pJsClients[Object.keys(shortIntervalPkc.clients.libp2pJsClients)[0]];
+                const clientFunctions = libp2pJsClient.heliaWithKuboRpcClientFunctions;
+                const originalResolve = clientFunctions.name.resolve.bind(clientFunctions.name);
+                const safetyNetResolveNocacheValues: (boolean | undefined)[] = [];
+                let recording = false;
+                try {
+                    const staticRecord = await publishCommunityRecordWithExtraProp();
+                    staticRecordsToCleanUp.push(staticRecord);
+                    const community = (await shortIntervalPkc.createCommunity({
+                        address: staticRecord.ipnsObj.signer.address
+                    })) as RemoteCommunity;
+                    const firstUpdate = new Promise<void>((resolve) => community.once("update", () => resolve()));
+                    await community.update();
+                    await firstUpdate;
 
-                // Record only resolves of THIS community's name from after the first update
-                // cycle: the record is static and nothing publishes to it, so every recorded
-                // resolve is a timer-fired safety-net tick, never an arrival-woken one. The
-                // client functions object is shared across pkc instances (test-util keys the
-                // helia client by a constant), hence the name filter.
-                clientFunctions.name.resolve = ((name, options) => {
-                    if (recording && String(name) === staticRecord.ipnsObj.signer.address)
-                        safetyNetResolveNocacheValues.push(options?.nocache);
-                    return originalResolve(name, options);
-                }) as typeof clientFunctions.name.resolve;
-                recording = true;
+                    // Record only resolves of THIS community's name from after the first update
+                    // cycle: the record is static and nothing publishes to it, so every recorded
+                    // resolve is a timer-fired safety-net tick, never an arrival-woken one. The
+                    // client functions object is shared across pkc instances (test-util keys the
+                    // helia client by a constant), hence the name filter.
+                    clientFunctions.name.resolve = ((name, options) => {
+                        if (recording && String(name) === staticRecord.ipnsObj.signer.address)
+                            safetyNetResolveNocacheValues.push(options?.nocache);
+                        return originalResolve(name, options);
+                    }) as typeof clientFunctions.name.resolve;
+                    recording = true;
 
-                const deadline = Date.now() + 30_000;
-                while (safetyNetResolveNocacheValues.length < 2 && Date.now() < deadline) await sleep(200);
-                await community.stop();
+                    // The floor counts from the loop start, so the two forced revalidations land
+                    // ~30s and ~60s in; the deadline leaves headroom for a loaded runner and the
+                    // tick jitter.
+                    const forcedCount = () => safetyNetResolveNocacheValues.filter((nocache) => nocache === true).length;
+                    const deadline = Date.now() + 90_000;
+                    while (forcedCount() < 2 && Date.now() < deadline) await sleep(500);
+                    await community.stop();
 
-                expect(
-                    safetyNetResolveNocacheValues.length,
-                    "the safety-net poll must have ticked at least twice inside the window"
-                ).to.be.greaterThanOrEqual(2);
-                for (const nocache of safetyNetResolveNocacheValues)
                     expect(
-                        nocache,
-                        "a timer-fired safety-net tick must resolve with nocache: true — through the cache gate it can never observe a push it missed, leaving the community stale for the record's whole ttl instead of one updateInterval"
-                    ).to.equal(true);
-            } finally {
-                clientFunctions.name.resolve = originalResolve;
-                await shortIntervalPkc.destroy();
-            }
-        }, 120_000);
+                        forcedCount(),
+                        "timer-fired safety-net ticks must force nocache revalidations at the floored cadence — through the cache gate the net can never observe a push it missed, leaving the community stale for the record's whole ttl instead of max(updateInterval, floor)"
+                    ).to.be.greaterThanOrEqual(2);
+                    expect(
+                        safetyNetResolveNocacheValues.filter((nocache) => nocache !== true).length,
+                        "ticks inside the 30s revalidation floor must keep riding the routing-layer cache: a sub-30s updateInterval must not force the network on every tick"
+                    ).to.be.greaterThanOrEqual(2);
+                } finally {
+                    clientFunctions.name.resolve = originalResolve;
+                    await shortIntervalPkc.destroy();
+                }
+            },
+            150_000
+        );
 
         it("a newer record published while updating is still delivered", async () => {
             const { community, staticRecord } = await startUpdatingStaticCommunityAndAwaitFirstUpdate();

--- a/test/node-and-browser/community/update-loop-event-driven.test.ts
+++ b/test/node-and-browser/community/update-loop-event-driven.test.ts
@@ -146,6 +146,69 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             }
         }, 120_000);
 
+        // The arrival listener fires from the wrapped localStore.put MID-updateOnce (inside
+        // resolveIpnsToCidP2P's direct-fetch cache write), BEFORE updateOnce records the cid in
+        // _updateCidsAlreadyLoaded / updateCid. The filter in _onIpnsRecordArrival therefore
+        // cannot tell the loop's own fetch of a new record from a genuinely unconsumed push, and
+        // the park must re-check pending arrivals against POST-updateOnce state instead of
+        // fast-returning on a stale boolean — otherwise every record change the loop discovers
+        // itself (a missed gossip push picked up by the safety net) triggers one redundant full
+        // updateOnce plus a phantom fetching-ipns/waiting-retry pair, reintroducing #308 churn.
+        // Exercised as a unit sequence on a non-updating community's manager so the mid-flight
+        // ordering is deterministic instead of raced through the real network.
+        describe("the park re-checks pending arrivals against post-update state", () => {
+            type ManagerParkInternals = {
+                _onIpnsRecordArrival(arrival: { pubsubTopic: string; record: { value: string } }): void;
+                _sleepUntilIpnsArrivalOrTimeoutOrAbort(ms: number, signal?: AbortSignal): Promise<void>;
+                _updateCidsAlreadyLoaded: { add(cid: string): void };
+            };
+            const makeIdleManager = async () => {
+                // A fresh, never-updated community: its manager has no running loop, so parking it
+                // directly cannot collide with a live loop's wake slot.
+                const signer = await pkc.createSigner();
+                const community = (await pkc.createCommunity({ address: signer.address })) as RemoteCommunity;
+                return community._clientsManager as unknown as ManagerParkInternals;
+            };
+            const CID_A = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+            const CID_B = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku";
+
+            it("an arrival consumed by the update cycle it woke does not fast-return the park (issue #308)", async () => {
+                const manager = await makeIdleManager();
+                // Mid-updateOnce: the loop's own cache write reports the record being consumed.
+                manager._onIpnsRecordArrival({ pubsubTopic: "/record/test", record: { value: `/ipfs/${CID_A}` } });
+                // updateOnce then finishes consuming exactly that record.
+                manager._updateCidsAlreadyLoaded.add(CID_A);
+                const parkStartedAt = Date.now();
+                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort(400);
+                expect(
+                    Date.now() - parkStartedAt,
+                    "the park must sleep its full period: its only pending arrival was consumed by the cycle that produced it"
+                ).to.be.at.least(350);
+            });
+
+            it("an arrival the update cycle did not consume still fast-returns the park", async () => {
+                const manager = await makeIdleManager();
+                manager._onIpnsRecordArrival({ pubsubTopic: "/record/test", record: { value: `/ipfs/${CID_B}` } });
+                manager._updateCidsAlreadyLoaded.add(CID_A); // the cycle consumed something else
+                const parkStartedAt = Date.now();
+                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort(10_000);
+                expect(
+                    Date.now() - parkStartedAt,
+                    "a genuinely unconsumed arrival must skip the park so the loop reacts to the push"
+                ).to.be.below(2000);
+            });
+
+            it("an intermediate-hop (/ipns/ value) arrival fast-returns the park", async () => {
+                const manager = await makeIdleManager();
+                manager._onIpnsRecordArrival({ pubsubTopic: "/record/test", record: { value: "/ipns/someintermediatehopname" } });
+                const parkStartedAt = Date.now();
+                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort(10_000);
+                expect(Date.now() - parkStartedAt, "a newer delegated-chain hop record always warrants an immediate walk").to.be.below(
+                    2000
+                );
+            });
+        });
+
         it("a newer record published while updating is still delivered", async () => {
             const { community, staticRecord } = await startUpdatingStaticCommunityAndAwaitFirstUpdate();
 
@@ -153,26 +216,34 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             newerRecord.updatedAt = Math.max(newerRecord.updatedAt + 1, timestamp());
             newerRecord.signature = await signCommunity({ community: newerRecord, signer: staticRecord.ipnsObj.signer });
 
+            const onUpdate = () => {
+                if (community.updatedAt === newerRecord.updatedAt) deliveredResolve();
+            };
+            let deliveredResolve!: () => void;
             const delivered = new Promise<void>((resolve) => {
-                const onUpdate = () => {
-                    if (community.updatedAt === newerRecord.updatedAt) {
-                        community.removeListener("update", onUpdate);
-                        resolve();
-                    }
-                };
+                deliveredResolve = resolve;
                 community.on("update", onUpdate);
             });
             await staticRecord.ipnsObj.publishToIpns(JSON.stringify(newerRecord));
 
-            // On master the 1s polling loop delivers this within a couple of seconds. After
-            // the fix delivery rides the gossipsub push channel (or, if the push is missed,
-            // the safety-net poll), so allow one full jittered safety-net period.
+            // On master the 1s polling loop delivers this within a couple of seconds. After the
+            // fix delivery rides the gossipsub push channel; if the push is missed, worst case is
+            // a safety-net tick that still serves the stale record inside its jittered effective
+            // ttl (up to 60s, issue #307) followed by one full jittered safety-net period (up to
+            // 75s) before the revalidating tick — ~135s total, so allow 150s. The losing timer is
+            // cleared so no 150s handle outlives the test.
             let deliveredInTime = true;
-            const timer = sleep(120_000).then(() => {
-                deliveredInTime = false;
+            let timer: ReturnType<typeof setTimeout> | undefined;
+            const timeout = new Promise<void>((resolve) => {
+                timer = setTimeout(() => {
+                    deliveredInTime = false;
+                    resolve();
+                }, 150_000);
             });
-            await Promise.race([delivered, timer]);
+            await Promise.race([delivered, timeout]);
+            clearTimeout(timer);
+            community.removeListener("update", onUpdate);
             expect(deliveredInTime, "the newer community record must reach the updating community").to.equal(true);
-        }, 180_000);
+        }, 240_000);
     });
 });

--- a/test/node-and-browser/community/update-loop-event-driven.test.ts
+++ b/test/node-and-browser/community/update-loop-event-driven.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { getAvailablePKCConfigsToTestAgainst, publishCommunityRecordWithExtraProp } from "../../../dist/node/test/test-util.js";
+import { signCommunity } from "../../../dist/node/signer/signatures.js";
+import { timestamp } from "../../../dist/node/util.js";
+
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { RemoteCommunity } from "../../../dist/node/community/remote-community.js";
+
+// Repro suite for issue #308: with a libp2p-js client the update loop re-runs updateOnce every
+// second per community even though the transport is push-based (gossipsub delivers new records
+// the moment they are published, and since issue #301 they land in the routing-layer cache).
+// Post-#302 each 1s tick is a local cache read, but it still walks the full
+// updateOnce -> fetchNewUpdateForCommunity pipeline and oscillates updatingState between
+// waiting-retry and fetching-ipns, emitting two real updatingstatechange events per tick per
+// community while nothing changed (~110 events/s measured at 64 communities). The loop should
+// instead react to pushed records, with only a slow jittered safety-net poll for missed pushes.
+//
+// Expected on master: the churn test FAILS (an idle community emits ~2 transitions/s in the
+// observation window); the delivery test passes (polling delivers the new record) and must stay
+// green after the fix, where gossip push replaces polling as the delivery mechanism.
+//
+// remote-libp2pjs only: the event-driven path applies when the default record resolver is a
+// libp2p-js client. The kubo-RPC path keeps its polling loop for now (its push channel needs
+// kubo-side pubsub plumbing, tracked separately in issue #308) and gateways already poll at
+// pkc.updateInterval.
+getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"] }).map((config) => {
+    describe(`community update loop is event-driven, not 1s polling (issue #308) - ${config.name}`, () => {
+        let pkc: PKCType;
+        const communitiesToStop: RemoteCommunity[] = [];
+        const staticRecordsToCleanUp: Awaited<ReturnType<typeof publishCommunityRecordWithExtraProp>>[] = [];
+
+        beforeAll(async () => {
+            pkc = await config.pkcInstancePromise();
+        });
+        afterAll(async () => {
+            for (const community of communitiesToStop.splice(0)) {
+                try {
+                    await community.stop();
+                } catch {
+                    // already stopped
+                }
+            }
+            for (const staticRecord of staticRecordsToCleanUp.splice(0)) await staticRecord.ipnsObj.pkc.destroy();
+            await pkc.destroy();
+        });
+
+        const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+        // Every call publishes a fresh static community record under a fresh IPNS key, so each
+        // test drives its own update loop instead of attaching as a mirror to a loop another
+        // test already started for a shared address.
+        const startUpdatingStaticCommunityAndAwaitFirstUpdate = async () => {
+            const staticRecord = await publishCommunityRecordWithExtraProp();
+            staticRecordsToCleanUp.push(staticRecord);
+            const community = (await pkc.createCommunity({ address: staticRecord.ipnsObj.signer.address })) as RemoteCommunity;
+            communitiesToStop.push(community);
+            const firstUpdate = new Promise<void>((resolve) => community.once("update", () => resolve()));
+            await community.update();
+            await firstUpdate;
+            return { community, staticRecord };
+        };
+
+        it("an updating community whose record does not change stops churning updatingstatechange", async () => {
+            const { community } = await startUpdatingStaticCommunityAndAwaitFirstUpdate();
+            // Let the tail of the first update cycle (fetching-ipfs -> succeeded and any
+            // background name classification) settle before judging steady state.
+            await sleep(2000);
+
+            const observationWindowMs = 12_000;
+            const recordedStates: string[] = [];
+            const onStateChange = (newState: RemoteCommunity["updatingState"]) => recordedStates.push(newState);
+            community.on("updatingstatechange", onStateChange);
+            await sleep(observationWindowMs);
+            community.removeListener("updatingstatechange", onStateChange);
+
+            // On master this is ~2 transitions per second (waiting-retry -> fetching-ipns and
+            // back on every 1s tick), i.e. ~24 in this window. Event-driven, an idle community
+            // in a 12s window sees no safety-net tick (its jittered period is much longer), so
+            // at most a stray transition pair may land.
+            expect(
+                recordedStates.length,
+                `an idle updating community must not churn updatingstatechange; saw [${recordedStates.join(", ")}]`
+            ).to.be.at.most(4);
+        }, 120_000);
+
+        it("a newer record published while updating is still delivered", async () => {
+            const { community, staticRecord } = await startUpdatingStaticCommunityAndAwaitFirstUpdate();
+
+            const newerRecord = JSON.parse(JSON.stringify(staticRecord.communityRecord)) as typeof staticRecord.communityRecord;
+            newerRecord.updatedAt = Math.max(newerRecord.updatedAt + 1, timestamp());
+            newerRecord.signature = await signCommunity({ community: newerRecord, signer: staticRecord.ipnsObj.signer });
+
+            const delivered = new Promise<void>((resolve) => {
+                const onUpdate = () => {
+                    if (community.updatedAt === newerRecord.updatedAt) {
+                        community.removeListener("update", onUpdate);
+                        resolve();
+                    }
+                };
+                community.on("update", onUpdate);
+            });
+            await staticRecord.ipnsObj.publishToIpns(JSON.stringify(newerRecord));
+
+            // On master the 1s polling loop delivers this within a couple of seconds. After
+            // the fix delivery rides the gossipsub push channel (or, if the push is missed,
+            // the safety-net poll), so allow one full jittered safety-net period.
+            let deliveredInTime = true;
+            const timer = sleep(120_000).then(() => {
+                deliveredInTime = false;
+            });
+            await Promise.race([delivered, timer]);
+            expect(deliveredInTime, "the newer community record must reach the updating community").to.equal(true);
+        }, 180_000);
+    });
+});

--- a/test/node-and-browser/community/update-loop-event-driven.test.ts
+++ b/test/node-and-browser/community/update-loop-event-driven.test.ts
@@ -50,6 +50,12 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
 
         const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+        // kubo 0.43's name.publish default ttl is 300s, so the routing-layer cache would serve a
+        // stale record for 225s+ (the ttl is jittered down to [0.75, 1.0) of itself, issue #307).
+        // The safety-net test has to observe a cache expiry inside its own timeout, so it
+        // publishes with a short ttl instead of waiting out kubo's default.
+        const SHORT_RECORD_TTL = "10s";
+
         // Every call publishes a fresh static community record under a fresh IPNS key, so each
         // test drives its own update loop instead of attaching as a mirror to a loop another
         // test already started for a shared address.
@@ -244,6 +250,84 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             clearTimeout(timer);
             community.removeListener("update", onUpdate);
             expect(deliveredInTime, "the newer community record must reach the updating community").to.equal(true);
+        }, 240_000);
+
+        // The safety net is the whole reason it is safe to stop polling, and nothing exercised
+        // it: every other test here is satisfied by the push channel, so a loop that ONLY ever
+        // woke on pushes would pass them all and then strand a community forever the first time
+        // a push was missed (mesh partition, a record published while we had no subscribers, or
+        // a regression in the arrival plumbing itself).
+        //
+        // Suppressing ipnsRecordArrivals.subscribe is the faithful way to model that: the loop
+        // registers no listener, so nothing can wake it early and only the jittered timeout can
+        // fire. Gossipsub itself keeps running underneath (the record may still land in the
+        // routing-layer cache), which is deliberate — this pins the loss of the WAKE SIGNAL, the
+        // failure mode PR #311 actually introduces, not a total pubsub outage.
+        //
+        // The record carries a 10s ttl instead of kubo 0.43's 300s default so the bound holds on
+        // both branches: whether or not gossip warmed the cache, the safety-net tick that fires
+        // at updateInterval * [0.75, 1.25] (45-75s) is guaranteed to find the cache expired and
+        // revalidate against the network. 120s covers that plus the record fetch.
+        it("a newer record still arrives via the safety-net poll when the push wake is lost", async () => {
+            const libp2pJsClient = pkc.clients.libp2pJsClients[Object.keys(pkc.clients.libp2pJsClients)[0]];
+            const arrivals = libp2pJsClient.heliaWithKuboRpcClientFunctions.ipnsRecordArrivals;
+            // Spied before the loop starts so the loop never registers an arrival listener at all.
+            // The spy sits on the shared client, so it is restored in finally to avoid muting the
+            // push channel for anything else in this file.
+            const subscribeSpy = vi.spyOn(arrivals, "subscribe").mockImplementation(() => {});
+            try {
+                const staticRecord = await publishCommunityRecordWithExtraProp({ ttl: SHORT_RECORD_TTL });
+                staticRecordsToCleanUp.push(staticRecord);
+                const community = (await pkc.createCommunity({
+                    address: staticRecord.ipnsObj.signer.address
+                })) as RemoteCommunity;
+                communitiesToStop.push(community);
+                const firstUpdate = new Promise<void>((resolve) => community.once("update", () => resolve()));
+                await community.update();
+                await firstUpdate;
+
+                // The update event fires INSIDE updateOnce, while the loop syncs its arrival
+                // subscriptions immediately AFTER updateOnce returns, so poll instead of racing
+                // that ordering (same reason as the stop() test above).
+                const subscribeDeadline = Date.now() + 10_000;
+                while (Date.now() < subscribeDeadline && subscribeSpy.mock.calls.length === 0) await sleep(100);
+                expect(
+                    subscribeSpy.mock.calls.length,
+                    "the loop must have attempted to register an arrival listener, otherwise this test is not suppressing anything"
+                ).to.be.greaterThan(0);
+
+                const newerRecord = JSON.parse(JSON.stringify(staticRecord.communityRecord)) as typeof staticRecord.communityRecord;
+                newerRecord.updatedAt = Math.max(newerRecord.updatedAt + 1, timestamp());
+                newerRecord.signature = await signCommunity({ community: newerRecord, signer: staticRecord.ipnsObj.signer });
+
+                const onUpdate = () => {
+                    if (community.updatedAt === newerRecord.updatedAt) deliveredResolve();
+                };
+                let deliveredResolve!: () => void;
+                const delivered = new Promise<void>((resolve) => {
+                    deliveredResolve = resolve;
+                    community.on("update", onUpdate);
+                });
+                await staticRecord.ipnsObj.publishToIpns(JSON.stringify(newerRecord), { ttl: SHORT_RECORD_TTL });
+
+                let deliveredInTime = true;
+                let timer: ReturnType<typeof setTimeout> | undefined;
+                const timeout = new Promise<void>((resolve) => {
+                    timer = setTimeout(() => {
+                        deliveredInTime = false;
+                        resolve();
+                    }, 120_000);
+                });
+                await Promise.race([delivered, timeout]);
+                clearTimeout(timer);
+                community.removeListener("update", onUpdate);
+                expect(
+                    deliveredInTime,
+                    "with the push wake suppressed the jittered safety-net poll must still deliver the newer record; a miss here means a missed push strands the community until it is restarted"
+                ).to.equal(true);
+            } finally {
+                subscribeSpy.mockRestore();
+            }
         }, 240_000);
     });
 });

--- a/test/node-and-browser/community/update-loop-event-driven.test.ts
+++ b/test/node-and-browser/community/update-loop-event-driven.test.ts
@@ -30,7 +30,11 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
         const staticRecordsToCleanUp: Awaited<ReturnType<typeof publishCommunityRecordWithExtraProp>>[] = [];
 
         beforeAll(async () => {
-            pkc = await config.pkcInstancePromise();
+            // Test pkc instances default to updateInterval: 500 (test-util's mockPKC), and the
+            // event-driven loop honors updateInterval as its safety-net period — a 500ms net is
+            // polling again, which is exactly what this suite pins against. Use the production
+            // default (60s) so the loop's quiet steady state is observable in the window.
+            pkc = await config.pkcInstancePromise({ pkcOptions: { updateInterval: 60_000 } });
         });
         afterAll(async () => {
             for (const community of communitiesToStop.splice(0)) {

--- a/test/node-and-browser/community/update-loop-event-driven.test.ts
+++ b/test/node-and-browser/community/update-loop-event-driven.test.ts
@@ -188,13 +188,13 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 // directly cannot collide with a live loop's wake slot.
                 const signer = await pkc.createSigner();
                 const community = (await pkc.createCommunity({ address: signer.address })) as RemoteCommunity;
-                return community._clientsManager as unknown as ManagerParkInternals;
+                return { manager: community._clientsManager as unknown as ManagerParkInternals, community };
             };
             const CID_A = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
             const CID_B = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku";
 
             it("an arrival consumed by the update cycle it woke does not fast-return the park (issue #308)", async () => {
-                const manager = await makeIdleManager();
+                const { manager } = await makeIdleManager();
                 // Mid-updateOnce: the loop's own cache write reports the record being consumed.
                 manager._onIpnsRecordArrival({ pubsubTopic: "/record/test", record: { value: `/ipfs/${CID_A}` } });
                 // updateOnce then finishes consuming exactly that record.
@@ -208,7 +208,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             });
 
             it("an arrival the update cycle did not consume still fast-returns the park", async () => {
-                const manager = await makeIdleManager();
+                const { manager } = await makeIdleManager();
                 manager._onIpnsRecordArrival({ pubsubTopic: "/record/test", record: { value: `/ipfs/${CID_B}` } });
                 manager._updateCidsAlreadyLoaded.add(CID_A); // the cycle consumed something else
                 const parkStartedAt = Date.now();
@@ -220,15 +220,150 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             });
 
             it("an intermediate-hop (/ipns/ value) arrival fast-returns the park", async () => {
-                const manager = await makeIdleManager();
+                const { manager } = await makeIdleManager();
                 manager._onIpnsRecordArrival({ pubsubTopic: "/record/test", record: { value: "/ipns/someintermediatehopname" } });
                 const parkStartedAt = Date.now();
                 await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort(10_000);
-                expect(Date.now() - parkStartedAt, "a newer delegated-chain hop record always warrants an immediate walk").to.be.below(
-                    2000
-                );
+                expect(
+                    Date.now() - parkStartedAt,
+                    "a hop record pointing outside any walked chain always warrants an immediate walk"
+                ).to.be.below(2000);
+            });
+
+            // The /ipns/ (hop) arrivals need the SAME self-arrival dedupe the /ipfs/ (cid)
+            // arrivals get, keyed by the hop target the record delegates to. Without it, a
+            // delegated community re-runs updateOnce on every republish of its anchor's record
+            // (bumped sequence, unchanged /ipns/<minter> value — kubo republishes on a timer):
+            // the walk's own cache write of the anchor record fires the arrival mid-updateOnce,
+            // an undiscriminating hop-wake survives the park's re-check, and the loop skips its
+            // park for a fully redundant updateOnce plus a phantom fetching-ipns/waiting-retry
+            // pair — the exact #308 churn this PR removes, at the anchor's republish cadence.
+            it("a hop arrival whose target the update cycle walked does not fast-return the park (issue #308, delegated communities)", async () => {
+                const { manager, community } = await makeIdleManager();
+                // Mid-updateOnce: the walk's own cache write of the ANCHOR record reports the
+                // anchor's /ipns/ value (the minter it delegates to) BEFORE ipnsHops is updated.
+                manager._onIpnsRecordArrival({ pubsubTopic: "/record/anchor", record: { value: "/ipns/minterhopname" } });
+                // updateOnce then finishes having walked exactly that chain.
+                community.ipnsHops = ["anchorhopname", "minterhopname"];
+                const parkStartedAt = Date.now();
+                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort(400);
+                expect(
+                    Date.now() - parkStartedAt,
+                    "the park must sleep its full period: the pending hop arrival names a hop the cycle that produced it already walked (an anchor republish, not a delegation change)"
+                ).to.be.at.least(350);
+            });
+
+            it("a hop arrival delegating to a hop outside the walked chain still fast-returns the park", async () => {
+                const { manager, community } = await makeIdleManager();
+                community.ipnsHops = ["anchorhopname", "minterhopname"];
+                // The anchor's record now delegates to a DIFFERENT minter: genuinely news.
+                manager._onIpnsRecordArrival({ pubsubTopic: "/record/anchor", record: { value: "/ipns/replacementminter" } });
+                const parkStartedAt = Date.now();
+                await manager._sleepUntilIpnsArrivalOrTimeoutOrAbort(10_000);
+                expect(
+                    Date.now() - parkStartedAt,
+                    "a delegation change must skip the park so the loop walks the new chain now"
+                ).to.be.below(2000);
             });
         });
+
+        // Between update()'s first resolve and the end of the first updateOnce (IPFS fetch,
+        // parse, signature verification — seconds on a cold client) a gossiped record fires no
+        // listener and is recorded nowhere if the arrival subscriptions only sync AFTER
+        // updateOnce returns: the first pushed record is then only picked up by the first
+        // safety-net tick, 45-75s later at the production interval, where master's 1s poll
+        // closed the same window in a second. The subscription topic is derivable pre-resolve
+        // for every non-domain address (ipnsName === address), so the loop must arm it before
+        // its first updateOnce. Oracle: snapshot the manager's subscription set at the FIRST
+        // fetching-ipns emission — that state fires inside fetchNewUpdateForCommunity before
+        // the resolve begins, strictly before the post-updateOnce sync could ever run, so the
+        // reading is deterministic (no sleep racing the first cycle's duration).
+        it("the arrival subscription is armed before the first updateOnce so a record pushed mid-first-fetch is not missed", async () => {
+            const staticRecord = await publishCommunityRecordWithExtraProp();
+            staticRecordsToCleanUp.push(staticRecord);
+            const community = (await pkc.createCommunity({ address: staticRecord.ipnsObj.signer.address })) as RemoteCommunity;
+            communitiesToStop.push(community);
+            let topicsAtFirstFetchingIpns: number | undefined;
+            const onStateChange = (newUpdatingState: RemoteCommunity["updatingState"]) => {
+                if (newUpdatingState !== "fetching-ipns" || topicsAtFirstFetchingIpns !== undefined) return;
+                // The loop runs on the TRACKED updating instance (this instance may be a mirror
+                // attached to it); by the time any state event flows, the mirror link is set.
+                const updatingInstance = community._updatingCommunityInstanceWithListeners?.community ?? community;
+                topicsAtFirstFetchingIpns = (updatingInstance._clientsManager as unknown as { _subscribedIpnsArrivalTopics: Set<string> })
+                    ._subscribedIpnsArrivalTopics.size;
+            };
+            community.on("updatingstatechange", onStateChange);
+            const firstUpdate = new Promise<void>((resolve) => community.once("update", () => resolve()));
+            await community.update();
+            await firstUpdate;
+            community.removeListener("updatingstatechange", onStateChange);
+            expect(topicsAtFirstFetchingIpns, "the first update cycle must have emitted fetching-ipns").to.be.a("number");
+            expect(
+                topicsAtFirstFetchingIpns,
+                "the arrival subscription must be armed before the first updateOnce; unarmed, a record pushed during the initial fetch waits for the first safety-net tick instead of waking the loop"
+            ).to.be.greaterThan(0);
+        }, 120_000);
+
+        // The safety net exists for pushes that never arrived — mesh partition, a record
+        // published while we had no subscribers, a regression in the arrival plumbing. A tick
+        // that goes through the routing-layer cache gate cannot see any of those: the cache
+        // still holds the OLD record well inside its ttl (kubo 0.43 publishes 300s, jittered
+        // down to no less than 225s, issue #307), so the tick does zero network work, serves
+        // the stale cid, and parks again — a missed push then strands the community for the
+        // record's whole ttl instead of the one updateInterval the safety net promises (master's
+        // 1s poll was bounded by ~ttl too, but re-checked every second). A timer-fired (non-
+        // arrival) wake must therefore resolve with nocache: true. Oracle: spy the resolver's
+        // name.resolve options rather than racing a real 225s staleness window.
+        it("a safety-net tick revalidates against the network instead of riding the routing-layer cache", async () => {
+            const SAFETY_NET_INTERVAL_MS = 3000;
+            // Own pkc: the suite instance runs the production 60s interval, which would park
+            // this test for minutes per tick.
+            const shortIntervalPkc = await config.pkcInstancePromise({ pkcOptions: { updateInterval: SAFETY_NET_INTERVAL_MS } });
+            const libp2pJsClient = shortIntervalPkc.clients.libp2pJsClients[Object.keys(shortIntervalPkc.clients.libp2pJsClients)[0]];
+            const clientFunctions = libp2pJsClient.heliaWithKuboRpcClientFunctions;
+            const originalResolve = clientFunctions.name.resolve.bind(clientFunctions.name);
+            const safetyNetResolveNocacheValues: (boolean | undefined)[] = [];
+            let recording = false;
+            try {
+                const staticRecord = await publishCommunityRecordWithExtraProp();
+                staticRecordsToCleanUp.push(staticRecord);
+                const community = (await shortIntervalPkc.createCommunity({
+                    address: staticRecord.ipnsObj.signer.address
+                })) as RemoteCommunity;
+                const firstUpdate = new Promise<void>((resolve) => community.once("update", () => resolve()));
+                await community.update();
+                await firstUpdate;
+
+                // Record only resolves of THIS community's name from after the first update
+                // cycle: the record is static and nothing publishes to it, so every recorded
+                // resolve is a timer-fired safety-net tick, never an arrival-woken one. The
+                // client functions object is shared across pkc instances (test-util keys the
+                // helia client by a constant), hence the name filter.
+                clientFunctions.name.resolve = ((name, options) => {
+                    if (recording && String(name) === staticRecord.ipnsObj.signer.address)
+                        safetyNetResolveNocacheValues.push(options?.nocache);
+                    return originalResolve(name, options);
+                }) as typeof clientFunctions.name.resolve;
+                recording = true;
+
+                const deadline = Date.now() + 30_000;
+                while (safetyNetResolveNocacheValues.length < 2 && Date.now() < deadline) await sleep(200);
+                await community.stop();
+
+                expect(
+                    safetyNetResolveNocacheValues.length,
+                    "the safety-net poll must have ticked at least twice inside the window"
+                ).to.be.greaterThanOrEqual(2);
+                for (const nocache of safetyNetResolveNocacheValues)
+                    expect(
+                        nocache,
+                        "a timer-fired safety-net tick must resolve with nocache: true — through the cache gate it can never observe a push it missed, leaving the community stale for the record's whole ttl instead of one updateInterval"
+                    ).to.equal(true);
+            } finally {
+                clientFunctions.name.resolve = originalResolve;
+                await shortIntervalPkc.destroy();
+            }
+        }, 120_000);
 
         it("a newer record published while updating is still delivered", async () => {
             const { community, staticRecord } = await startUpdatingStaticCommunityAndAwaitFirstUpdate();

--- a/test/node-and-browser/community/update.community.test.ts
+++ b/test/node-and-browser/community/update.community.test.ts
@@ -600,6 +600,12 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             const originalAddress = community.address;
             const newKey = signers[1].address;
 
+            // The resolved delegation chain describes the OLD key's record and must not survive a
+            // migration: the update loop's IPNS arrival subscriptions are derived from ipnsHops
+            // (preferred over ipnsName), so a stale chain keeps the loop watching the old key's
+            // gossip topics and the new key's record pushes cannot wake it (issue #308).
+            community.ipnsHops = [originalAddress, "someterminalhopname"];
+
             community._clearDataForKeyMigration(newKey);
 
             // All data fields should be cleared
@@ -630,6 +636,9 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             // Key updated
             expect(community.publicKey).to.equal(newKey);
             expect(community.ipnsName).to.equal(newKey);
+            // Same default-single-hop shape fetchNewUpdateForCommunity uses for a fresh ipnsName;
+            // the next successful resolve replaces it with the full walked chain.
+            expect(community.ipnsHops).to.deep.equal([newKey]);
 
             // Calling twice doesn't crash
             community._clearDataForKeyMigration(newKey);

--- a/test/node-and-browser/community/update.community.test.ts
+++ b/test/node-and-browser/community/update.community.test.ts
@@ -103,7 +103,13 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
             await community.update();
             await publishRandomPost({ communityAddress: community.address, pkc: pkc }); // Invoke an update
             await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => oldUpdatedAt !== community.updatedAt });
-            expect(oldUpdatedAt).to.not.equal(community.updatedAt);
+            // Strictly greater, not merely different: a community that served an OLDER record
+            // would satisfy `!==` and hide a regression. Strict monotonicity was previously
+            // asserted only on local communities (test/node/community/update.community.test.ts),
+            // never on the remote subscriber path this test covers.
+            expect(community.updatedAt, "the updating community must reach a NEWER record").to.be.a("number");
+            if (typeof oldUpdatedAt === "number")
+                expect(community.updatedAt, "updatedAt must never go backwards on an updating community").to.be.greaterThan(oldUpdatedAt);
             expect(community.address).to.equal("plebbit.bso");
             await community.stop();
         });

--- a/test/node-and-browser/publications/comment/clients/libp2pjsClient.kuboRpc.clients.test.ts
+++ b/test/node-and-browser/publications/comment/clients/libp2pjsClient.kuboRpc.clients.test.ts
@@ -51,9 +51,13 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
         });
 
         it(`Correct order of ${clientFieldName} state when updating a post that was created with pkc.createComment({cid})`, async () => {
-            const community = await pkc.getCommunity({ address: signers[0].address });
-
-            const mockPost = await pkc.createComment({ cid: community.posts.pages.hot.comments[0].cid });
+            // A STATIC community (fresh key, published once) instead of the shared live
+            // signers[0]: this asserts the WHOLE state sequence with deep.equal, so a new
+            // signers[0] record published by any concurrently-running suite mid-test inserts a
+            // community fetch cycle anywhere in the array (arrival-driven update loop, issue
+            // #308) and fails it — the PR #311 CI flake class.
+            const staticCommunity = await publishStaticCommunityWithPostInPages();
+            const mockPost = await pkc.createComment({ cid: staticCommunity.commentCid });
 
             const expectedStates = [
                 "fetching-ipfs",
@@ -80,6 +84,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             await mockPost.stop();
 
             expect(actualStates).to.deep.equal(expectedStates);
+            await staticCommunity.ipnsObj.pkc.destroy();
         });
 
         it(`Correct order of ${clientFieldName} state when updating a reply that was created with pkc.createComment({cid}) and the post has a single preloaded page`, async () => {

--- a/test/node-and-browser/publications/comment/clients/libp2pjsClient.kuboRpc.clients.test.ts
+++ b/test/node-and-browser/publications/comment/clients/libp2pjsClient.kuboRpc.clients.test.ts
@@ -7,7 +7,8 @@ import {
     createCommentUpdateWithInvalidSignature,
     mockCommentToNotUsePagesForUpdates,
     resolveWhenConditionIsTrue,
-    mockPostToReturnSpecificCommentUpdate
+    mockPostToReturnSpecificCommentUpdate,
+    publishStaticCommunityWithPostInPages
 } from "../../../../../dist/node/test/test-util.js";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import type { PKC } from "../../../../../dist/node/pkc/pkc.js";
@@ -186,20 +187,21 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
         it(`Correct order of ${clientFieldName} when we update a post but its community is not publishing new community records`, async () => {
             const customPKC = await config.pkcInstancePromise();
 
-            const community = await customPKC.createCommunity({ address: signers[0].address });
+            // A STATIC community under its own fresh IPNS key, published exactly once: the title's
+            // "not publishing new community records" is literal, no resolve stubbing needed. It
+            // must NOT be a shared live community (signers[0]): every concurrent suite publishes
+            // there, and since the update loop reacts to gossip arrivals (issue #308) each of
+            // those publishes would start a fetch cycle at a random moment, racing the exact
+            // state-sequence assertions below (the PR #311 CI flake).
+            const staticCommunity = await publishStaticCommunityWithPostInPages();
+
+            const community = await customPKC.createCommunity({ address: staticCommunity.communityAddress });
 
             // now pkc._updatingCommunities will be defined
 
             const updatePromise = new Promise((resolve) => community.once("update", resolve));
             await community.update();
             await updatePromise;
-
-            const updatingSubInstance = customPKC._updatingCommunities[community.address];
-
-            updatingSubInstance._clientsManager.resolveIpnsToCidP2P = async () => ({
-                cid: community.updateCid!,
-                ipnsHops: [community.address]
-            }); // stop it from loading new IPNS
 
             const mockPost = await customPKC.createComment({ cid: community.posts.pages.hot.comments[0].cid });
 
@@ -233,6 +235,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
             }
 
             await community.stop();
+            await staticCommunity.ipnsObj.pkc.destroy();
         });
 
         it(`Correct order of ${clientFieldName} when we update a post but its commentupdate is an invalid record (bad signature/schema/etc)`, async () => {

--- a/test/node-and-browser/publications/comment/update/change-driven-comment-update.test.ts
+++ b/test/node-and-browser/publications/comment/update/change-driven-comment-update.test.ts
@@ -28,12 +28,15 @@ import type { CommentIpfsWithCidDefined } from "../../../../../dist/node/publica
 // idle post, 100% discarded, and a fetching-update-ipfs -> waiting-retry updatingstatechange
 // cycle per walk.
 //
-// The waste pin below is marked it.fails: it asserts the DESIRED behavior (no per-post
-// postUpdates walk and no state churn when the post's CommentUpdate did not change), which the
-// current code fails, so the suite stays green in CI while the bug exists. The moment the #312
-// fix lands, the inverted test starts failing and the .fails flag must be removed, turning it
-// into the fix's regression pin. The delivery test is a plain green pin guarding that fix
-// against over-deduping.
+// The waste pin below asserts the bug's presence EXPLICITLY (walks happen today) instead of
+// wrapping the desired behavior in it.fails. it.fails records ANY throw as the expected
+// failure: if the filler posts failed to drive two community updates inside the deadline (a
+// live-community round trip on a loaded runner), the setup expect() would throw, vitest would
+// mark the test green, and the #312 oracle would never have been evaluated. As a plain test a
+// setup failure is loud, and the moment the #312 fix lands the inverted assertion goes red —
+// flip it to `.to.equal(0)` (and pin no updatingstatechange churn alongside) to turn it into
+// the fix's regression pin. The delivery test is a plain green pin guarding that fix against
+// over-deduping.
 //
 // remote-libp2pjs only: the waste exists on the kubo path too (same shared code in
 // comment-client-manager), but the network-fetch oracle instruments the libp2p-js client's cat.
@@ -97,62 +100,55 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             return { publishedPost, comment, community };
         };
 
-        it.fails(
-            "a community update that does not change a post's CommentUpdate costs no postUpdates walk and no state churn (issue #312)",
-            async () => {
-                const { publishedPost, comment, community } = await startIdlePostAndCommunityMirror();
-                await sleep(2000); // let the first update cycle's tail settle
+        it("a community update that does not change a post's CommentUpdate still costs a postUpdates walk today (issue #312 inverted pin)", async () => {
+            const { publishedPost, comment, community } = await startIdlePostAndCommunityMirror();
+            await sleep(2000); // let the first update cycle's tail settle
 
-                // Oracle: every P2P file fetch goes through the client functions' cat; a
-                // per-post postUpdates walk is a cat of <folderCid>/<postCid>/update, so any
-                // path containing this post's cid is a walk for it. A future shared
-                // folder-listing fetch (the #312 proposal) does not match, on purpose.
-                const libp2pJsClient = pkc.clients.libp2pJsClients[Object.keys(pkc.clients.libp2pJsClients)[0]];
-                const clientFunctions = libp2pJsClient.heliaWithKuboRpcClientFunctions;
-                const catPaths: string[] = [];
-                const originalCat = clientFunctions.cat.bind(clientFunctions);
-                clientFunctions.cat = ((...args: Parameters<typeof originalCat>) => {
-                    catPaths.push(String(args[0]));
-                    return originalCat(...args);
-                }) as typeof clientFunctions.cat;
+            // Oracle: every P2P file fetch goes through the client functions' cat; a
+            // per-post postUpdates walk is a cat of <folderCid>/<postCid>/update, so any
+            // path containing this post's cid is a walk for it. A future shared
+            // folder-listing fetch (the #312 proposal) does not match, on purpose.
+            const libp2pJsClient = pkc.clients.libp2pJsClients[Object.keys(pkc.clients.libp2pJsClients)[0]];
+            const clientFunctions = libp2pJsClient.heliaWithKuboRpcClientFunctions;
+            const catPaths: string[] = [];
+            const originalCat = clientFunctions.cat.bind(clientFunctions);
+            clientFunctions.cat = ((...args: Parameters<typeof originalCat>) => {
+                catPaths.push(String(args[0]));
+                return originalCat(...args);
+            }) as typeof clientFunctions.cat;
 
-                let communityUpdates = 0;
-                const onCommunityUpdate = () => communityUpdates++;
-                community.on("update", onCommunityUpdate);
-                const recordedCommentStates: string[] = [];
-                const onCommentStateChange = (newState: Comment["updatingState"]) => recordedCommentStates.push(newState);
-                comment.on("updatingstatechange", onCommentStateChange);
+            let communityUpdates = 0;
+            const onCommunityUpdate = () => communityUpdates++;
+            community.on("update", onCommunityUpdate);
 
-                try {
-                    // Drive community updates with activity UNRELATED to the post: filler posts
-                    // change the record (and the post's timestamp bucket) but never its
-                    // CommentUpdate. Wait for two community updates to land.
-                    const deadline = Date.now() + 120_000;
-                    while (communityUpdates < 2 && Date.now() < deadline) {
-                        await publishRandomPost({ communityAddress, pkc: publisherPkc });
-                        const target = Math.min(communityUpdates + 1, 2);
-                        while (communityUpdates < target && Date.now() < deadline) await sleep(500);
-                    }
-                    expect(communityUpdates, "the filler posts must produce community updates").to.be.greaterThanOrEqual(2);
-                    await sleep(3000); // give the per-update comment handlers time to finish their walks
-
-                    const postUpdatesWalksForThisPost = catPaths.filter((path) => path.includes(publishedPost.cid!));
-                    expect(
-                        postUpdatesWalksForThisPost.length,
-                        `community updates that did not change the post's CommentUpdate must not trigger network walks of its postUpdates path; saw ${postUpdatesWalksForThisPost.length} walks over ${communityUpdates} updates`
-                    ).to.equal(0);
-                    expect(
-                        recordedCommentStates.length,
-                        `an idle post must not churn updatingstatechange on unrelated community updates; saw [${recordedCommentStates.join(", ")}]`
-                    ).to.be.at.most(2);
-                } finally {
-                    clientFunctions.cat = originalCat;
-                    community.removeListener("update", onCommunityUpdate);
-                    comment.removeListener("updatingstatechange", onCommentStateChange);
+            try {
+                // Drive community updates with activity UNRELATED to the post: filler posts
+                // change the record (and the post's timestamp bucket) but never its
+                // CommentUpdate. Wait for two community updates to land.
+                const deadline = Date.now() + 120_000;
+                while (communityUpdates < 2 && Date.now() < deadline) {
+                    await publishRandomPost({ communityAddress, pkc: publisherPkc });
+                    const target = Math.min(communityUpdates + 1, 2);
+                    while (communityUpdates < target && Date.now() < deadline) await sleep(500);
                 }
-            },
-            300_000
-        );
+                // A loud setup precondition, not a swallowed one: with it.fails this throw
+                // would have counted as the expected failure and silently skipped the oracle.
+                expect(communityUpdates, "the filler posts must produce community updates").to.be.greaterThanOrEqual(2);
+                await sleep(3000); // give the per-update comment handlers time to finish their walks
+
+                const postUpdatesWalksForThisPost = catPaths.filter((path) => path.includes(publishedPost.cid!));
+                // INVERTED: the desired behavior is zero walks (plus no updatingstatechange
+                // churn on the idle post). This pins the measured #312 waste so the fix
+                // cannot land without flipping this assertion into its regression pin.
+                expect(
+                    postUpdatesWalksForThisPost.length,
+                    `issue #312 fixed? each community update used to trigger a postUpdates network walk for every idle updating post; saw ${postUpdatesWalksForThisPost.length} walks over ${communityUpdates} updates — flip this pin to .to.equal(0) and assert no state churn`
+                ).to.be.greaterThanOrEqual(1);
+            } finally {
+                clientFunctions.cat = originalCat;
+                community.removeListener("update", onCommunityUpdate);
+            }
+        }, 300_000);
 
         // Green today and must stay green after the #312 fix: deduping unchanged CommentUpdates
         // must never swallow a real change.

--- a/test/node-and-browser/publications/comment/update/change-driven-comment-update.test.ts
+++ b/test/node-and-browser/publications/comment/update/change-driven-comment-update.test.ts
@@ -1,5 +1,5 @@
 import signers from "../../../../fixtures/signers.js";
-import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { describe, it, beforeAll, afterAll, expect, vi } from "vitest";
 import {
     getAvailablePKCConfigsToTestAgainst,
     publishRandomPost,
@@ -112,10 +112,10 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             const clientFunctions = libp2pJsClient.heliaWithKuboRpcClientFunctions;
             const catPaths: string[] = [];
             const originalCat = clientFunctions.cat.bind(clientFunctions);
-            clientFunctions.cat = ((...args: Parameters<typeof originalCat>) => {
+            const catSpy = vi.spyOn(clientFunctions, "cat").mockImplementation((...args) => {
                 catPaths.push(String(args[0]));
                 return originalCat(...args);
-            }) as typeof clientFunctions.cat;
+            });
 
             let communityUpdates = 0;
             const onCommunityUpdate = () => communityUpdates++;
@@ -145,7 +145,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                     `issue #312 fixed? each community update used to trigger a postUpdates network walk for every idle updating post; saw ${postUpdatesWalksForThisPost.length} walks over ${communityUpdates} updates — flip this pin to .to.equal(0) and assert no state churn`
                 ).to.be.greaterThanOrEqual(1);
             } finally {
-                clientFunctions.cat = originalCat;
+                catSpy.mockRestore();
                 community.removeListener("update", onCommunityUpdate);
             }
         }, 300_000);

--- a/test/node-and-browser/publications/comment/update/change-driven-comment-update.test.ts
+++ b/test/node-and-browser/publications/comment/update/change-driven-comment-update.test.ts
@@ -72,7 +72,13 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
         }, 300_000);
 
         const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
-        const communityAddress = signers[0].address;
+        // NOT signers[0]: this suite drives the live community with filler posts, and several
+        // concurrently-running suites (post.updatingstate and friends) assert EXACT tail slices
+        // of updating states for posts on the signers[0] community; a filler-triggered update
+        // cycle landing between their post's succeeded and stopped shifts that tail and flakes
+        // them (observed on the browser CI legs). signers[7] runs the same no-challenge
+        // community with far fewer concurrent users.
+        const communityAddress = signers[7].address;
 
         // Publish a post, set it updating on the measuring pkc, and wait for its first update.
         // Also returns an updating community mirror on the same pkc (it attaches to the same

--- a/test/node-and-browser/publications/comment/update/change-driven-comment-update.test.ts
+++ b/test/node-and-browser/publications/comment/update/change-driven-comment-update.test.ts
@@ -1,0 +1,164 @@
+import signers from "../../../../fixtures/signers.js";
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import {
+    getAvailablePKCConfigsToTestAgainst,
+    publishRandomPost,
+    publishRandomReply,
+    mockPKCNoDataPathWithOnlyKuboClient,
+    resolveWhenConditionIsTrue
+} from "../../../../../dist/node/test/test-util.js";
+
+import type { PKC as PKCType } from "../../../../../dist/node/pkc/pkc.js";
+import type { Comment } from "../../../../../dist/node/publications/comment/comment.js";
+import type { RemoteCommunity } from "../../../../../dist/node/community/remote-community.js";
+import type { CommentIpfsWithCidDefined } from "../../../../../dist/node/publications/comment/types.js";
+
+// Repro suite for issue #312: comments carry no polling timer (handleUpdateEventFromCommunity
+// runs once per community update event), but what each invocation does for a post whose
+// CommentUpdate did NOT change is almost entirely wasted:
+// 1. a post found in the community's preloaded pages with an unchanged updatedAt still falls
+//    into useCommunityPostUpdatesToFetchCommentUpdateForPost (the pages hit only short-circuits
+//    when the pages copy is strictly newer), and
+// 2. the postUpdates folder-cid dedupe (didLastPostUpdateRangeHaveSameFolderCid) only engages
+//    when _commentUpdateIpfsPath was set by a previous postUpdates fetch (never set by a
+//    pages-served post) and its granularity is the whole timestamp bucket, so any unrelated
+//    activity in the bucket re-triggers a walk for every updating post in it.
+// Net effect, measured in test/benchmarks/comment-update-fetch-bench.test.ts: one full
+// <folderCid>/<postCid>/update network walk plus signature verification per community update per
+// idle post, 100% discarded, and a fetching-update-ipfs -> waiting-retry updatingstatechange
+// cycle per walk.
+//
+// The waste pin below is marked it.fails: it asserts the DESIRED behavior (no per-post
+// postUpdates walk and no state churn when the post's CommentUpdate did not change), which the
+// current code fails, so the suite stays green in CI while the bug exists. The moment the #312
+// fix lands, the inverted test starts failing and the .fails flag must be removed, turning it
+// into the fix's regression pin. The delivery test is a plain green pin guarding that fix
+// against over-deduping.
+//
+// remote-libp2pjs only: the waste exists on the kubo path too (same shared code in
+// comment-client-manager), but the network-fetch oracle instruments the libp2p-js client's cat.
+getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"] }).map((config) => {
+    describe(`comment updates are change-driven, not per-community-update refetches (issue #312) - ${config.name}`, () => {
+        let pkc: PKCType;
+        let publisherPkc: Awaited<ReturnType<typeof mockPKCNoDataPathWithOnlyKuboClient>>;
+        const commentsToStop: Comment[] = [];
+        const communitiesToStop: RemoteCommunity[] = [];
+
+        beforeAll(async () => {
+            // Production updateInterval so community updates arrive via gossip push (issue #308)
+            // rather than the test default's 500ms safety-net polling.
+            pkc = await config.pkcInstancePromise({ pkcOptions: { updateInterval: 60_000 } });
+            // Publishing runs on a separate kubo-backed pkc so the measuring client's cat()
+            // counts are not polluted by the publishing flow's own fetches.
+            publisherPkc = await mockPKCNoDataPathWithOnlyKuboClient({});
+        }, 120_000);
+        afterAll(async () => {
+            for (const comment of commentsToStop.splice(0)) {
+                try {
+                    await comment.stop();
+                } catch {
+                    // already stopped
+                }
+            }
+            for (const community of communitiesToStop.splice(0)) {
+                try {
+                    await community.stop();
+                } catch {
+                    // already stopped
+                }
+            }
+            await publisherPkc.destroy();
+            await pkc.destroy();
+        }, 300_000);
+
+        const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+        const communityAddress = signers[0].address;
+
+        // Publish a post, set it updating on the measuring pkc, and wait for its first update.
+        // Also returns an updating community mirror on the same pkc (it attaches to the same
+        // tracked updating instance the comment uses internally) to count community updates.
+        const startIdlePostAndCommunityMirror = async () => {
+            const publishedPost = await publishRandomPost({ communityAddress, pkc: publisherPkc });
+            const community = (await pkc.createCommunity({ address: communityAddress })) as RemoteCommunity;
+            communitiesToStop.push(community);
+            await community.update();
+            const comment = await pkc.createComment({ cid: publishedPost.cid! });
+            commentsToStop.push(comment);
+            await comment.update();
+            // Wait for the first CommentUpdate (not just the CommentIpfs load), so the
+            // measurement window starts from a fully-settled idle post.
+            await resolveWhenConditionIsTrue({ toUpdate: comment, predicate: async () => typeof comment.updatedAt === "number" });
+            return { publishedPost, comment, community };
+        };
+
+        it.fails(
+            "a community update that does not change a post's CommentUpdate costs no postUpdates walk and no state churn (issue #312)",
+            async () => {
+                const { publishedPost, comment, community } = await startIdlePostAndCommunityMirror();
+                await sleep(2000); // let the first update cycle's tail settle
+
+                // Oracle: every P2P file fetch goes through the client functions' cat; a
+                // per-post postUpdates walk is a cat of <folderCid>/<postCid>/update, so any
+                // path containing this post's cid is a walk for it. A future shared
+                // folder-listing fetch (the #312 proposal) does not match, on purpose.
+                const libp2pJsClient = pkc.clients.libp2pJsClients[Object.keys(pkc.clients.libp2pJsClients)[0]];
+                const clientFunctions = libp2pJsClient.heliaWithKuboRpcClientFunctions;
+                const catPaths: string[] = [];
+                const originalCat = clientFunctions.cat.bind(clientFunctions);
+                clientFunctions.cat = ((...args: Parameters<typeof originalCat>) => {
+                    catPaths.push(String(args[0]));
+                    return originalCat(...args);
+                }) as typeof clientFunctions.cat;
+
+                let communityUpdates = 0;
+                const onCommunityUpdate = () => communityUpdates++;
+                community.on("update", onCommunityUpdate);
+                const recordedCommentStates: string[] = [];
+                const onCommentStateChange = (newState: Comment["updatingState"]) => recordedCommentStates.push(newState);
+                comment.on("updatingstatechange", onCommentStateChange);
+
+                try {
+                    // Drive community updates with activity UNRELATED to the post: filler posts
+                    // change the record (and the post's timestamp bucket) but never its
+                    // CommentUpdate. Wait for two community updates to land.
+                    const deadline = Date.now() + 120_000;
+                    while (communityUpdates < 2 && Date.now() < deadline) {
+                        await publishRandomPost({ communityAddress, pkc: publisherPkc });
+                        const target = Math.min(communityUpdates + 1, 2);
+                        while (communityUpdates < target && Date.now() < deadline) await sleep(500);
+                    }
+                    expect(communityUpdates, "the filler posts must produce community updates").to.be.greaterThanOrEqual(2);
+                    await sleep(3000); // give the per-update comment handlers time to finish their walks
+
+                    const postUpdatesWalksForThisPost = catPaths.filter((path) => path.includes(publishedPost.cid!));
+                    expect(
+                        postUpdatesWalksForThisPost.length,
+                        `community updates that did not change the post's CommentUpdate must not trigger network walks of its postUpdates path; saw ${postUpdatesWalksForThisPost.length} walks over ${communityUpdates} updates`
+                    ).to.equal(0);
+                    expect(
+                        recordedCommentStates.length,
+                        `an idle post must not churn updatingstatechange on unrelated community updates; saw [${recordedCommentStates.join(", ")}]`
+                    ).to.be.at.most(2);
+                } finally {
+                    clientFunctions.cat = originalCat;
+                    community.removeListener("update", onCommunityUpdate);
+                    comment.removeListener("updatingstatechange", onCommentStateChange);
+                }
+            },
+            300_000
+        );
+
+        // Green today and must stay green after the #312 fix: deduping unchanged CommentUpdates
+        // must never swallow a real change.
+        it("a reply published to the post still bumps its CommentUpdate", async () => {
+            const { publishedPost, comment } = await startIdlePostAndCommunityMirror();
+            const replyCountBefore = comment.replyCount ?? 0;
+            await publishRandomReply({ parentComment: publishedPost as unknown as CommentIpfsWithCidDefined, pkc: publisherPkc });
+            await resolveWhenConditionIsTrue({
+                toUpdate: comment,
+                predicate: async () => (comment.replyCount ?? 0) > replyCountBefore
+            });
+            expect(comment.replyCount ?? 0, "the reply must reach the post's CommentUpdate").to.be.greaterThan(replyCountBefore);
+        }, 300_000);
+    });
+});

--- a/test/node-and-browser/publications/comment/update/post.updatingstate.test.ts
+++ b/test/node-and-browser/publications/comment/update/post.updatingstate.test.ts
@@ -7,7 +7,8 @@ import {
     resolveWhenConditionIsTrue,
     getAvailablePKCConfigsToTestAgainst,
     addStringToIpfs,
-    createStaticCommunityRecordForComment
+    createStaticCommunityRecordForComment,
+    publishStaticCommunityWithPostInPages
 } from "../../../../../dist/node/test/test-util.js";
 import { describeSkipIfRpc } from "../../../../helpers/conditional-tests.js";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
@@ -120,10 +121,14 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
 
         it(`updating states is in correct order upon updating a post with IPFS client using postUpdates`, async () => {
             const dedicatedPKC = await config.pkcInstancePromise();
+            // A STATIC community under its own fresh key rather than the shared live signers[0]:
+            // concurrent suites publish to signers[0] constantly, and since the update loop reacts
+            // to gossip arrivals (issue #308) each publish starts a community fetch cycle at a
+            // random moment; one landing between the delivering cycle's succeeded and stop()
+            // shifts the exact tail asserted below (the PR #311 CI flake).
+            const staticCommunity = await publishStaticCommunityWithPostInPages();
             try {
-                const community = await dedicatedPKC.getCommunity({ address: communityAddress });
-                const postCid = community.posts.pages.hot.comments[0].cid;
-                const mockPost = await dedicatedPKC.createComment({ cid: postCid });
+                const mockPost = await dedicatedPKC.createComment({ cid: staticCommunity.commentCid });
                 const expectedStates = [
                     "fetching-community-ipns",
                     "fetching-community-ipfs",
@@ -143,6 +148,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-kubo-rpc",
                 expect(recordedStates.slice(recordedStates.length - expectedStates.length)).to.deep.equal(expectedStates);
             } finally {
                 await dedicatedPKC.destroy();
+                await staticCommunity.ipnsObj.pkc.destroy();
             }
         });
 

--- a/test/node-and-browser/publications/comment/update/update.test.ts
+++ b/test/node-and-browser/publications/comment/update/update.test.ts
@@ -499,12 +499,22 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
             const post = await pkc.getComment({ cid: postCid });
             const errors: PKCError[] = [];
-            post.on("error", (err) => errors.push(err as PKCError));
+            // Captured synchronously inside the emission: _changeCommentStateEmitEventEmitStateChangeEvent
+            // sets the new updatingState BEFORE emitting the error, and nothing can interleave within
+            // the same emission turn. Sampling post.updatingState after the awaited condition instead
+            // is racy on the live signers[0] community: the next community update (gossip-arrival-
+            // driven since issue #308) may already have flipped the state to a fetching phase by the
+            // time the await resumes (the PR #311 CI flake).
+            let updatingStateAtFirstError: string | undefined;
+            post.on("error", (err) => {
+                errors.push(err as PKCError);
+                updatingStateAtFirstError ??= post.updatingState;
+            });
             await post.update();
             await mockPostToFailToLoadFromPostUpdates(post);
 
             await resolveWhenConditionIsTrue({ toUpdate: post, predicate: async () => errors.length === 1, eventName: "error" });
-            expect(post.updatingState).to.equal("waiting-retry"); // failing to load ipfs path is not critical error
+            expect(updatingStateAtFirstError).to.equal("waiting-retry"); // failing to load ipfs path is not critical error
 
             await post.stop();
             expect(post.state).to.equal("stopped");
@@ -520,12 +530,19 @@ getAvailablePKCConfigsToTestAgainst().map((config) => {
 
             const post = await pkc.getComment({ cid: postCid });
             const errors: PKCError[] = [];
-            post.on("error", (err) => errors.push(err as PKCError));
+            // Same capture-at-emission rationale as the postUpdates-failure test above: sampling
+            // after the await races the next (arrival-driven) community cycle, which sets
+            // waiting-retry over the failed state before the assertion runs (the PR #311 CI flake).
+            let updatingStateAtFirstError: string | undefined;
+            post.on("error", (err) => {
+                errors.push(err as PKCError);
+                updatingStateAtFirstError ??= post.updatingState;
+            });
             await post.update();
             await mockPostToHaveCommunityWithNoPostUpdates(post);
 
             await resolveWhenConditionIsTrue({ toUpdate: post, predicate: async () => errors.length === 1, eventName: "error" });
-            expect(post.updatingState).to.equal("failed");
+            expect(updatingStateAtFirstError).to.equal("failed");
 
             await post.stop();
             expect(post.state).to.equal("stopped");

--- a/test/node/helia/ipns-cache-ttl-jitter.unit.test.ts
+++ b/test/node/helia/ipns-cache-ttl-jitter.unit.test.ts
@@ -1,0 +1,93 @@
+import { expect, it } from "vitest";
+import { readFreshCachedIpnsRecordFromPubsubLocalStore } from "../../../dist/node/helia/util.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { generateKeyPair } from "@libp2p/crypto/keys";
+import { peerIdFromPrivateKey } from "@libp2p/peer-id";
+import { createIPNSRecord, marshalIPNSRecord, multihashToIPNSRoutingKey } from "ipns";
+import { CID } from "multiformats/cid";
+import type { IpnsPubsubLocalStore } from "../../../dist/node/helia/util.js";
+
+// Repro suite for issue #307: on a directory-style app all N community records are fetched
+// together at cold start, carry the same ttl, and are never individually refreshed while the
+// publishers are idle, so all N cache entries expire in the same instant. Every name then misses
+// the cache in the same update-loop tick and launches its multi-peer fetch race simultaneously:
+// N=64 produces 250-320 near-simultaneous /libp2p/fetch streams against a 64-stream outbound cap,
+// once per ttl window.
+//
+// The fix jitters the EFFECTIVE ttl per name: the cache gate serves a cached record for
+// ttl * factor(name) where factor is deterministic per routing key and uniform-ish in
+// [0.75, 1.0). Names cached in the same instant then stop expiring in the same instant, while a
+// record is never served beyond its own ttl (the factor only ever shortens the window) and never
+// expired before 75% of it.
+//
+// Expected on master: the lockstep test FAILS (every name is served until exactly ttl, so at 85%
+// of ttl age all names are still uniformly fresh); the floor/ceiling/determinism pins pass and
+// must stay green after the fix.
+describeSkipIfRpc("IPNS cache ttl jitter (issue #307)", () => {
+    const VALUE_CID = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+    const TTL_MS = 120_000;
+    const LIFETIME_MS = 24 * 60 * 60 * 1000; // far away, so record EOL never interferes with ttl
+
+    // A marshalled record for a fresh key plus a localStore stub that serves it as cached at
+    // `ageMs` ago. The stub implements the same structural IpnsPubsubLocalStore contract src
+    // reads through, so readFreshCachedIpnsRecordFromPubsubLocalStore exercises its real
+    // freshness logic against a fully controlled clock.
+    const makeCachedName = async (ageMs: number) => {
+        const privateKey = await generateKeyPair("Ed25519");
+        const routingKey = multihashToIPNSRoutingKey(peerIdFromPrivateKey(privateKey).toMultihash());
+        const recordBytes = marshalIPNSRecord(
+            await createIPNSRecord(privateKey, CID.parse(VALUE_CID), 1n, LIFETIME_MS, { ttlNs: BigInt(TTL_MS) * 1_000_000n })
+        );
+        const created = new Date(Date.now() - ageMs);
+        const localStore: IpnsPubsubLocalStore = {
+            has: async () => true,
+            get: async () => ({ record: recordBytes, created }),
+            put: async () => undefined
+        };
+        return { routingKey, localStore };
+    };
+
+    const isServedFromCache = async (name: Awaited<ReturnType<typeof makeCachedName>>): Promise<boolean> =>
+        (await readFreshCachedIpnsRecordFromPubsubLocalStore({ localStore: name.localStore, routingKey: name.routingKey })) !== undefined;
+
+    // The lockstep pin. 48 names cached in the same instant, all probed at 85% of their shared
+    // ttl: with a per-name effective ttl in [0.75, 1.0) * ttl, some names must already have
+    // expired (factor < 0.85) and some must still be fresh (factor > 0.85). On master the
+    // effective ttl is exactly ttl for every name, so all 48 are still fresh and the expired
+    // count is 0, which is precisely why they later all miss the cache in the same tick.
+    it("names cached in the same instant stop expiring in the same instant (issue #307)", async () => {
+        const names = await Promise.all(Array.from({ length: 48 }, () => makeCachedName(TTL_MS * 0.85)));
+        const served = await Promise.all(names.map(isServedFromCache));
+        const servedCount = served.filter(Boolean).length;
+        expect(servedCount, "some names must still be served at 85% of ttl (jitter floor is 75%)").to.be.greaterThan(0);
+        expect(servedCount, "some names must already have expired at 85% of ttl, or expiries stay in lockstep").to.be.lessThan(
+            names.length
+        );
+    });
+
+    // Floor pin: jitter may only shorten the serve window down to 75% of ttl, never below, or
+    // the cache gate would refetch mid-window and reintroduce churn the cache exists to stop.
+    it("every name is still served from cache below 75% of its ttl", async () => {
+        const names = await Promise.all(Array.from({ length: 24 }, () => makeCachedName(TTL_MS * 0.7)));
+        const served = await Promise.all(names.map(isServedFromCache));
+        expect(served.every(Boolean), "no name may expire before 75% of its ttl").to.equal(true);
+    });
+
+    // Ceiling pin: jitter must never EXTEND the window; at or beyond the record's own ttl the
+    // cache must not serve, matching IPNS ttl semantics.
+    it("no name is served from cache at or beyond its full ttl", async () => {
+        const names = await Promise.all(Array.from({ length: 24 }, () => makeCachedName(TTL_MS)));
+        const served = await Promise.all(names.map(isServedFromCache));
+        expect(served.some(Boolean), "a record must never be served from cache beyond its own ttl").to.equal(false);
+    });
+
+    // Determinism pin: the per-name factor must be a pure function of the name. A re-rolled
+    // random factor per read would make expiry flappy (a read can flip a name back and forth
+    // between fresh and expired), biasing effective ttl toward the floor as reads accumulate.
+    it("a name's effective ttl is deterministic across repeated reads", async () => {
+        const names = await Promise.all(Array.from({ length: 20 }, () => makeCachedName(TTL_MS * 0.85)));
+        const first = await Promise.all(names.map(isServedFromCache));
+        const second = await Promise.all(names.map(isServedFromCache));
+        expect(second, "repeated reads of the same cached name must agree on freshness").to.deep.equal(first);
+    });
+});

--- a/test/node/helia/ipns-cache-ttl-jitter.unit.test.ts
+++ b/test/node/helia/ipns-cache-ttl-jitter.unit.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from "vitest";
+import { expect, it, beforeAll, afterAll, vi } from "vitest";
 import { readFreshCachedIpnsRecordFromPubsubLocalStore } from "../../../dist/node/helia/util.js";
 import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
 import { generateKeyPair } from "@libp2p/crypto/keys";
@@ -23,10 +23,21 @@ import type { IpnsPubsubLocalStore } from "../../../dist/node/helia/util.js";
 // Expected on master: the lockstep test FAILS (every name is served until exactly ttl, so at 85%
 // of ttl age all names are still uniformly fresh); the floor/ceiling/determinism pins pass and
 // must stay green after the fix.
+//
+// Skipped under RPC only because it is a pure in-process unit test of the cache gate against a
+// stubbed localStore: nothing in it touches an RPC server, so running it per-RPC-config would
+// only duplicate coverage.
 describeSkipIfRpc("IPNS cache ttl jitter (issue #307)", () => {
     const VALUE_CID = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
     const TTL_MS = 120_000;
     const LIFETIME_MS = 24 * 60 * 60 * 1000; // far away, so record EOL never interferes with ttl
+
+    // Freeze Date (and only Date — no timers are used here) so `created` and the freshness
+    // check's Date.now() agree exactly: with a live clock, a name whose jittered expiry boundary
+    // falls between the two reads of the determinism pin flips freshness mid-test (probability
+    // roughly gap/30s per name, so a loaded CI runner's event-loop stall makes it a real flake).
+    beforeAll(() => vi.useFakeTimers({ toFake: ["Date"] }));
+    afterAll(() => vi.useRealTimers());
 
     // A marshalled record for a fresh key plus a localStore stub that serves it as cached at
     // `ageMs` ago. The stub implements the same structural IpnsPubsubLocalStore contract src


### PR DESCRIPTION
## What

Fixes #308 and #307 test-first, in three commits:

1. **Repro tests**, verified red against unmodified src:
   - `test/node/helia/ipns-cache-ttl-jitter.unit.test.ts`: 48 names cached in the same instant must stop expiring in the same instant (#307). On master all 48 stay uniformly fresh at 85% of ttl, which is exactly why they later all miss the cache in the same tick. Floor (never below 75% of ttl), ceiling (never beyond ttl), and determinism pins stay green.
   - `test/node-and-browser/community/update-loop-event-driven.test.ts`: an idle updating community must not churn `updatingstatechange` (#308). Master emits exactly 2 transitions/s (`waiting-retry` <-> `fetching-ipns` on every 1s tick). A newer-record delivery pin is green on master and guards the redesign.
   - `test/benchmarks/update-loop-bench.test.ts`: a manually-run before/after harness (no CI glob covers `test/benchmarks/`), see numbers below.
2. **The fix**:
   - `helia-for-pkc` wraps the pubsub router's `localStore.put`. Gossipsub delivery (`handleRecord`), the direct-fetch cache write (#210), and the fallback `router.get()` fetch all converge there, and none writes a record older than the cached one, so a put is exactly "a newer record for this name is now held locally". Exposed as `ipnsRecordArrivals.subscribe/unsubscribe` per IPNS pubsub topic; listeners fire after the record is validated and cached, avoiding the ordering hazard of raw pubsub `message` listeners.
   - The community update loop, when the default resolver is a libp2p-js client, parks until a pushed record arrival, a jittered safety-net timeout (`updateInterval * [0.75, 1.25)`), or stop. It subscribes one topic per hop in `ipnsHops` (a delegated community wakes on a push to any hop), ignores records whose `/ipfs/` value it already consumed (republishes with a bumped sequence but an unchanged CID, and its own direct-fetch cache write), and consumes an arrival that lands while `updateOnce` is mid-flight on the next park instead of losing it. All the guards in `updateOnce` (key migration, retry machinery, in-flight dedupe) stay on the only path; state emission semantics are unchanged, the churn stops because the no-op ticks stop.
   - The cache gate's effective ttl is jittered per name (#307): FNV-1a over the routing key, uniform-ish in `[0.75, 1.0)` of the record ttl, deterministic per name so freshness is never flappy. Names fetched in the same second stop expiring in the same instant, and the jittered safety net keeps the polls themselves out of lockstep too.
3. **Test/bench pkc instances pin `updateInterval: 60_000`** (the production default): test-util's default of 500ms would make the safety net poll at 2/s, hiding the quiet steady state. The event-driven loop honoring `updateInterval` is deliberate: it was already the documented "time to wait to check for updates" knob, and the old kubo/helia loop ignored it.

The kubo-RPC resolver keeps its 1s poll for now (kubo's namesys cache has no push signal observable from pkc yet; #308 stays open to track it) and gateways keep polling at `pkc.updateInterval`.

## Measured (32 communities, 150s steady-state window, records with 60s ttl, libp2p-js client)

| Metric | master (0.0.92) | this PR | change |
|---|---|---|---|
| `updatingstatechange` events | 9,553 (63.7/s, 1.99/community/s) | 131 (0.87/s, 0.027/community/s) | -98.6% |
| IPNS fetch ops, max in any 1s bucket | 31 (bursts exactly 60s apart: the #307 herd) | 3 | herd flattened |
| IPNS fetch ops, total | 64 | 53 | -17% |
| Client CPU over window | 3.14% (4,712ms) | 0.75% (1,125ms) | -76% |
| Newer-record delivery latency | 53ms this run; 0-1s by construction (1s poll) | 20ms (gossip push) | bounded by push, not poll |
| Serving daemon bandwidth (in/out) | 0.01 / 0.08 MB | 0.01 / 0.08 MB | unchanged |
| Gossipsub messages received | 97 | 97 | unchanged |

Baseline numbers are from the same bench file on master; master's loop hardcodes its 1s cadence and ignores `updateInterval`, so the bench's `updateInterval` override does not affect the baseline. Reproduce with:

```
node test/run-test-config.js --pkc-config remote-libp2pjs test/benchmarks/update-loop-bench.test.ts
```

Re-measured after the review follow-up commits (same 32/150s/60s-ttl setup): churn 133 events (0.89/s), fetch ops 53 with max 4 in any 1s bucket, CPU 0.77%, delivery 25ms, daemon bandwidth unchanged. Within run-to-run noise of the table above, as expected: the self-wake fix only removes redundant cycles on self-discovered record changes, which an idle steady state rarely hits.


## Verification

- Repro suites red -> green across the commits (each red observed against unmodified src).
- Regression suites, all green with the fix:
  - `test/node/helia/` full directory (11 files, 100 tests) including the #301/#302 cache-and-gossip pins and direct-fetch suites
  - `updatingstate` + `update.community` under remote-libp2pjs and remote-kubo-rpc (31 tests each config)
  - `waiting-retry.update` + `helia.test.ts` under remote-libp2pjs (25 tests)
  - `community-update-loop-abort-listener-leak` + `ipns-hops.community` (3 tests)
  - `delegated-anchor-claim` + `delegated-ipns-domain` (48 tests)

Closes #307.

#308 stays open on purpose: this PR makes the libp2p-js path (where the issue's 1s constant lived and its measurement came from) event-driven, but the issue also covers giving the kubo-RPC path the same treatment, which needs kubo-side pubsub plumbing and is worth doing separately.

## Review follow-ups (pushed after a deep review pass + CodeRabbit)

- fix: the park now re-checks pending arrivals against post-`updateOnce` state. The loop's own direct-fetch cache write fires the arrival listener mid-`updateOnce`, before the consumed cid is recorded in `_updateCidsAlreadyLoaded`/`updateCid`, so the boolean pending flag made every self-discovered record change run one redundant `updateOnce` and emit a phantom `fetching-ipns`/`waiting-retry` pair. Pending arrivals are now tracked per cid and dropped when the cycle that just ran consumed them. Deterministic repro test included, observed red first.
- fix: `_clearDataForKeyMigration` now resets `ipnsHops` to the new key's single-hop default. The stale resolved chain kept the arrival subscriptions watching the old key's gossip topics until the next successful resolve. Pinned in the existing migration unit test, observed red first.
- refactor: the put wrapper derives the arrival topic via `binaryKeyToPubsubTopic` instead of an inline copy of the encoding, and the park's sleep shares one `interruptibleSleep` util with `sleepUntilTimeoutOrAbort` so the issue #145 settle pattern has a single home.
- tests: the jitter suite runs on a frozen `Date` (with a live clock the determinism pin can flip a name whose jittered expiry boundary falls between its two reads on a loaded runner); losing delivery timers are cleared instead of outliving their tests; the delivery allowance is 150s to cover the true worst case of a missed push (a safety-net tick can serve the stale record inside its jittered effective ttl, then park one full jittered period); bench counters are snapshotted at the window boundary; the `describeSkipIfRpc` skip carries its mandatory justification comment.
- branch: the two CommunityList doc commits are rebased out; they belong to PR #309 and would otherwise land inside this PR's squash commit.



## Second review pass (verified findings)

Also in scope: `test/benchmarks/comment-update-fetch-bench.test.ts` and `test/node-and-browser/publications/comment/update/change-driven-comment-update.test.ts` measure and pin the comment-update waste tracked in #312; the change-driven pin is designed to go red when #312 is fixed.

Fixed in this PR after review (`fix(community): keep the push channel on the community's identity and consume wakes once`): domain+publicKey communities now arm their push subscription before the first cycle, a key migration re-syncs subscriptions and drops old-key pending arrivals immediately, an arrival that wakes the park is consumed by that wake (no double-run of a failing walk), and the forced network revalidation is consumed by the first resolve attempt of a cycle.

Deferred to follow-up issues: #317 (revalidation floor stamping), #318 (single owner for the ipnsName/ipnsHops invariant), #319 (rate limit for arrival-driven cycles), #320 (one freshness bound honored by the cache gate), #321 (local-store compare-then-write race).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added notifications for newly published IPNS community records.
  * Added subscription controls for monitoring record arrivals.
* **Performance**
  * Reduced unnecessary polling and update activity.
  * Staggered cache expiration to prevent simultaneous refresh spikes.
* **Bug Fixes**
  * Community updates now respond promptly to new records, with fallback revalidation.
  * Cached records respect their configured lifetime while avoiding synchronized expiration.
  * Key migration now refreshes community routing and subscriptions correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

