### PR TITLE
fix(rpc): make client and server destroy() wait for their websockets to close

### DIFF
--- a/src/clients/rpc-client/pkc-rpc-client.ts
+++ b/src/clients/rpc-client/pkc-rpc-client.ts
@@ -70,6 +70,14 @@ import {
 
 const log = Logger("pkc-js:PKCRpcClient");
 
+// The subset of ws (Node) and the native WebSocket (browser) that destroy() needs to wait for a close
+interface RawWebSocket {
+    readonly readyState: number;
+    addEventListener(type: "close", listener: () => void, options?: { once: boolean }): void;
+}
+const WEBSOCKET_READY_STATE_CLOSED = 3;
+const DESTROY_SOCKET_CLOSE_TIMEOUT_MS = 5_000;
+
 // Captured at module load so the deferred attach-and-replay (attachSubscriptionHandlersDeferred)
 // keeps working when a downstream app enables fake timers: vitest/jest replace the GLOBAL
 // setTimeout after modules are imported, so this bound reference stays the real timer and
@@ -189,7 +197,9 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
             });
 
             this._webSocketClient.on("close", () => {
-                log.error("connection with web socket has been closed", this._websocketServerUrl);
+                // destroy() already awaited this close and logged it; a log here would land after
+                // destroy() resolved (#325)
+                if (!this._destroyRequested) log.error("connection with web socket has been closed", this._websocketServerUrl);
                 this._openConnectionPromise = undefined;
                 this.setState("stopped");
             });
@@ -278,7 +288,12 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
         try {
             if (this._webSocketClient instanceof WebSocketClient) {
                 this._webSocketClient.setAutoReconnect(false);
+                // Wait for the socket to actually close so nothing (in particular no log line) runs on our
+                // behalf after destroy() has resolved (#325)
+                const socketClosed = this._waitForSocketClose();
                 this._webSocketClient.close();
+                await socketClosed;
+                log("Closed websocket connection to", this._websocketServerUrl);
             }
         } catch (e) {
             log.error("Failed to close websocket", e);
@@ -286,6 +301,21 @@ export default class PKCRpcClient extends TypedEmitter<PKCRpcClientEvents> {
 
         this._openConnectionPromise = undefined;
         this.setState("stopped");
+    }
+
+    // Resolves once the raw socket under rpc-websockets has fully closed, right away if there is none.
+    // Bounded so a peer that never completes the close handshake cannot hang destroy(); rpc-websockets
+    // exposes the raw socket as `.socket` (ws in Node, the native WebSocket in browsers), both of which
+    // support addEventListener.
+    private async _waitForSocketClose(): Promise<void> {
+        const socket = (this._webSocketClient as unknown as { socket?: RawWebSocket }).socket;
+        if (!socket || socket.readyState === WEBSOCKET_READY_STATE_CLOSED) return;
+        const closed = new Promise<void>((resolve) => socket.addEventListener("close", () => resolve(), { once: true }));
+        try {
+            await pTimeout(closed, { milliseconds: DESTROY_SOCKET_CLOSE_TIMEOUT_MS });
+        } catch {
+            log.error("Websocket did not close within", DESTROY_SOCKET_CLOSE_TIMEOUT_MS, "ms of destroy()", this._websocketServerUrl);
+        }
     }
 
     toJSON() {

--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -179,6 +179,7 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
     // http server underlies the WS.
     private _httpServer: HTTPServer | HTTPSServer | undefined;
     private _ownsHttpServer: boolean = false;
+    private _pendingDisconnectionCleanups: Set<Promise<void>> = new Set();
 
     constructor({
         port,
@@ -275,25 +276,18 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
             log("Established connection with new RPC client", ws._id);
         });
 
-        // cleanup on disconnect
-        this.rpcWebsockets.on("disconnection", async (ws) => {
-            log("RPC client disconnected", ws._id, "number of rpc clients connected", this.rpcWebsockets.wss.clients.size);
-            const subscriptionCleanups = this.subscriptionCleanups[ws._id];
-            if (!subscriptionCleanups) {
-                delete this.subscriptionCleanups[ws._id];
-                delete this.connections[ws._id];
-                delete this._onSettingsChange[ws._id];
-                log("Disconnected from RPC client (no subscriptions to clean)", ws._id);
-                return;
-            }
-            for (const subscriptionId in subscriptionCleanups) {
-                await subscriptionCleanups[subscriptionId]();
-                delete subscriptionCleanups[subscriptionId];
-            }
-            delete this.subscriptionCleanups[ws._id];
-            delete this.connections[ws._id];
-            delete this._onSettingsChange[ws._id];
-            log("Disconnected from RPC client", ws._id);
+        // cleanup on disconnect. rpc-websockets does not await this listener, so its promise is tracked in
+        // _pendingDisconnectionCleanups for destroy() to await (#325): a subscription registered between
+        // destroy()'s unsubscribe loop and the socket close would otherwise still be cleaning up after
+        // destroy() resolved.
+        this.rpcWebsockets.on("disconnection", (ws) => {
+            const cleanup = this._cleanUpDisconnectedClient(ws._id);
+            this._pendingDisconnectionCleanups.add(cleanup);
+            const untrack = () => this._pendingDisconnectionCleanups.delete(cleanup);
+            cleanup.then(untrack, (e) => {
+                log.error("Failed to clean up after RPC client disconnected", ws._id, e);
+                untrack();
+            });
         });
 
         // register all JSON RPC methods
@@ -1986,6 +1980,26 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
         return { success: true };
     }
 
+    private async _cleanUpDisconnectedClient(connectionId: string) {
+        log("RPC client disconnected", connectionId, "number of rpc clients connected", this.rpcWebsockets.wss.clients.size);
+        const subscriptionCleanups = this.subscriptionCleanups[connectionId];
+        if (!subscriptionCleanups) {
+            delete this.subscriptionCleanups[connectionId];
+            delete this.connections[connectionId];
+            delete this._onSettingsChange[connectionId];
+            log("Disconnected from RPC client (no subscriptions to clean)", connectionId);
+            return;
+        }
+        for (const subscriptionId in subscriptionCleanups) {
+            await subscriptionCleanups[subscriptionId]();
+            delete subscriptionCleanups[subscriptionId];
+        }
+        delete this.subscriptionCleanups[connectionId];
+        delete this.connections[connectionId];
+        delete this._onSettingsChange[connectionId];
+        log("Disconnected from RPC client", connectionId);
+    }
+
     async destroy() {
         for (const connectionId of keys(this.subscriptionCleanups))
             for (const subscriptionId of keys(this.subscriptionCleanups[connectionId]))
@@ -2009,6 +2023,8 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
             for (const client of this.ws.clients) client.terminate();
             await wssClosed;
         }
+        // Every client's "disconnection" has fired by now; wait for the cleanups they started
+        await Promise.allSettled(this._pendingDisconnectionCleanups); // failures were already logged where they happened
         if (this._ownsHttpServer && this._httpServer) await new Promise<void>((r) => this._httpServer!.close(() => r()));
         const pkc = await this._getPKCInstance();
         await pkc.destroy(); // this will stop all started communities

--- a/src/rpc/src/index.ts
+++ b/src/rpc/src/index.ts
@@ -34,6 +34,7 @@ import type {
     DecryptedChallengeVerificationMessageType
 } from "../../pubsub-messages/types.js";
 import WebSocket from "ws";
+import pTimeout from "p-timeout";
 import Publication from "../../publications/publication.js";
 import { PKCError } from "../../pkc-error.js";
 import { LocalCommunity } from "../../runtime/node/community/local-community.js";
@@ -114,6 +115,8 @@ import { findStartedCommunity } from "../../pkc/tracked-instance-registry-util.j
 // store as a singleton because not possible to start the same community twice at the same time
 
 const log = Logger("pkc-js-rpc:pkc-ws-server");
+
+const DESTROY_CLIENTS_CLOSE_TIMEOUT_MS = 5_000;
 
 // Max retries when an auto-start hits a transient Kubo network blip (e.g. a boot-time restart).
 // With factor=2, minTimeout=2s, maxTimeout=15s this spans ~89s of backoff, comfortably covering a
@@ -1988,7 +1991,24 @@ class PKCWsServer extends TypedEmitter<PKCRpcServerEvents> {
             for (const subscriptionId of keys(this.subscriptionCleanups[connectionId]))
                 await this.unsubscribe([{ subscriptionId: Number(subscriptionId) }], connectionId);
 
+        // Close every connected client and wait for the websocket server's "close", which ws only emits once
+        // the last client is gone. ws.close() alone leaves existing connections open when the http server is
+        // external, and http.Server.close() does not wait for upgraded sockets either, so the "disconnection"
+        // cleanup (and its logs) used to run after destroy() had resolved (#325).
+        const wssClosed = new Promise<void>((resolve) => this.ws.once("close", () => resolve()));
         this.ws.close();
+        for (const client of this.ws.clients) client.close(1000, "PKCWsServer is shutting down");
+        try {
+            await pTimeout(wssClosed, { milliseconds: DESTROY_CLIENTS_CLOSE_TIMEOUT_MS });
+        } catch {
+            log.error(
+                "Some RPC clients did not complete the close handshake within",
+                DESTROY_CLIENTS_CLOSE_TIMEOUT_MS,
+                "ms of destroy(), terminating them"
+            );
+            for (const client of this.ws.clients) client.terminate();
+            await wssClosed;
+        }
         if (this._ownsHttpServer && this._httpServer) await new Promise<void>((r) => this._httpServer!.close(() => r()));
         const pkc = await this._getPKCInstance();
         await pkc.destroy(); // this will stop all started communities

--- a/test/node/rpc/rpc-destroy-late-logs.test.ts
+++ b/test/node/rpc/rpc-destroy-late-logs.test.ts
@@ -1,0 +1,231 @@
+// Regression test for #325: PKCRpcClient.destroy() and PKCWsServer.destroy() used to resolve
+// before their websockets had actually closed, so the "close"/"disconnection" handlers kept
+// logging a few milliseconds AFTER the caller believed teardown was done.
+//
+// Why that matters: under --per-test-logs, test/vitest-node-setup.js routes the `debug` module
+// through console.error, and vitest forwards every console line from the worker to the main
+// process over its birpc channel (onUserConsoleLog). A line that lands while vitest is already
+// tearing the worker down (an RPC suite's afterAll was the last thing in that worker) is
+// rejected with `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`,
+// which vitest counts as an unhandled error and turns an all-green run into exit 1 (CI run
+// 33630856165 on master, blamed on start-error-replay-stop-race.rpc.test.ts).
+//
+// The contract asserted here: once destroy() resolves, the endpoint's socket(s) are closed and
+// it emits no further debug output. The capture hooks the shared `debug` sink (the same singleton
+// dist/ logs through, which is what the setup file relies on), so any late line from the
+// endpoint's namespaces shows up in `lateLines`.
+import { describe, it, expect, afterAll, beforeAll } from "vitest";
+import { createRequire } from "node:module";
+import { once } from "node:events";
+import { WebSocketServer, type WebSocket as WsSocket, type RawData } from "ws";
+import PKC from "../../../dist/node/index.js";
+import PKCRpcClient from "../../../dist/node/clients/rpc-client/pkc-rpc-client.js";
+import { mockRpcServerPKC } from "../../../dist/node/test/test-util.js";
+import { createInProcessRpcServer, uniqueTmpDataPath, type PKCWsServerType } from "../../helpers/rpc-server-harness.js";
+import { describeIfRpc } from "../../helpers/conditional-tests.js";
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+
+interface DebugModule {
+    log: (...args: unknown[]) => void;
+    enable: (namespaces: string) => void;
+    disable: () => string;
+}
+
+// `debug` ships no typings and is CJS; createRequire hands back the same cached instance that
+// @pkcprotocol/pkc-logger (and therefore dist/) logs through.
+const debugModule: DebugModule = createRequire(import.meta.url)("debug");
+
+const CLIENT_NAMESPACES = "pkc-js:pkc-rpc-client*,pkc-js:PKCRpcClient*";
+const SERVER_NAMESPACES = "pkc-js:PKCWsServer*,pkc-js-rpc:pkc-ws-server*";
+
+// Enable the given namespaces and divert the debug sink into an array. restore() puts back
+// whatever sink and namespace selection were active before (the per-test-logs redirect, DEBUG
+// env), so the capture never leaks into other suites in the worker.
+function captureDebugOutput(namespaces: string): { lines: string[]; restore: () => void } {
+    const lines: string[] = [];
+    const previousLog = debugModule.log;
+    const previousNamespaces = debugModule.disable();
+    debugModule.enable(namespaces);
+    debugModule.log = (...args: unknown[]) => {
+        lines.push(args.map((arg) => (typeof arg === "string" ? arg : String(arg))).join(" "));
+    };
+    return {
+        lines,
+        restore: () => {
+            debugModule.log = previousLog;
+            debugModule.enable(previousNamespaces);
+        }
+    };
+}
+
+// The rpc-websockets "close" event is emitted on a setTimeout(0) after the raw socket closes, so
+// a late log from either endpoint arrives within a couple of macrotasks. 500ms is a generous
+// window for it to show up in `lateLines`.
+const LATE_LOG_SETTLE_MS = 500;
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const WS_READY_STATE_CLOSED = 3;
+
+// Just enough JSON-RPC to let PKCRpcClient open a connection and get one response back.
+class MinimalRpcServer {
+    private constructor(
+        readonly wss: WebSocketServer,
+        readonly port: number
+    ) {
+        wss.on("connection", (socket: WsSocket) => {
+            socket.on("message", (raw: RawData) => {
+                const message = JSON.parse(raw.toString()) as { id?: number };
+                if (typeof message.id !== "number") return;
+                socket.send(JSON.stringify({ jsonrpc: "2.0", id: message.id, result: {} }));
+            });
+        });
+    }
+
+    static async create(): Promise<MinimalRpcServer> {
+        const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+        await once(wss, "listening");
+        const address = wss.address();
+        if (address === null || typeof address === "string") throw Error("Expected WebSocketServer to listen on a TCP port");
+        return new MinimalRpcServer(wss, address.port);
+    }
+
+    async destroy() {
+        for (const client of this.wss.clients) client.terminate();
+        await new Promise<void>((resolve, reject) => this.wss.close((err) => (err ? reject(err) : resolve())));
+    }
+}
+
+type RpcClientInternals = { _webSocketClient: { socket?: { readyState: number } } };
+type RpcServerInternals = { rpcWebsockets: { wss: { clients: Set<unknown> } } };
+
+describe("PKCRpcClient.destroy() closes its websocket before resolving (#325)", () => {
+    let server: MinimalRpcServer;
+
+    beforeAll(async () => {
+        server = await MinimalRpcServer.create();
+    });
+
+    afterAll(async () => {
+        await server.destroy();
+    });
+
+    it("the socket is closed when destroy() resolves and no rpc-client debug output follows", async () => {
+        const client = new PKCRpcClient(`ws://127.0.0.1:${server.port}`);
+        await client.rpcCall("ping", []); // opens the connection
+        expect(client.state).toBe("connected");
+
+        const capture = captureDebugOutput(CLIENT_NAMESPACES);
+        try {
+            await client.destroy();
+            // rpc-websockets clears .socket once the underlying socket has fully closed
+            const socket = (client as unknown as RpcClientInternals)._webSocketClient.socket;
+            const socketClosedWhenDestroyResolved = socket === undefined || socket.readyState === WS_READY_STATE_CLOSED;
+            const linesWhenDestroyResolved = capture.lines.length;
+
+            await sleep(LATE_LOG_SETTLE_MS);
+
+            expect({
+                socketClosedWhenDestroyResolved,
+                lateLines: capture.lines.slice(linesWhenDestroyResolved)
+            }).toEqual({
+                socketClosedWhenDestroyResolved: true,
+                lateLines: []
+            });
+        } finally {
+            capture.restore();
+        }
+    });
+});
+
+// Needs the in-process PKCWsServer, which is backed by a Node-side PKC pointed at the local test
+// Kubo like every other in-process RPC suite here, so it runs in the RPC configs only.
+describeIfRpc("PKCWsServer.destroy() closes its clients before resolving (#325)", () => {
+    let rpcServer: PKCWsServerType;
+    let serverPKC: PKCType;
+    let rpcUrl: string;
+
+    beforeAll(async () => {
+        serverPKC = await mockRpcServerPKC({ dataPath: uniqueTmpDataPath("pkc-rpc-destroy-late-logs-test") });
+        ({ rpcServer, rpcUrl } = await createInProcessRpcServer({ serverPKC, authKey: "test-rpc-destroy-late-logs" }));
+    });
+
+    let serverDestroyedByTest = false;
+
+    afterAll(async () => {
+        // PKCWsServer.destroy() is not idempotent (it destroys its PKC), so only clean up here if
+        // the test did not get as far as destroying the server itself
+        if (rpcServer && !serverDestroyedByTest) await rpcServer.destroy();
+        if (serverPKC && !serverPKC.destroyed) await serverPKC.destroy();
+    });
+
+    it("a still-connected client is disconnected when destroy() resolves and no server debug output follows", async () => {
+        const client = new PKCRpcClient(rpcUrl);
+        const wss = (rpcServer as unknown as RpcServerInternals).rpcWebsockets.wss;
+        const capture = captureDebugOutput(SERVER_NAMESPACES);
+        try {
+            await client.initalizeCommunitieschangeEvent(); // opens the connection and leaves a live subscription for destroy() to clean up
+            expect(wss.clients.size).toBe(1);
+
+            serverDestroyedByTest = true;
+            await rpcServer.destroy();
+            const clientsWhenDestroyResolved = wss.clients.size;
+            const linesWhenDestroyResolved = capture.lines.length;
+
+            await sleep(LATE_LOG_SETTLE_MS);
+
+            expect({
+                clientsWhenDestroyResolved,
+                lateLines: capture.lines.slice(linesWhenDestroyResolved)
+            }).toEqual({
+                clientsWhenDestroyResolved: 0,
+                lateLines: []
+            });
+        } finally {
+            capture.restore();
+            await client.destroy();
+        }
+    });
+});
+
+// The exact teardown shape of the failing CI run: the test destroys its client PKC, then afterAll
+// destroys the in-process server and the server PKC, and the worker is torn down right after.
+describeIfRpc("client PKC then PKCWsServer teardown emits no debug output after the last destroy() resolves (#325)", () => {
+    let rpcServer: PKCWsServerType;
+    let serverPKC: PKCType;
+    let rpcUrl: string;
+
+    beforeAll(async () => {
+        serverPKC = await mockRpcServerPKC({ dataPath: uniqueTmpDataPath("pkc-rpc-destroy-sequence-test") });
+        ({ rpcServer, rpcUrl } = await createInProcessRpcServer({ serverPKC, authKey: "test-rpc-destroy-sequence" }));
+    });
+
+    let serverDestroyedByTest = false;
+
+    afterAll(async () => {
+        if (rpcServer && !serverDestroyedByTest) await rpcServer.destroy();
+        if (serverPKC && !serverPKC.destroyed) await serverPKC.destroy();
+    });
+
+    it("no client or server debug output lands after the teardown sequence resolves", async () => {
+        const client = await PKC({ pkcRpcClientsOptions: [rpcUrl], dataPath: undefined, httpRoutersOptions: [] });
+        const capture = captureDebugOutput(`${CLIENT_NAMESPACES},${SERVER_NAMESPACES}`);
+        try {
+            const rpcClient = client.clients.pkcRpcClients[rpcUrl];
+            await rpcClient.initalizeCommunitieschangeEvent(); // opens the connection with a live subscription, like a real client
+            expect(rpcClient.state).toBe("connected");
+
+            await client.destroy();
+            serverDestroyedByTest = true;
+            await rpcServer.destroy(); // also destroys serverPKC
+            if (!serverPKC.destroyed) await serverPKC.destroy();
+            const linesWhenTeardownResolved = capture.lines.length;
+
+            await sleep(LATE_LOG_SETTLE_MS);
+
+            expect(capture.lines.slice(linesWhenTeardownResolved)).toEqual([]);
+        } finally {
+            capture.restore();
+            if (!client.destroyed) await client.destroy();
+        }
+    });
+});


### PR DESCRIPTION
Closes #325

## Problem

CI run 33630856165 (`test-pkc-rpc` on master) exited 1 with all 2291 tests green:

```
Errors  2 errors
EnvironmentTeardownError: [vitest-worker]: Closing rpc while "onUserConsoleLog" was pending
This error originated in "test/node/rpc/start-error-replay-stop-race.rpc.test.ts" test file.
```

Both RPC endpoints kept logging after their `destroy()` had resolved:

- `PKCRpcClient.destroy()` called `close()` on the websocket and returned without waiting for it to close. The rpc-websockets `close` handler then logged `connection with web socket has been closed` a few ms later.
- `PKCWsServer.destroy()` only stopped accepting new connections: with an external http server, `wss.close()` leaves existing clients open, and `http.Server.close()` does not wait for upgraded sockets. The `disconnection` cleanup and its `RPC client disconnected` logs ran after `destroy()` resolved.

Under `--per-test-logs` the `debug` module is routed through `console.error`, so each late line becomes an `onUserConsoleLog` birpc call from the worker to the main process. When an RPC suite's `afterAll` is the last thing in its worker, that call lands while vitest is closing the channel, is rejected as `EnvironmentTeardownError`, and vitest counts it as an unhandled error. Any RPC test file can hit this; it is unrelated to the commit that was under test.

## Fix

- `PKCRpcClient.destroy()` awaits the raw socket's close (bounded at 5s) before resolving, and the `close` handler stays quiet once destroy was requested, mirroring what the `error` handler already did.
- `PKCWsServer.destroy()` closes every connected client and awaits the websocket server's `close` event (emitted by `ws` only once the last client is gone; bounded at 5s, then terminates stragglers) before closing the http server, so the disconnection cleanup runs inside `destroy()`.

## Test

`test/node/rpc/rpc-destroy-late-logs.test.ts` hooks the shared `debug` sink (the same singleton `dist/` logs through) and asserts that after `destroy()` resolves the endpoint's sockets are closed and no further output from its namespaces arrives:

- client alone against a minimal JSON-RPC server (runs in every config)
- in-process `PKCWsServer` with a still-connected client (RPC configs)
- the exact client-PKC-then-server teardown sequence of the failing run (RPC configs)

Against unmodified `src/` the client test fails with the same late line the CI log showed:

```
+   "lateLines": [
+     "  pkc-js:pkc-rpc-client:_init:error connection with web socket has been closed ws://127.0.0.1:40873 +0ms",
+   ],
+   "socketClosedWhenDestroyResolved": false,
```

Locally green: the new file, all of `test/node/rpc` (18 files, 54 tests, 0 unhandled errors) and `src/rpc/test/node{,-and-browser}` under `local-kubo-rpc,remote-pkc-rpc`.

## Follow-up

CodeRabbit pointed out that rpc-websockets does not await the async `disconnection` listener, so a subscription registered between `destroy()`'s unsubscribe loop and the socket close could still be cleaning up after `destroy()` resolved. The listener's promise is now tracked and `destroy()` awaits all pending cleanups (allSettled) after the websocket server closes. A cleanup failure is logged where it happens instead of becoming an unhandled rejection.

The first CI run failed only on node-local (windows-latest), in the Helia warmup floor timing test (`floor leg took 16518ms: expected below 14000`), which does not touch the RPC paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket shutdown handling so client and server cleanup completes only after connections have fully closed.
  * Prevented delayed diagnostic messages from appearing after shutdown finishes.
  * Added timeout handling and forced termination for connections that do not close promptly.
  * Ensured subscription cleanup completes before shutdown finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->