### PR TITLE
perf(helia): serve subscribed IPNS names from cache while the push channel is healthy (#330)

### DIFF
--- a/src/community/community-client-manager.ts
+++ b/src/community/community-client-manager.ts
@@ -866,18 +866,40 @@ export class CommunityClientsManager extends PKCClientsManager {
         });
     }
 
+    // True while the libp2p-js resolver's push-channel watchdog vouches for `ipnsName`'s topic
+    // (issue #330). A probe failure must never break the update cycle: on any error the answer
+    // is "unhealthy", which only costs a network revalidation.
+    private _isIpnsPushChannelHealthyForName(libp2pJsClient: Libp2pJsClient, ipnsName: string): boolean {
+        try {
+            return libp2pJsClient.heliaWithKuboRpcClientFunctions.isIpnsPushChannelHealthy({
+                pubsubTopic: ipnsNameToIpnsOverPubsubTopic(ipnsName)
+            });
+        } catch {
+            return false;
+        }
+    }
+
     private async _fetchCommunityIpnsP2PAndVerify(ipnsName: string): Promise<ResultOfFetchingCommunity> {
         const log = Logger("pkc-js:clients-manager:_fetchCommunityIpnsP2PAndVerify");
         const kuboRpcOrHelia = this.getDefaultKuboRpcClientOrHelia();
         if ("_helia" in kuboRpcOrHelia) {
             this.updateLibp2pJsClientState("fetching-ipns", kuboRpcOrHelia._libp2pJsClientsOptions.key);
         } else this.updateKuboRpcState("fetching-ipns", kuboRpcOrHelia.url);
-        // A cycle woken by the safety-net timer (not by an arrival) must revalidate on the
-        // network: the routing-layer cache gate cannot observe a push that never arrived, and
-        // would otherwise serve the stale record for its whole remaining ttl (300s at kubo
-        // 0.43's default) instead of the max(updateInterval, revalidation floor) the safety net
-        // promises. No-op for the kubo-RPC resolver, which always resolves with nocache: true.
-        const forceNetworkRevalidation = this._nextResolveRevalidatesNetwork;
+        // A cycle woken by the safety-net timer (not by an arrival) exists for pushes that
+        // never arrived, which the routing-layer cache gate's ttl check alone cannot observe —
+        // it would serve the stale record for its whole remaining ttl (300s at kubo 0.43's
+        // default) instead of the max(updateInterval, revalidation floor) the safety net
+        // promises. The push-channel watchdog (issue #330) observes exactly that condition
+        // though: while the anchor topic has gossipsub subscribers and a signature-valid record
+        // arrived within the watchdog window, rebroadcasts and fetch-on-join are demonstrably
+        // keeping the cache current, so the forced network revalidation is skipped and the
+        // resolve rides the cache gate (each hop of a delegated chain then consults its own
+        // topic's health, and the gate itself falls back to per-ttl revalidation the moment a
+        // channel degrades — the next armed tick after that forces the network again). No-op
+        // for the kubo-RPC resolver, which always resolves with nocache: true.
+        const forceNetworkRevalidation =
+            this._nextResolveRevalidatesNetwork &&
+            !("_helia" in kuboRpcOrHelia && this._isIpnsPushChannelHealthyForName(kuboRpcOrHelia, ipnsName));
         // Consumed by the cycle's FIRST attempt only: updateOnce retries this fetch (forever,
         // with backoff) on retriable errors such as a CID fetch timeout after a successful
         // resolve, and those attempts must ride the cache as the 1s poll's retries did instead

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -435,26 +435,46 @@ export async function createLibp2pJsClientOrUseExistingOne(
         const ipnsRecordNetworkValidatedAtMs = new Map<string, number>();
 
         // Push-channel health state for IPNS resolution (issue #330). A topic's push channel is
-        // HEALTHY when it has at least one gossipsub subscriber AND a signature-valid record for
-        // it was obtained from the network within `watchdogMs` — via a gossiped message
-        // (identical rebroadcast bytes included, see the raw-message listener below), an
-        // accepted-newer localStore write from any path, or a validated fetch (direct fast path
-        // or fallback router.get()). While healthy, name.resolve serves the cached record PAST
-        // its ttl (the ipns-pubsub-router spec's model: pushes, rebroadcasts, and fetch-on-join
-        // keep a subscribed node current, so timer-driven revalidation buys nothing); while
-        // unhealthy it falls back to the exact per-ttl revalidation of issues #301/#307.
-        // `routingKeyByTopic` scopes the raw-message listener to IPNS topics this resolver
-        // registered and gives it the key to validate against. Exposed on the client as
-        // `_ipnsPushChannel` so tests can shrink the watchdog window and inspect arrivals; both
-        // maps are bounded by the set of IPNS names this helia instance resolves.
+        // HEALTHY when it has at least one gossipsub subscriber AND a signature-valid,
+        // sequence-current record for it was obtained from the network within `watchdogMs` — via
+        // a gossiped message (identical rebroadcast bytes included, see the raw-message listener
+        // below), an accepted-newer localStore write from any path, or a validated fetch (direct
+        // fast path or fallback router.get()). While healthy, name.resolve serves the cached
+        // record PAST its ttl (the ipns-pubsub-router spec's model: pushes, rebroadcasts, and
+        // fetch-on-join keep a subscribed node current, so timer-driven revalidation buys
+        // nothing); while unhealthy it falls back to the exact per-ttl revalidation of issues
+        // #301/#307. `routingKeyByTopic` scopes the raw-message listener to IPNS topics this
+        // resolver registered and gives it the key to validate against. Exposed on the client as
+        // `_ipnsPushChannel` so tests can shrink the watchdog window and inspect arrivals; all
+        // three maps are bounded by the set of IPNS names this helia instance resolves.
         const ipnsPushChannel: IpnsPushChannelState = {
             watchdogMs: IPNS_PUSH_CHANNEL_WATCHDOG_MS,
             lastValidRecordArrivalMs: new Map<string, number>(),
-            routingKeyByTopic: new Map<string, Uint8Array>()
+            routingKeyByTopic: new Map<string, Uint8Array>(),
+            highestKnownSequenceByTopic: new Map<string, bigint>()
         };
         const isIpnsPushChannelHealthy = (pubsubTopic: string): boolean =>
             helia.libp2p.services.pubsub.getSubscribers(pubsubTopic).length > 0 &&
             Date.now() - (ipnsPushChannel.lastValidRecordArrivalMs.get(pubsubTopic) ?? 0) < ipnsPushChannel.watchdogMs;
+
+        // The single stamping path for every watchdog heartbeat, and the stale-replay guard:
+        // `ipnsValidator` checks the signature and EOL but NOT sequence order, so without this
+        // comparison a signature-valid but strictly OLDER (still unexpired) record — a lagging
+        // peer rebroadcasting its stale best, or an adversarial subscriber replaying an old one —
+        // would hold the watchdog open indefinitely (up to the replayed record's validity) and
+        // keep the resolver from the revalidation that would find the newer record. A heartbeat
+        // must attest that the channel delivers records at least as new as the best we hold:
+        // only a sequence >= the highest we've seen from any validated source advances the
+        // stamp (identical rebroadcasts pass, which is the point of the raw-message listener).
+        const stampIpnsPushChannelArrival = (pubsubTopic: string, sequence: bigint): void => {
+            const highestKnown = ipnsPushChannel.highestKnownSequenceByTopic.get(pubsubTopic);
+            if (highestKnown !== undefined && sequence < highestKnown) {
+                log.trace("Ignoring a stale-replay push-channel heartbeat on IPNS topic", pubsubTopic, sequence, "<", highestKnown);
+                return;
+            }
+            ipnsPushChannel.highestKnownSequenceByTopic.set(pubsubTopic, sequence);
+            ipnsPushChannel.lastValidRecordArrivalMs.set(pubsubTopic, Date.now());
+        };
 
         // The watchdog's heartbeat source (issue #330): kubo rebroadcasts the CURRENT record
         // every 10 minutes, and the pubsub router's #handleRecord returns before localStore.put
@@ -462,13 +482,17 @@ export async function createLibp2pJsClientOrUseExistingOne(
         // the very messages that prove the channel is alive. Listen to raw gossip instead, gated
         // on the topics this resolver registered, and stamp an arrival only after the record
         // validates against the topic's routing key (a garbage or forged message must not feed
-        // the watchdog). Validation failures are dropped quietly: gossip is an open channel and
-        // the router logs its own rejections.
+        // the watchdog) AND clears the stamp helper's sequence guard (a valid-but-older replay
+        // must not either). Validation failures are dropped quietly: gossip is an open channel
+        // and the router logs its own rejections. This validation duplicates the one
+        // #handleRecord runs on the same bytes; at rebroadcast cadence (one message per topic
+        // per 10 minutes) the doubled crypto is negligible, and deduping would mean reaching
+        // into the router's internals.
         helia.libp2p.services.pubsub.addEventListener("message", (evt) => {
             const gossipRoutingKey = ipnsPushChannel.routingKeyByTopic.get(evt.detail.topic);
             if (!gossipRoutingKey) return;
             ipnsValidator(gossipRoutingKey, evt.detail.data)
-                .then(() => ipnsPushChannel.lastValidRecordArrivalMs.set(evt.detail.topic, Date.now()))
+                .then(() => stampIpnsPushChannelArrival(evt.detail.topic, unmarshalIPNSRecord(evt.detail.data).sequence))
                 .catch((err) => log.trace("Ignoring an invalid record gossiped on IPNS topic", evt.detail.topic, err));
         });
 
@@ -489,10 +513,6 @@ export async function createLibp2pJsClientOrUseExistingOne(
         ipnsPubsubLocalStore.put = async (routingKey, marshalledRecord, options) => {
             await originalLocalStorePut(routingKey, marshalledRecord, options);
             const pubsubTopic = binaryKeyToPubsubTopic(routingKey);
-            // Every accepted-newer record is also a push-channel heartbeat (issue #330).
-            ipnsPushChannel.lastValidRecordArrivalMs.set(pubsubTopic, Date.now());
-            const listeners = ipnsRecordArrivalListeners.get(pubsubTopic);
-            if (!listeners || listeners.size === 0) return;
             let record: IPNSRecord;
             try {
                 record = unmarshalIPNSRecord(marshalledRecord);
@@ -500,6 +520,12 @@ export async function createLibp2pJsClientOrUseExistingOne(
                 log.error("Failed to unmarshal a cached IPNS record for the arrival listeners of topic", pubsubTopic, e);
                 return;
             }
+            // Every accepted-newer record is also a push-channel heartbeat (issue #330); the
+            // helper's sequence guard is a no-op here since accepted writes are newer-only, but
+            // it must still learn the sequence so gossip replays are compared against it.
+            stampIpnsPushChannelArrival(pubsubTopic, record.sequence);
+            const listeners = ipnsRecordArrivalListeners.get(pubsubTopic);
+            if (!listeners || listeners.size === 0) return;
             for (const listener of [...listeners]) {
                 try {
                     listener({ pubsubTopic, record });
@@ -660,7 +686,9 @@ export async function createLibp2pJsClientOrUseExistingOne(
                                     // A validated fetch also opens the push-channel trust window
                                     // (issue #330): staleness is zero right now, and the channel
                                     // has watchdogMs to prove itself before the next refetch.
-                                    ipnsPushChannel.lastValidRecordArrivalMs.set(ipnsPubsubTopic, Date.now());
+                                    // (Sequence-guarded like every heartbeat: a lagging provider
+                                    // serving an older record than we hold must not extend it.)
+                                    stampIpnsPushChannelArrival(ipnsPubsubTopic, record.sequence);
                                     // Direct fetch bypasses the pubsub router's handleRecord, which is
                                     // where gossipsub-delivered records get cached at the routing layer.
                                     // Persist the record there ourselves (newer-only, issue #210) so
@@ -795,7 +823,7 @@ export async function createLibp2pJsClientOrUseExistingOne(
                         const record = unmarshalIPNSRecord(recordBytes);
                         // Same freshness stamps as the direct-fetch hit above (issues #301/#330).
                         ipnsRecordNetworkValidatedAtMs.set(ipnsPubsubTopic, Date.now());
-                        ipnsPushChannel.lastValidRecordArrivalMs.set(ipnsPubsubTopic, Date.now());
+                        stampIpnsPushChannelArrival(ipnsPubsubTopic, record.sequence);
                         yield record.value;
                     }
 
@@ -1003,6 +1031,7 @@ export async function createLibp2pJsClientOrUseExistingOne(
                     ipnsRecordArrivalListeners.clear();
                     ipnsPushChannel.lastValidRecordArrivalMs.clear();
                     ipnsPushChannel.routingKeyByTopic.clear();
+                    ipnsPushChannel.highestKnownSequenceByTopic.clear();
 
                     // Tear down the IPNS pubsub router's internal subscription state.
                     // PubSubIPNSRouting (@helia/ipns) implements Startable and tracks its own

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -987,6 +987,7 @@ export async function createLibp2pJsClientOrUseExistingOne(
                     if (listeners.size === 0) ipnsRecordArrivalListeners.delete(pubsubTopic);
                 }
             },
+            isIpnsPushChannelHealthy: ({ pubsubTopic }: { pubsubTopic: string }) => isIpnsPushChannelHealthy(pubsubTopic),
             async stop(options) {
                 const clientFromMap = libp2pJsClients[pkcOptions.key];
                 if (!clientFromMap) return; // already been stopped

--- a/src/helia/helia-for-pkc.ts
+++ b/src/helia/helia-for-pkc.ts
@@ -23,7 +23,7 @@ import type { AddResult, NameResolveOptions as KuboNameResolveOptions } from "ku
 import type { IpfsHttpClientPubsubMessage, ParsedPKCOptions } from "../types.js";
 
 import { EventEmitter } from "events";
-import type { HeliaWithLibp2pPubsub, IpnsRecordArrivalListener } from "./types.js";
+import type { HeliaWithLibp2pPubsub, IpnsPushChannelState, IpnsRecordArrivalListener } from "./types.js";
 import { PKCError } from "../pkc-error.js";
 import { Libp2pJsClient } from "./libp2pjsClient.js";
 import {
@@ -118,6 +118,15 @@ export function ipnsRouterTag(router: unknown): string {
 export function isLocalStoreIpnsRouter(router: unknown): boolean {
     return ipnsRouterTag(router) === "LocalStoreRouting()";
 }
+
+// How long a name's push channel is trusted after the last signature-valid record was obtained
+// from the network (issue #330). kubo's go-libp2p-pubsub-router rebroadcasts its best record on
+// every subscribed topic every 10 minutes and fetches from every peer that joins a topic, so a
+// topic with a live mesh delivers a valid record at least once per rebroadcast interval even
+// when nothing changes. 1.5x that interval means one missed rebroadcast is tolerated; silence
+// beyond it can only mean the push channel is broken, and cache serving falls back to the
+// per-ttl revalidation of issues #301/#307 (which also re-warms the mesh via the network path).
+export const IPNS_PUSH_CHANNEL_WATCHDOG_MS = 15 * 60_000;
 
 export async function createLibp2pJsClientOrUseExistingOne(
     pkcOptions: Required<Pick<ParsedPKCOptions, "httpRoutersOptions">> &
@@ -425,6 +434,44 @@ export async function createLibp2pJsClientOrUseExistingOne(
         // of IPNS names this helia instance resolves (communities the app follows).
         const ipnsRecordNetworkValidatedAtMs = new Map<string, number>();
 
+        // Push-channel health state for IPNS resolution (issue #330). A topic's push channel is
+        // HEALTHY when it has at least one gossipsub subscriber AND a signature-valid record for
+        // it was obtained from the network within `watchdogMs` — via a gossiped message
+        // (identical rebroadcast bytes included, see the raw-message listener below), an
+        // accepted-newer localStore write from any path, or a validated fetch (direct fast path
+        // or fallback router.get()). While healthy, name.resolve serves the cached record PAST
+        // its ttl (the ipns-pubsub-router spec's model: pushes, rebroadcasts, and fetch-on-join
+        // keep a subscribed node current, so timer-driven revalidation buys nothing); while
+        // unhealthy it falls back to the exact per-ttl revalidation of issues #301/#307.
+        // `routingKeyByTopic` scopes the raw-message listener to IPNS topics this resolver
+        // registered and gives it the key to validate against. Exposed on the client as
+        // `_ipnsPushChannel` so tests can shrink the watchdog window and inspect arrivals; both
+        // maps are bounded by the set of IPNS names this helia instance resolves.
+        const ipnsPushChannel: IpnsPushChannelState = {
+            watchdogMs: IPNS_PUSH_CHANNEL_WATCHDOG_MS,
+            lastValidRecordArrivalMs: new Map<string, number>(),
+            routingKeyByTopic: new Map<string, Uint8Array>()
+        };
+        const isIpnsPushChannelHealthy = (pubsubTopic: string): boolean =>
+            helia.libp2p.services.pubsub.getSubscribers(pubsubTopic).length > 0 &&
+            Date.now() - (ipnsPushChannel.lastValidRecordArrivalMs.get(pubsubTopic) ?? 0) < ipnsPushChannel.watchdogMs;
+
+        // The watchdog's heartbeat source (issue #330): kubo rebroadcasts the CURRENT record
+        // every 10 minutes, and the pubsub router's #handleRecord returns before localStore.put
+        // when the gossiped bytes are identical to the cache — so the put wrap below never sees
+        // the very messages that prove the channel is alive. Listen to raw gossip instead, gated
+        // on the topics this resolver registered, and stamp an arrival only after the record
+        // validates against the topic's routing key (a garbage or forged message must not feed
+        // the watchdog). Validation failures are dropped quietly: gossip is an open channel and
+        // the router logs its own rejections.
+        helia.libp2p.services.pubsub.addEventListener("message", (evt) => {
+            const gossipRoutingKey = ipnsPushChannel.routingKeyByTopic.get(evt.detail.topic);
+            if (!gossipRoutingKey) return;
+            ipnsValidator(gossipRoutingKey, evt.detail.data)
+                .then(() => ipnsPushChannel.lastValidRecordArrivalMs.set(evt.detail.topic, Date.now()))
+                .catch((err) => log.trace("Ignoring an invalid record gossiped on IPNS topic", evt.detail.topic, err));
+        });
+
         // Push signal for IPNS names (issue #308): every accepted-newer record converges on the
         // pubsub router's localStore.put — gossipsub delivery (handleRecord), the direct-fetch
         // cache write (cacheIpnsRecordInPubsubLocalStore), and the fallback router.get() fetch
@@ -442,6 +489,8 @@ export async function createLibp2pJsClientOrUseExistingOne(
         ipnsPubsubLocalStore.put = async (routingKey, marshalledRecord, options) => {
             await originalLocalStorePut(routingKey, marshalledRecord, options);
             const pubsubTopic = binaryKeyToPubsubTopic(routingKey);
+            // Every accepted-newer record is also a push-channel heartbeat (issue #330).
+            ipnsPushChannel.lastValidRecordArrivalMs.set(pubsubTopic, Date.now());
             const listeners = ipnsRecordArrivalListeners.get(pubsubTopic);
             if (!listeners || listeners.size === 0) return;
             let record: IPNSRecord;
@@ -514,7 +563,13 @@ export async function createLibp2pJsClientOrUseExistingOne(
                         // cached record is inside its ttl window — not a fresh multi-peer fetch
                         // race per call. This is what turns the update loop's 1s cadence from
                         // ~150 fetch streams/s at 64 communities into pushes plus one
-                        // revalidation per name per ttl. Gated on the topic being subscribed
+                        // revalidation per name per ttl. And while the push channel is HEALTHY
+                        // (subscribers present, a valid record arrived within the watchdog
+                        // window), even the per-ttl revalidation is skipped (issue #330): the
+                        // ipns-pubsub-router spec keeps a subscribed node current via pushes,
+                        // rebroadcasts, and fetch-on-join, so the cached record serves for as
+                        // long as it stays signature-valid — the steady-state network cost of an
+                        // updating name drops to zero. Gated on the topic being subscribed
                         // because freshness relies on the push channel this resolver set up on a
                         // previous call; nocache: true bypasses the cache entirely (explicit
                         // refresh, kubo semantics). A cache read failure must never fail the
@@ -524,7 +579,8 @@ export async function createLibp2pJsClientOrUseExistingOne(
                                 const cachedRecord = await readFreshCachedIpnsRecordFromPubsubLocalStore({
                                     localStore: ipnsPubsubLocalStore,
                                     routingKey,
-                                    lastNetworkValidatedAtMs: ipnsRecordNetworkValidatedAtMs.get(ipnsPubsubTopic)
+                                    lastNetworkValidatedAtMs: ipnsRecordNetworkValidatedAtMs.get(ipnsPubsubTopic),
+                                    pushChannelHealthy: isIpnsPushChannelHealthy(ipnsPubsubTopic)
                                 });
                                 if (cachedRecord) {
                                     log.trace("Serving IPNS record for", currentName, "from the routing-layer cache");
@@ -565,6 +621,10 @@ export async function createLibp2pJsClientOrUseExistingOne(
                             // router.get() (which since @helia/ipns 10 skips this add when the
                             // topic is already libp2p-subscribed).
                             ipnsPubsubRouterSubscriptions.add(ipnsPubsubTopic);
+                            // Arm the push-channel watchdog's raw-message listener for this
+                            // topic (issue #330) — it needs the routing key to validate gossiped
+                            // records before stamping arrivals.
+                            ipnsPushChannel.routingKeyByTopic.set(ipnsPubsubTopic, routingKey);
                             void warmupForTopic(ipnsPubsubTopic, options).catch((e) =>
                                 log.trace("Fire-and-forget warmup failed for", ipnsPubsubTopic, e)
                             );
@@ -597,6 +657,10 @@ export async function createLibp2pJsClientOrUseExistingOne(
                                     // this stamp is what lets an idle name serve from cache for
                                     // another ttl window after a revalidation.
                                     ipnsRecordNetworkValidatedAtMs.set(ipnsPubsubTopic, Date.now());
+                                    // A validated fetch also opens the push-channel trust window
+                                    // (issue #330): staleness is zero right now, and the channel
+                                    // has watchdogMs to prove itself before the next refetch.
+                                    ipnsPushChannel.lastValidRecordArrivalMs.set(ipnsPubsubTopic, Date.now());
                                     // Direct fetch bypasses the pubsub router's handleRecord, which is
                                     // where gossipsub-delivered records get cached at the routing layer.
                                     // Persist the record there ourselves (newer-only, issue #210) so
@@ -729,8 +793,9 @@ export async function createLibp2pJsClientOrUseExistingOne(
                         // Validate the record's signature against its routing key before trusting its value.
                         await ipnsValidator(routingKey, recordBytes);
                         const record = unmarshalIPNSRecord(recordBytes);
-                        // Same freshness stamp as the direct-fetch hit above (issue #301).
+                        // Same freshness stamps as the direct-fetch hit above (issues #301/#330).
                         ipnsRecordNetworkValidatedAtMs.set(ipnsPubsubTopic, Date.now());
+                        ipnsPushChannel.lastValidRecordArrivalMs.set(ipnsPubsubTopic, Date.now());
                         yield record.value;
                     }
 
@@ -935,6 +1000,8 @@ export async function createLibp2pJsClientOrUseExistingOne(
                     // Update loops unsubscribe their own arrival listeners on stop; clearing here
                     // covers loops torn down after the shared client's final release.
                     ipnsRecordArrivalListeners.clear();
+                    ipnsPushChannel.lastValidRecordArrivalMs.clear();
+                    ipnsPushChannel.routingKeyByTopic.clear();
 
                     // Tear down the IPNS pubsub router's internal subscription state.
                     // PubSubIPNSRouting (@helia/ipns) implements Startable and tracks its own
@@ -1008,7 +1075,8 @@ export async function createLibp2pJsClientOrUseExistingOne(
             mergedHeliaOptions: mergedHeliaInit,
             countOfUsesOfInstance: 1,
             libp2pJsClientsOptions: pkcOptions,
-            key: pkcOptions.key
+            key: pkcOptions.key,
+            ipnsPushChannel
         };
 
         const client = new Libp2pJsClient(fullInstanceWithOptions);

--- a/src/helia/libp2pjsClient.ts
+++ b/src/helia/libp2pjsClient.ts
@@ -1,5 +1,5 @@
 import type { createHelia } from "helia";
-import type { HeliaWithKuboRpcClientFunctions, HeliaWithLibp2pPubsub } from "./types.js";
+import type { HeliaWithKuboRpcClientFunctions, HeliaWithLibp2pPubsub, IpnsPushChannelState } from "./types.js";
 import type { unixfs } from "@helia/unixfs";
 import { hideClassPrivateProps } from "../util.js";
 import type { ipns } from "@helia/ipns";
@@ -14,6 +14,7 @@ type Libp2pJsClientInit = {
     mergedHeliaOptions: Parameters<typeof createHelia>[0]; // merged defaults with user input for helia and libp2p
     key: string;
     countOfUsesOfInstance: number;
+    ipnsPushChannel: IpnsPushChannelState;
 };
 
 export class Libp2pJsClient {
@@ -25,6 +26,9 @@ export class Libp2pJsClient {
     _mergedHeliaOptions: Omit<NonNullable<Parameters<typeof createHelia>[0]>, "http"> | undefined; // merged defaults with user input for helia and libp2p
     key: Libp2pJsClientInit["key"];
     countOfUsesOfInstance: number;
+    // Push-channel health state for IPNS resolution (issue #330); tests shrink its watchdog
+    // window and inspect arrivals through this handle.
+    _ipnsPushChannel: IpnsPushChannelState;
 
     /**
      * The running Helia node backing this libp2p-js client — the public, semver-covered way for
@@ -52,6 +56,7 @@ export class Libp2pJsClient {
         this._mergedHeliaOptions = libp2pJsClientOptions.mergedHeliaOptions;
         this.key = libp2pJsClientOptions.key;
         this.countOfUsesOfInstance = libp2pJsClientOptions.countOfUsesOfInstance;
+        this._ipnsPushChannel = libp2pJsClientOptions.ipnsPushChannel;
 
         hideClassPrivateProps(this);
     }

--- a/src/helia/types.ts
+++ b/src/helia/types.ts
@@ -18,6 +18,22 @@ export interface IpnsRecordArrival {
 }
 export type IpnsRecordArrivalListener = (arrival: IpnsRecordArrival) => void;
 
+// Push-channel health state for IPNS resolution (issue #330), one per libp2p-js client. A
+// topic's push channel is healthy while it has gossipsub subscribers and a signature-valid
+// record arrived within `watchdogMs`; healthy names serve resolves from the cached record past
+// its ttl instead of revalidating over the network once per ttl window. Exposed on the client as
+// `_ipnsPushChannel` so tests can shrink the watchdog window and inspect arrivals.
+export interface IpnsPushChannelState {
+    watchdogMs: number;
+    // per-topic time of the last signature-valid record obtained from the network: a gossiped
+    // message (identical rebroadcast bytes included), an accepted-newer localStore write, or a
+    // validated fetch
+    lastValidRecordArrivalMs: Map<string, number>;
+    // topics registered by name.resolve, with the routing key the raw-message listener validates
+    // gossiped records against before stamping an arrival
+    routingKeyByTopic: Map<string, Uint8Array>;
+}
+
 export interface HeliaWithKuboRpcClientFunctions extends Pick<NonNullable<KuboRpcClient["_client"]>, "add" | "cat" | "pubsub" | "stop"> {
     add: KuboRpcClient["_client"]["add"];
     name: Pick<KuboRpcClient["_client"]["name"], "resolve">;

--- a/src/helia/types.ts
+++ b/src/helia/types.ts
@@ -25,10 +25,15 @@ export type IpnsRecordArrivalListener = (arrival: IpnsRecordArrival) => void;
 // `_ipnsPushChannel` so tests can shrink the watchdog window and inspect arrivals.
 export interface IpnsPushChannelState {
     watchdogMs: number;
-    // per-topic time of the last signature-valid record obtained from the network: a gossiped
-    // message (identical rebroadcast bytes included), an accepted-newer localStore write, or a
-    // validated fetch
+    // per-topic time of the last signature-valid, sequence-current record obtained from the
+    // network: a gossiped message (identical rebroadcast bytes included), an accepted-newer
+    // localStore write, or a validated fetch. "Sequence-current" means at least as new as
+    // `highestKnownSequenceByTopic` — a replay of an older record never advances this stamp.
     lastValidRecordArrivalMs: Map<string, number>;
+    // per-topic highest record sequence seen from any validated source; the heartbeat guard
+    // that keeps a stale replay (signature-valid but older, see ipns-push-channel-watchdog
+    // tests) from holding the watchdog window open
+    highestKnownSequenceByTopic: Map<string, bigint>;
     // topics registered by name.resolve, with the routing key the raw-message listener validates
     // gossiped records against before stamping an arrival
     routingKeyByTopic: Map<string, Uint8Array>;

--- a/src/helia/types.ts
+++ b/src/helia/types.ts
@@ -56,6 +56,11 @@ export interface HeliaWithKuboRpcClientFunctions extends Pick<NonNullable<KuboRp
         subscribe(args: { pubsubTopic: string; listener: IpnsRecordArrivalListener }): void;
         unsubscribe(args: { pubsubTopic: string; listener: IpnsRecordArrivalListener }): void;
     };
+    // Push-channel health probe (issue #330), pkc-only: true while the topic has gossipsub
+    // subscribers and a signature-valid record for it arrived within the watchdog window. The
+    // update loop uses it to skip its forced safety-net network revalidation — the watchdog
+    // directly observes the "push that never arrived" condition the force existed for.
+    isIpnsPushChannelHealthy(args: { pubsubTopic: string }): boolean;
     // Test-only override of BITSWAP_SESSION_STALLED_GET_FAILOVER_MS, read by cat() at each block
     // get. The issue #189 guard test (at most one routing query per DAG) sets it beyond its own
     // timeout: on slow CI runners a block can legitimately stall, and the failover's broadcast

--- a/src/helia/util.ts
+++ b/src/helia/util.ts
@@ -903,14 +903,25 @@ export function ipnsCacheTtlJitterFactor(routingKey: Uint8Array): number {
 // The record's signature and validity window are re-checked on every read (a cached record can
 // pass its EOL while sitting in the store); an invalid, expired, or stale record yields
 // undefined so the caller falls through to the network path.
+//
+// `pushChannelHealthy` (issue #330) widens the serve window past the record's ttl: when the
+// caller can attest that the name's push channel is demonstrably alive (the topic has gossipsub
+// subscribers and a signature-valid record arrived within the watchdog window), the
+// ipns-pubsub-router spec's model applies — the network keeps a subscribed node current via
+// pushes, rebroadcasts, and fetch-on-join, so a timer-driven revalidation buys nothing — and the
+// cached record is served for as long as it stays signature-valid and inside its EOL. The ttl
+// check below is the DEGRADED mode, exactly the pre-#330 behavior, for a name whose push channel
+// is unhealthy (no subscribers, or the watchdog tripped).
 export async function readFreshCachedIpnsRecordFromPubsubLocalStore({
     localStore,
     routingKey,
-    lastNetworkValidatedAtMs
+    lastNetworkValidatedAtMs,
+    pushChannelHealthy
 }: {
     localStore: IpnsPubsubLocalStore;
     routingKey: Uint8Array;
     lastNetworkValidatedAtMs?: number;
+    pushChannelHealthy?: boolean;
 }): Promise<IPNSRecord | undefined> {
     if (!(await localStore.has(routingKey))) return undefined;
     const { record: recordBytes, created } = await localStore.get(routingKey);
@@ -921,6 +932,7 @@ export async function readFreshCachedIpnsRecordFromPubsubLocalStore({
         return undefined;
     }
     const record = unmarshalIPNSRecord(recordBytes);
+    if (pushChannelHealthy === true) return record; // issue #330: freshness is the push channel's job
     const ttlMs = record.ttl !== undefined ? Number(record.ttl / 1_000_000n) : DEFAULT_CACHED_IPNS_RECORD_TTL_MS;
     // Effective ttl is jittered per name (issue #307) so names cached together don't all miss
     // the cache together; the factor only ever shortens the window, never extends it.

--- a/test/benchmarks/update-loop-bench.test.ts
+++ b/test/benchmarks/update-loop-bench.test.ts
@@ -36,10 +36,11 @@ import type { RemoteCommunity } from "../../dist/node/community/remote-community
 //     churn for staleness)
 // Results are printed and written to .tmp/update-loop-bench-<timestamp>.json for the PR table.
 //
-// Tune with PKC_BENCH_COMMUNITIES (default 32) and PKC_BENCH_WINDOW_MS (default 150000; keep it
-// above 2 ttl windows so at least one expiry boundary lands inside the measurement).
+// Tune with PKC_BENCH_COMMUNITIES (default 32) and PKC_BENCH_WINDOW_MS (default 300000, i.e.
+// "how many fetch calls in 5 minutes", the issues #329/#330 headline number; keep it above 2
+// ttl windows so at least one expiry boundary lands inside the measurement).
 const COMMUNITY_COUNT = Number(process.env.PKC_BENCH_COMMUNITIES) > 0 ? Number(process.env.PKC_BENCH_COMMUNITIES) : 32;
-const WINDOW_MS = Number(process.env.PKC_BENCH_WINDOW_MS) > 0 ? Number(process.env.PKC_BENCH_WINDOW_MS) : 150_000;
+const WINDOW_MS = Number(process.env.PKC_BENCH_WINDOW_MS) > 0 ? Number(process.env.PKC_BENCH_WINDOW_MS) : 300_000;
 const RECORD_TTL = "60s";
 
 getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"] }).map((config) => {

--- a/test/benchmarks/update-loop-bench.test.ts
+++ b/test/benchmarks/update-loop-bench.test.ts
@@ -24,7 +24,11 @@ import type { RemoteCommunity } from "../../dist/node/community/remote-community
 // measures over a steady-state window:
 //   - updatingstatechange events (the #308 churn metric)
 //   - IPNS record network fetch operations via the libp2p fetch service, bucketed per second so
-//     the #307 expiry burst shape is visible (clustered before, spread after)
+//     the #307 expiry burst shape is visible (clustered before, spread after), plus per-call
+//     outcomes: completed vs errored/aborted, the count of calls started while an identical
+//     (same peer, same routing key) call was already in flight (the issue #329 duplicate: the
+//     subscriber and provider branches racing the same peer), and the busiest peers (the issue
+//     #330 fan-out metric: a hub peer serving many topics is asked once per name per ttl window)
 //   - gossipsub messages received (the push channel's traffic)
 //   - client process CPU time over the window
 //   - the serving kubo daemon's bandwidth delta (RPC stats.bw)
@@ -100,11 +104,37 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             // ---- instrumentation on the single libp2p-js client ----
             const libp2pJsClient = pkc.clients.libp2pJsClients[Object.keys(pkc.clients.libp2pJsClients)[0]];
             const fetchService = libp2pJsClient._helia.libp2p.services.fetch;
-            const fetchTimestamps: number[] = [];
+            // Every fetch call is recorded with its target peer, whether an identical call (same
+            // peer, same routing key) was already in flight when it started (the issue #329
+            // duplicate signature), and how it settled. "error" folds real failures and aborts
+            // together because the loser of a duplicated race surfaces as an AbortError, which is
+            // exactly the noise issue #329 describes.
+            type FetchCallRecord = { ts: number; peer: string; startedWhileIdenticalCallInFlight: boolean; outcome?: "ok" | "error" };
+            const fetchCalls: FetchCallRecord[] = [];
+            const inFlightCountByPeerAndKey = new Map<string, number>();
             const originalFetch = fetchService.fetch.bind(fetchService);
             const fetchSpy = vi.spyOn(fetchService, "fetch").mockImplementation((...args) => {
-                fetchTimestamps.push(Date.now());
-                return originalFetch(...args);
+                const [peer, key] = args;
+                const inFlightKey = `${String(peer)}/${Buffer.from(key).toString("base64")}`;
+                const call: FetchCallRecord = {
+                    ts: Date.now(),
+                    peer: String(peer),
+                    startedWhileIdenticalCallInFlight: (inFlightCountByPeerAndKey.get(inFlightKey) ?? 0) > 0
+                };
+                fetchCalls.push(call);
+                inFlightCountByPeerAndKey.set(inFlightKey, (inFlightCountByPeerAndKey.get(inFlightKey) ?? 0) + 1);
+                const settle = (outcome: "ok" | "error") => {
+                    call.outcome = outcome;
+                    const remaining = (inFlightCountByPeerAndKey.get(inFlightKey) ?? 1) - 1;
+                    if (remaining <= 0) inFlightCountByPeerAndKey.delete(inFlightKey);
+                    else inFlightCountByPeerAndKey.set(inFlightKey, remaining);
+                };
+                const fetchPromise = originalFetch(...args);
+                fetchPromise.then(
+                    () => settle("ok"),
+                    () => settle("error")
+                );
+                return fetchPromise;
             });
             onTestFinished(() => fetchSpy.mockRestore());
 
@@ -135,7 +165,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             updatingStateChanges = 0;
             updateEvents = 0;
             pubsubMessagesReceived = 0;
-            fetchTimestamps.length = 0;
+            fetchCalls.length = 0;
             const cpuBefore = process.cpuUsage();
             const bwBefore = await readServingDaemonBandwidth();
             const windowStart = Date.now();
@@ -175,7 +205,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             const windowUpdatingStateChanges = updatingStateChanges;
             const windowUpdateEvents = updateEvents;
             const windowPubsubMessagesReceived = pubsubMessagesReceived;
-            const windowFetchTimestamps = fetchTimestamps.filter((ts) => ts <= windowEndedAt);
+            const windowFetchCalls = fetchCalls.filter((call) => call.ts <= windowEndedAt);
 
             // Give the mid-window delivery until the end of the run to land, then require it. The
             // losing timer is cleared so no 120s handle outlives the run.
@@ -195,14 +225,32 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             // ---- report ----
             const windowSec = (windowEndedAt - windowStart) / 1000;
             const fetchBuckets = new Map<number, number>();
-            for (const ts of windowFetchTimestamps) {
-                const second = Math.floor((ts - windowStart) / 1000);
+            for (const call of windowFetchCalls) {
+                const second = Math.floor((call.ts - windowStart) / 1000);
                 fetchBuckets.set(second, (fetchBuckets.get(second) ?? 0) + 1);
             }
             const busiestFetchSeconds = [...fetchBuckets.entries()]
                 .sort((a, b) => b[1] - a[1])
                 .slice(0, 5)
                 .map(([second, count]) => ({ atSecond: second, fetchOps: count }));
+
+            // Per-peer breakdown (issues #329/#330): a hub peer subscribed to many topics is
+            // asked once per name per ttl window, twice while the #329 duplicate exists, so the
+            // top rows are where the before/after difference of those fixes shows up.
+            const perPeer = new Map<string, { started: number; ok: number; errorOrAborted: number; pending: number; duplicateConcurrent: number }>();
+            for (const call of windowFetchCalls) {
+                const row = perPeer.get(call.peer) ?? { started: 0, ok: 0, errorOrAborted: 0, pending: 0, duplicateConcurrent: 0 };
+                row.started++;
+                if (call.outcome === "ok") row.ok++;
+                else if (call.outcome === "error") row.errorOrAborted++;
+                else row.pending++;
+                if (call.startedWhileIdenticalCallInFlight) row.duplicateConcurrent++;
+                perPeer.set(call.peer, row);
+            }
+            const busiestPeers = [...perPeer.entries()]
+                .sort((a, b) => b[1].started - a[1].started)
+                .slice(0, 5)
+                .map(([peer, row]) => ({ peer, ...row }));
 
             const report = {
                 communities: COMMUNITY_COUNT,
@@ -215,10 +263,15 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 },
                 updateEvents: windowUpdateEvents,
                 ipnsNetworkFetchOps: {
-                    total: windowFetchTimestamps.length,
-                    perSecond: Number((windowFetchTimestamps.length / windowSec).toFixed(2)),
+                    total: windowFetchCalls.length,
+                    perSecond: Number((windowFetchCalls.length / windowSec).toFixed(2)),
+                    completed: windowFetchCalls.filter((call) => call.outcome === "ok").length,
+                    erroredOrAborted: windowFetchCalls.filter((call) => call.outcome === "error").length,
+                    stillPendingAtReport: windowFetchCalls.filter((call) => call.outcome === undefined).length,
+                    duplicateConcurrentSamePeerSameKey: windowFetchCalls.filter((call) => call.startedWhileIdenticalCallInFlight).length,
                     maxInOneSecond: busiestFetchSeconds[0]?.fetchOps ?? 0,
-                    busiestSeconds: busiestFetchSeconds
+                    busiestSeconds: busiestFetchSeconds,
+                    busiestPeers
                 },
                 pubsubMessagesReceived: windowPubsubMessagesReceived,
                 clientCpu: {

--- a/test/node-and-browser/community/update-loop-event-driven.test.ts
+++ b/test/node-and-browser/community/update-loop-event-driven.test.ts
@@ -443,26 +443,28 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
             ).to.be.greaterThan(0);
         }, 120_000);
 
-        // The safety net exists for pushes that never arrived — mesh partition, a record
-        // published while we had no subscribers, a regression in the arrival plumbing. A tick
-        // that goes through the routing-layer cache gate cannot see any of those: the cache
-        // still holds the OLD record well inside its ttl (kubo 0.43 publishes 300s, jittered
-        // down to no less than 225s, issue #307), so the tick does zero network work, serves
-        // the stale cid, and parks again — a missed push then strands the community for the
-        // record's whole ttl instead of the bound the safety net promises (master's 1s poll was
-        // bounded by ~ttl too, but re-checked every second). Timer-fired (non-arrival) wakes
-        // must therefore resolve with nocache: true — bounded by the 30s revalidation floor, so
-        // a sub-30s updateInterval (every test pkc defaults to 500ms) does not force the
-        // network on each tick: unfloored, the loop's duty cycle flips from parked-in-
-        // waiting-retry to mid-fetching-ipns, which tripped the browser CI legs' state-sampling
-        // assertions. The promised staleness bound is max(updateInterval, floor). Oracle: spy
-        // the resolver's name.resolve options rather than racing a real 225s staleness window.
+        // The DEGRADED-mode safety-net pin (issues #311/#330). The safety net exists for pushes
+        // that never arrived — mesh partition, a record published while we had no subscribers, a
+        // regression in the arrival plumbing. A tick that rides the routing-layer cache gate's
+        // ttl check alone cannot see any of those: the cache still holds the OLD record well
+        // inside its ttl (kubo 0.43 publishes 300s, jittered down to no less than 225s, issue
+        // #307), so a missed push would strand the community for the record's whole ttl instead
+        // of the bound the safety net promises. Timer-fired (non-arrival) wakes whose push
+        // channel is NOT healthy must therefore resolve with nocache: true — bounded by the 30s
+        // revalidation floor, so a sub-30s updateInterval (every test pkc defaults to 500ms)
+        // does not force the network on each tick. The promised degraded staleness bound is
+        // max(updateInterval, floor). Since issue #330 an armed tick first consults the
+        // push-channel watchdog and skips the force while the channel is healthy (the
+        // zero-fetch steady state is pinned by update-loop-fetch-quiescence.test.ts), so this
+        // test zeroes the client's watchdog window: every tick then sees an unhealthy channel
+        // and the pre-#330 forcing contract must hold unchanged. Oracle: spy the resolver's
+        // name.resolve options rather than racing a real 225s staleness window.
         //
         // Node only for the same load reason as the park test above: with the floor, observing
         // two forced revalidations keeps an updating community live for ~65s on the shared
         // browser page, and the logic has no browser-specific component.
         itSkipIfBrowser(
-            "safety-net ticks revalidate against the network at the floored cadence instead of riding the cache",
+            "safety-net ticks with an unhealthy push channel revalidate at the floored cadence instead of riding the cache",
             async () => {
                 const SAFETY_NET_INTERVAL_MS = 3000;
                 // Own pkc: the suite instance runs the production 60s interval, which would park
@@ -471,6 +473,11 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 const libp2pJsClient = shortIntervalPkc.clients.libp2pJsClients[Object.keys(shortIntervalPkc.clients.libp2pJsClients)[0]];
                 const clientFunctions = libp2pJsClient.heliaWithKuboRpcClientFunctions;
                 const originalResolve = clientFunctions.name.resolve.bind(clientFunctions.name);
+                // Zero watchdog = the push channel never counts as healthy, forcing the degraded
+                // mode this test pins. The helia client is SHARED across pkc instances
+                // (test-util keys it by a constant), so the original window is restored below.
+                const originalWatchdogMs = libp2pJsClient._ipnsPushChannel.watchdogMs;
+                libp2pJsClient._ipnsPushChannel.watchdogMs = 0;
                 const safetyNetResolveNocacheValues: (boolean | undefined)[] = [];
                 let recording = false;
                 try {
@@ -505,7 +512,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
 
                     expect(
                         forcedCount(),
-                        "timer-fired safety-net ticks must force nocache revalidations at the floored cadence — through the cache gate the net can never observe a push it missed, leaving the community stale for the record's whole ttl instead of max(updateInterval, floor)"
+                        "timer-fired safety-net ticks with an UNHEALTHY push channel must force nocache revalidations at the floored cadence — the ttl-only cache gate can never observe a push it missed, leaving the community stale for the record's whole ttl instead of max(updateInterval, floor) (issues #311/#330 degraded mode)"
                     ).to.be.greaterThanOrEqual(2);
                     expect(
                         safetyNetResolveNocacheValues.filter((nocache) => nocache !== true).length,
@@ -513,6 +520,7 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                     ).to.be.greaterThanOrEqual(2);
                 } finally {
                     clientFunctions.name.resolve = originalResolve;
+                    libp2pJsClient._ipnsPushChannel.watchdogMs = originalWatchdogMs;
                     await shortIntervalPkc.destroy();
                 }
             },
@@ -584,6 +592,13 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
         // failure (which costs another whole jittered park) does not turn a slow CI runner into a
         // red build; the test still fails outright if the safety net never fires at all, which is
         // the property being pinned.
+        //
+        // Since issue #330 the client's push-channel watchdog is zeroed for the test's duration:
+        // with a healthy watchdog the tick would serve the cache past the 10s ttl, and on the
+        // gossip-warmed branch that cache already holds the newer record — delivery would then
+        // prove the push channel, not the safety net this test exists to exercise. An unhealthy
+        // channel restores the pre-#330 revalidation guarantee on both branches (the
+        // healthy-channel steady state is pinned by update-loop-fetch-quiescence.test.ts).
         itSkipIfBrowser(
             "a newer record still arrives via the safety-net poll when the push wake is lost",
             async () => {
@@ -594,6 +609,9 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                 };
                 let managerInternals: ManagerArrivalInternals | undefined;
                 let syncSpy: { mockRestore(): void } | undefined;
+                const libp2pJsClient = pkc.clients.libp2pJsClients[Object.keys(pkc.clients.libp2pJsClients)[0]];
+                const originalWatchdogMs = libp2pJsClient._ipnsPushChannel.watchdogMs;
+                libp2pJsClient._ipnsPushChannel.watchdogMs = 0; // see the comment above the test
                 try {
                     const staticRecord = await publishCommunityRecordWithExtraProp({ ttl: SHORT_RECORD_TTL });
                     staticRecordsToCleanUp.push(staticRecord);
@@ -657,8 +675,10 @@ getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"]
                     ).to.equal(true);
                 } finally {
                     // Hand the loop its real sync back so the community resubscribes on its next
-                    // iteration and afterAll's stop() unsubscribes a consistent set.
+                    // iteration and afterAll's stop() unsubscribes a consistent set. The shared
+                    // client gets its real watchdog window back for the same reason.
                     syncSpy?.mockRestore();
+                    libp2pJsClient._ipnsPushChannel.watchdogMs = originalWatchdogMs;
                 }
             },
             240_000

--- a/test/node-and-browser/community/update-loop-fetch-quiescence.test.ts
+++ b/test/node-and-browser/community/update-loop-fetch-quiescence.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, afterAll, expect, onTestFinished, vi } from "vitest";
+import { getAvailablePKCConfigsToTestAgainst, publishCommunityRecordWithExtraProp } from "../../../dist/node/test/test-util.js";
+import { signCommunity } from "../../../dist/node/signer/signatures.js";
+import { timestamp } from "../../../dist/node/util.js";
+
+import type { PKC as PKCType } from "../../../dist/node/pkc/pkc.js";
+import type { RemoteCommunity } from "../../../dist/node/community/remote-community.js";
+
+// Issue #330 steady-state pin for the UPDATE LOOP (the resolver-level behavior is pinned in
+// test/node/helia/ipns-push-channel-watchdog.unit.test.ts): an updating community whose push
+// channel is healthy (the serving daemon is subscribed to the record topic and a valid record
+// arrived within the watchdog window) must make ZERO IPNS fetch-protocol calls at steady state.
+//
+// This pins the update-loop half of the fix specifically: the issue #308/#311 loop forces
+// `nocache: true` on every safety-net-timer wake (bounded by the 30s revalidation floor),
+// which bypasses the resolver's cache gate entirely — so serving from cache while healthy is
+// not enough; the loop must also skip the forced revalidation while the watchdog can vouch for
+// the channel. Written red-first: with only the resolver half in place this test still failed
+// (one forced fetch per 30s floor window per name, the exact per-minute churn the PR #331
+// 5-minute benchmark measured as unchanged).
+//
+// The measurement window spans the 30s forced-revalidation floor so a forced tick MUST land
+// inside it if the loop still forces; the ending publish proves the quiescent loop is parked on
+// a live push channel rather than dead.
+//
+// libp2p-js only: the kubo-RPC resolver polls kubo's own namesys (always nocache) by design.
+getAvailablePKCConfigsToTestAgainst({ includeOnlyTheseTests: ["remote-libp2pjs"] }).map((config) => {
+    describe(`update loop fetch quiescence (issue #330) - ${config.name}`, () => {
+        let pkc: PKCType;
+        const communitiesToStop: RemoteCommunity[] = [];
+        const staticRecordsToCleanUp: Awaited<ReturnType<typeof publishCommunityRecordWithExtraProp>>[] = [];
+
+        afterAll(async () => {
+            for (const community of communitiesToStop.splice(0)) {
+                try {
+                    await community.stop();
+                } catch {
+                    // already stopped
+                }
+            }
+            for (const staticRecord of staticRecordsToCleanUp.splice(0)) await staticRecord.ipnsObj.pkc.destroy();
+            if (pkc) await pkc.destroy();
+        });
+
+        const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+        // Above the forced-revalidation floor divided by anything: with a 1s safety-net period
+        // the loop ticks ~26-52 times in the window, and the 30s floor guarantees at least one
+        // of those ticks is ARMED to force the network — if the loop still forces at all.
+        const UPDATE_INTERVAL_MS = 1_000;
+        const QUIESCENCE_WINDOW_MS = 35_000;
+        const DELIVERY_BUDGET_MS = 25_000;
+
+        it("safety-net ticks make zero IPNS fetch calls while the push channel is healthy (issue #330)", async () => {
+            pkc = await config.pkcInstancePromise({ pkcOptions: { updateInterval: UPDATE_INTERVAL_MS } });
+            const staticRecord = await publishCommunityRecordWithExtraProp();
+            staticRecordsToCleanUp.push(staticRecord);
+
+            const community = (await pkc.createCommunity({ address: staticRecord.ipnsObj.signer.address })) as RemoteCommunity;
+            communitiesToStop.push(community);
+            const firstUpdate = new Promise<void>((resolve) => community.once("update", () => resolve()));
+            await community.update();
+            await firstUpdate;
+
+            // Let the first-update tail (warmup dials, retried fetches) settle before measuring.
+            await sleep(3_000);
+
+            const libp2pJsClient = pkc.clients.libp2pJsClients[Object.keys(pkc.clients.libp2pJsClients)[0]];
+            const fetchService = libp2pJsClient._helia.libp2p.services.fetch;
+            let fetchCalls = 0;
+            const originalFetch = fetchService.fetch.bind(fetchService);
+            const fetchSpy = vi.spyOn(fetchService, "fetch").mockImplementation((...args) => {
+                fetchCalls++;
+                return originalFetch(...args);
+            });
+            onTestFinished(() => fetchSpy.mockRestore());
+
+            await sleep(QUIESCENCE_WINDOW_MS);
+            expect(
+                fetchCalls,
+                `an updating community with a healthy push channel must make ZERO IPNS fetch calls at steady state; ` +
+                    `${fetchCalls} calls in ${QUIESCENCE_WINDOW_MS}ms means the safety-net tick still forces a network revalidation ` +
+                    `the watchdog should have vouched away (issue #330)`
+            ).to.equal(0);
+
+            // The quiescent loop must still be ALIVE: a newer record published now must arrive
+            // over the push channel well inside the delivery budget (same bound as
+            // update-freshness.test.ts), proving the zero above is a parked loop on a healthy
+            // channel, not a dead one.
+            const nextRecord = JSON.parse(JSON.stringify(staticRecord.communityRecord)) as typeof staticRecord.communityRecord;
+            nextRecord.updatedAt = Math.max(community.updatedAt! + 1, timestamp());
+            nextRecord.signature = await signCommunity({ community: nextRecord, signer: staticRecord.ipnsObj.signer });
+            let onUpdate!: () => void;
+            let timer: ReturnType<typeof setTimeout> | undefined;
+            const delivered = new Promise<boolean>((resolve) => {
+                onUpdate = () => {
+                    if (community.updatedAt === nextRecord.updatedAt) resolve(true);
+                };
+                community.on("update", onUpdate);
+                timer = setTimeout(() => resolve(false), DELIVERY_BUDGET_MS);
+            });
+            await staticRecord.ipnsObj.publishToIpns(JSON.stringify(nextRecord));
+            const deliveredInTime = await delivered;
+            clearTimeout(timer);
+            community.removeListener("update", onUpdate);
+            expect(deliveredInTime, "the quiescent loop must still consume a pushed newer record within the delivery budget").to.equal(
+                true
+            );
+        }, 180_000);
+    });
+});

--- a/test/node/helia/ipns-fetch-call-count.unit.test.ts
+++ b/test/node/helia/ipns-fetch-call-count.unit.test.ts
@@ -1,0 +1,272 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createLibp2pJsClientOrUseExistingOne } from "../../../dist/node/helia/helia-for-pkc.js";
+import { directFetchIpnsRecordFromProviders } from "../../../dist/node/helia/util.js";
+import { MockHttpRouter } from "../../../dist/node/runtime/node/test/mock-http-router.js";
+import { ipnsNameToIpnsOverPubsubTopic, pubsubTopicToDhtKeyCid } from "../../../dist/node/util.js";
+import Logger from "../../../dist/node/logger.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { generateKeyPair } from "@libp2p/crypto/keys";
+import { peerIdFromPrivateKey } from "@libp2p/peer-id";
+import { createIPNSRecord, marshalIPNSRecord, multihashToIPNSRoutingKey } from "ipns";
+import { ipnsValidator } from "ipns/validator";
+import { CID } from "multiformats/cid";
+import { equals as uint8ArrayEquals } from "uint8arrays/equals";
+import type { Libp2pJsClient } from "../../../dist/node/helia/libp2pjsClient.js";
+
+// Fetch-protocol call-count pins for the IPNS resolution path (issues #329 and #330). The #329
+// evidence measured 389 libp2p/fetch calls to ONE peer in ~3.5 minutes at 64 updating
+// communities; this suite counts every /ipns/ fetch lookup a record host actually answers (the
+// network-traffic oracle, same pattern as the issue #301 suite) and pins the per-race and
+// per-ttl-window bounds so the volume cannot silently regress toward those numbers:
+//
+// - one direct-fetch race asks each DISTINCT peer exactly once (subscriber branch + provider
+//   branch, no branch may ask a peer twice on its own);
+// - a peer that is BOTH a topic subscriber and a router provider is asked at most twice per race
+//   (today exactly twice, one call per branch; the issue #329 fix must tighten this to once);
+// - the resolve path pays exactly ONE fetch round per name per record-ttl window and ZERO inside
+//   the window (the cache gate, issues #301/#307). Per issue #330 this once-per-window
+//   revalidation itself deviates from the ipns-pubsub-router spec (fetch-on-join + gossip, no
+//   timer refetch), so the spec-alignment fix should tighten the post-expiry bound from one round
+//   to zero for a subscribed name with a healthy mesh.
+//
+// Like the direct-fetch suite, this stands up a STARTED node-under-test plus real second libp2p
+// nodes that listen on /ws and serve the record over the fetch protocol. Client-side libp2p only
+// and config-independent (never touches Kubo or the PKC RPC server), so it runs once under
+// non-RPC via describeSkipIfRpc.
+describeSkipIfRpc("IPNS fetch-protocol call counts (issues #329/#330)", () => {
+    const log = Logger("pkc-js:test:fetch-call-count");
+    const clientsToStop: Libp2pJsClient[] = [];
+    const startedRouters: MockHttpRouter[] = [];
+    let keyCounter = 0;
+
+    afterEach(async () => {
+        while (clientsToStop.length) await clientsToStop.pop()!.heliaWithKuboRpcClientFunctions.stop();
+        while (startedRouters.length) {
+            try {
+                await startedRouters.pop()!.destroy();
+            } catch {
+                // already destroyed
+            }
+        }
+    });
+
+    const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+    const createNode = async (opts: { listen?: boolean; routers?: string[] } = {}): Promise<Libp2pJsClient> => {
+        const client = (await createLibp2pJsClientOrUseExistingOne({
+            key: `fetch-call-count-${keyCounter++}`,
+            httpRoutersOptions: opts.routers ?? ["http://localhost:1"],
+            libp2pOptions: {
+                ...(opts.listen ? { addresses: { listen: ["/ip4/127.0.0.1/tcp/0/ws"] } } : {})
+            },
+            heliaOptions: {}
+        })) as Libp2pJsClient;
+        clientsToStop.push(client);
+        return client;
+    };
+
+    const VALUE_CID = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+
+    // A fresh IPNS name + a validly-signed record for it. `ttlMs` becomes the record's ttl field,
+    // which is what the resolve path's cache gate serves within (jittered to 0.75-1.0x, issue
+    // #307), so the ttl-window test can use a short window instead of the 60s production default.
+    const makeRecord = async (opts: { ttlMs?: number } = {}) => {
+        const privateKey = await generateKeyPair("Ed25519");
+        const ipnsPeerId = peerIdFromPrivateKey(privateKey);
+        const record = await createIPNSRecord(
+            privateKey,
+            CID.parse(VALUE_CID),
+            1n,
+            60 * 60 * 1000,
+            opts.ttlMs !== undefined ? { ttlNs: BigInt(opts.ttlMs) * 1_000_000n } : undefined
+        );
+        const marshalled = marshalIPNSRecord(record);
+        const routingKey = multihashToIPNSRoutingKey(ipnsPeerId.toMultihash());
+        const topic = ipnsNameToIpnsOverPubsubTopic(ipnsPeerId.toString());
+        const cid = pubsubTopicToDhtKeyCid(topic).toString();
+        return { privateKey, ipnsPeerId, record, marshalled, routingKey, topic, cid };
+    };
+
+    // A real libp2p node that listens on /ws and serves `recordToServe` for `routingKey` over the
+    // fetch protocol, counting every /ipns/ lookup it answers for that key. `lookupDelayMs` holds
+    // each answer open so that when a race asks the same peer from two branches, BOTH calls are
+    // demonstrably in flight before the first one returns and the counter deterministically sees
+    // both (a fast answer would let the winner check skip the second branch and hide the issue
+    // #329 duplicate). If `subscribeTopic` is given, the node also subscribes to that topic (via
+    // the GossipSub PROTOTYPE method, bypassing helia-for-pkc's instance-level subscribe
+    // monkey-patch so it does not kick off its own warmup).
+    const startPublisherNode = async (args: {
+        routingKey: Uint8Array;
+        recordToServe: Uint8Array;
+        subscribeTopic?: string;
+        lookupDelayMs?: number;
+    }) => {
+        const client = await createNode({ listen: true });
+        let fetchCount = 0;
+        const fetchService = client._helia.libp2p.services.fetch;
+        fetchService.unregisterLookupFunction("/ipns/");
+        fetchService.registerLookupFunction("/ipns/", async (key: Uint8Array) => {
+            if (!uint8ArrayEquals(key, args.routingKey)) return undefined;
+            fetchCount++;
+            if (args.lookupDelayMs) await sleep(args.lookupDelayMs);
+            return args.recordToServe;
+        });
+
+        if (args.subscribeTopic) {
+            const pubsub = client._helia.libp2p.services.pubsub;
+            Object.getPrototypeOf(pubsub).subscribe.call(pubsub, args.subscribeTopic);
+        }
+
+        const wsAddrs = client._helia.libp2p
+            .getMultiaddrs()
+            .map((m) => m.toString())
+            .filter((a) => a.includes("/ws"))
+            .map((a) => a.replace(/\/p2p\/[^/]+$/, ""));
+        expect(wsAddrs.length, "publisher must expose at least one ws multiaddr").to.be.greaterThan(0);
+        return {
+            client,
+            ID: client._helia.libp2p.peerId.toString(),
+            Addrs: wsAddrs,
+            getFetchCount: () => fetchCount
+        };
+    };
+
+    const startRouterServing = async (cid: string, provider: { ID: string; Addrs: string[] }): Promise<string> => {
+        const router = new MockHttpRouter();
+        await router.start();
+        startedRouters.push(router);
+        router.addProviderForTesting(cid, provider);
+        return router.url;
+    };
+
+    // Dial `publisher` from `node` and wait until gossipsub reports it as a subscriber of `topic`,
+    // so the subscriber branch of a subsequent race deterministically includes it.
+    const connectUntilSeenAsSubscriber = async (
+        node: Libp2pJsClient,
+        publisher: { client: Libp2pJsClient; ID: string },
+        topic: string
+    ): Promise<void> => {
+        await node._helia.libp2p.dial(publisher.client._helia.libp2p.getMultiaddrs());
+        const deadline = Date.now() + 15_000;
+        while (
+            Date.now() < deadline &&
+            !node._helia.libp2p.services.pubsub.getSubscribers(topic).some((p) => p.toString() === publisher.ID)
+        )
+            await sleep(100);
+        expect(
+            node._helia.libp2p.services.pubsub.getSubscribers(topic).map((p) => p.toString()),
+            "publisher must be a known subscriber before the race starts"
+        ).to.include(publisher.ID);
+    };
+
+    // Both branches of one race, distinct peers: the subscriber branch asks the subscribed peer,
+    // the provider branch asks the router-discovered peer, and neither branch may ask its peer
+    // more than once. The slow lookups keep both calls in flight until both are counted, so a
+    // regression that re-asks a peer within one branch (e.g. the issue #215 addr-merge retry
+    // re-fetching a peer that already answered) shows up as a count above 1.
+    it("one direct-fetch race asks each distinct peer exactly once", async () => {
+        const { routingKey, marshalled, topic, cid } = await makeRecord();
+        const subscriberPeer = await startPublisherNode({ routingKey, recordToServe: marshalled, subscribeTopic: topic, lookupDelayMs: 1_000 });
+        const providerPeer = await startPublisherNode({ routingKey, recordToServe: marshalled, lookupDelayMs: 1_000 });
+        const routerUrl = await startRouterServing(cid, providerPeer);
+        const node = await createNode({ routers: [routerUrl] });
+        await connectUntilSeenAsSubscriber(node, subscriberPeer, topic);
+
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers: 4,
+            validate: ipnsValidator,
+            log
+        });
+
+        expect(result, "the race must produce a record").to.not.equal(undefined);
+        expect(subscriberPeer.getFetchCount(), "the subscriber peer must be asked exactly once").to.equal(1);
+        expect(providerPeer.getFetchCount(), "the provider peer must be asked exactly once").to.equal(1);
+    });
+
+    // Issue #329: a peer that is BOTH a topic subscriber and a router provider is asked by both
+    // branches concurrently, so today it deterministically answers TWO lookups per race (the slow
+    // lookup guarantees the second call starts before the first returns, exactly like a real peer
+    // answering under network latency; the loser is then aborted). The at-most-2 bound is the
+    // "not going overboard" guard: a third call would mean a NEW duplication source on top of
+    // #329. The #329 fix (per-race attempted-peer set) must tighten this assertion to exactly 1.
+    it("a peer that is both subscriber and provider is asked at most twice per race (issue #329)", async () => {
+        const { routingKey, marshalled, topic, cid } = await makeRecord();
+        const publisher = await startPublisherNode({ routingKey, recordToServe: marshalled, subscribeTopic: topic, lookupDelayMs: 1_000 });
+        const routerUrl = await startRouterServing(cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+        await connectUntilSeenAsSubscriber(node, publisher, topic);
+
+        const result = await directFetchIpnsRecordFromProviders({
+            helia: node._helia,
+            pubsubTopic: topic,
+            routingKey,
+            maxPeers: 4,
+            validate: ipnsValidator,
+            log
+        });
+
+        expect(result, "the race must produce a record").to.not.equal(undefined);
+        expect(publisher.getFetchCount(), "the dual-role peer must be asked at least once").to.be.greaterThanOrEqual(1);
+        expect(
+            publisher.getFetchCount(),
+            "a peer that is both subscriber and provider must not be asked more than once per branch (issue #329 caps this at 2; its fix tightens it to 1)"
+        ).to.be.lessThanOrEqual(2);
+    });
+
+    // Drain name.resolve's async generator and return the final yielded value (an /ipfs/ path).
+    const resolveOnce = async (node: Libp2pJsClient, ipnsName: string): Promise<string> => {
+        const values: string[] = [];
+        for await (const value of node.heliaWithKuboRpcClientFunctions.name.resolve(ipnsName)) values.push(value);
+        expect(values.length, "name.resolve must yield at least one value").to.be.greaterThan(0);
+        return values[values.length - 1];
+    };
+
+    // The steady-state cost pin for the update loop (issue #330). With the cache gate in place
+    // (issues #301/#307), a name's network cost must be exactly one fetch round per record-ttl
+    // window: the cold resolve fetches once, every resolve inside the (jittered, 0.75-1.0x ttl)
+    // window is a local cache read with ZERO fetch calls, the first resolve after expiry
+    // revalidates with exactly ONE more call, and the revalidation opens a fresh window. This is
+    // what bounds N updating communities to N fetch rounds per ttl window instead of the
+    // per-second churn of issue #301 or the 389-calls-per-peer volume of issue #329. Per issue
+    // #330 the post-expiry revalidation itself deviates from the ipns-pubsub-router spec
+    // (fetch-on-join + gossip, no timer refetch): the spec-alignment fix should tighten the
+    // post-expiry delta below from 1 to 0 for a subscribed name with a healthy mesh.
+    it("the resolve path pays exactly one fetch round per name per ttl window (issue #330)", async () => {
+        const TTL_MS = 5_000; // effective serve window after jitter: 3750-5000ms
+        const { routingKey, marshalled, topic, cid, ipnsPeerId } = await makeRecord({ ttlMs: TTL_MS });
+        const publisher = await startPublisherNode({ routingKey, recordToServe: marshalled });
+        const routerUrl = await startRouterServing(cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+
+        // Cold resolve: one fetch round against the single provider = exactly one call.
+        const firstValue = await resolveOnce(node, ipnsPeerId.toString());
+        const windowOpenedAt = Date.now();
+        expect(firstValue, "the cold resolve must return the served record's value").to.contain(VALUE_CID);
+        expect(publisher.getFetchCount(), "the cold resolve must fetch exactly once from the only peer").to.equal(1);
+        expect(node._helia.libp2p.services.pubsub.getTopics(), "resolve must leave the ipns topic subscribed").to.include(topic);
+
+        // Inside the serve window (well under the 3750ms jitter floor): local reads, zero calls.
+        for (let i = 0; i < 3; i++) {
+            const repeatValue = await resolveOnce(node, ipnsPeerId.toString());
+            expect(repeatValue).to.contain(VALUE_CID);
+        }
+        expect(publisher.getFetchCount(), "resolves inside the ttl window must make zero fetch calls").to.equal(1);
+        expect(Date.now() - windowOpenedAt, "the in-window resolves must have finished under the jitter floor").to.be.lessThan(3_000);
+
+        // Past the full (unjittered) ttl the window has expired for every jitter factor: the next
+        // resolve must revalidate with exactly one more call, and only one.
+        await sleep(windowOpenedAt + TTL_MS + 600 - Date.now());
+        const postExpiryValue = await resolveOnce(node, ipnsPeerId.toString());
+        expect(postExpiryValue).to.contain(VALUE_CID);
+        expect(publisher.getFetchCount(), "the first resolve after ttl expiry must revalidate with exactly one fetch call").to.equal(2);
+
+        // The revalidation stamped a fresh window (even though the refetched bytes were identical
+        // to the cache): the next resolve is a local read again.
+        const reopenedValue = await resolveOnce(node, ipnsPeerId.toString());
+        expect(reopenedValue).to.contain(VALUE_CID);
+        expect(publisher.getFetchCount(), "a resolve right after the revalidation must make zero fetch calls").to.equal(2);
+    });
+});

--- a/test/node/helia/ipns-fetch-call-count.unit.test.ts
+++ b/test/node/helia/ipns-fetch-call-count.unit.test.ts
@@ -24,10 +24,10 @@ import type { Libp2pJsClient } from "../../../dist/node/helia/libp2pjsClient.js"
 // - a peer that is BOTH a topic subscriber and a router provider is asked at most twice per race
 //   (today exactly twice, one call per branch; the issue #329 fix must tighten this to once);
 // - the resolve path pays exactly ONE fetch round per name per record-ttl window and ZERO inside
-//   the window (the cache gate, issues #301/#307). Per issue #330 this once-per-window
-//   revalidation itself deviates from the ipns-pubsub-router spec (fetch-on-join + gossip, no
-//   timer refetch), so the spec-alignment fix should tighten the post-expiry bound from one round
-//   to zero for a subscribed name with a healthy mesh.
+//   the window (the cache gate, issues #301/#307) — for a name whose push channel is UNHEALTHY
+//   (here: a topic with zero subscribers). This is the issue #330 DEGRADED mode: a name with a
+//   healthy push channel (subscribers + a record arrival within the watchdog window) skips even
+//   the once-per-window revalidation and pays zero, pinned by the push-channel-watchdog suite.
 //
 // Like the direct-fetch suite, this stands up a STARTED node-under-test plus real second libp2p
 // nodes that listen on /ws and serve the record over the fetch protocol. Client-side libp2p only
@@ -224,17 +224,17 @@ describeSkipIfRpc("IPNS fetch-protocol call counts (issues #329/#330)", () => {
         return values[values.length - 1];
     };
 
-    // The steady-state cost pin for the update loop (issue #330). With the cache gate in place
-    // (issues #301/#307), a name's network cost must be exactly one fetch round per record-ttl
-    // window: the cold resolve fetches once, every resolve inside the (jittered, 0.75-1.0x ttl)
-    // window is a local cache read with ZERO fetch calls, the first resolve after expiry
-    // revalidates with exactly ONE more call, and the revalidation opens a fresh window. This is
-    // what bounds N updating communities to N fetch rounds per ttl window instead of the
-    // per-second churn of issue #301 or the 389-calls-per-peer volume of issue #329. Per issue
-    // #330 the post-expiry revalidation itself deviates from the ipns-pubsub-router spec
-    // (fetch-on-join + gossip, no timer refetch): the spec-alignment fix should tighten the
-    // post-expiry delta below from 1 to 0 for a subscribed name with a healthy mesh.
-    it("the resolve path pays exactly one fetch round per name per ttl window (issue #330)", async () => {
+    // The DEGRADED-mode cost pin for the update loop (issue #330). The publisher here is
+    // provider-only (never a topic subscriber), so the node's push channel for the name is
+    // unhealthy by construction and the issue #330 watchdog gate falls back to exact ttl
+    // semantics (issues #301/#307): the cold resolve fetches once, every resolve inside the
+    // (jittered, 0.75-1.0x ttl) window is a local cache read with ZERO fetch calls, the first
+    // resolve after expiry revalidates with exactly ONE more call, and the revalidation opens a
+    // fresh window. This bounds N updating communities to N fetch rounds per ttl window even
+    // when no push channel exists — instead of the per-second churn of issue #301 or the
+    // 389-calls-per-peer volume of issue #329. The HEALTHY-channel counterpart (zero fetch
+    // rounds past ttl expiry) is pinned by the push-channel-watchdog suite.
+    it("the resolve path pays exactly one fetch round per name per ttl window when the push channel is down (issue #330)", async () => {
         const TTL_MS = 5_000; // effective serve window after jitter: 3750-5000ms
         const { routingKey, marshalled, topic, cid, ipnsPeerId } = await makeRecord({ ttlMs: TTL_MS });
         const publisher = await startPublisherNode({ routingKey, recordToServe: marshalled });

--- a/test/node/helia/ipns-push-channel-watchdog.unit.test.ts
+++ b/test/node/helia/ipns-push-channel-watchdog.unit.test.ts
@@ -53,7 +53,9 @@ describeSkipIfRpc("IPNS push-channel watchdog (issue #330)", () => {
 
     const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-    type ClientWithPushChannel = Libp2pJsClient & { _ipnsPushChannel?: { watchdogMs: number } };
+    type ClientWithPushChannel = Libp2pJsClient & {
+        _ipnsPushChannel?: { watchdogMs: number; lastValidRecordArrivalMs?: Map<string, number> };
+    };
 
     const createNode = async (opts: { listen?: boolean; routers?: string[] } = {}): Promise<Libp2pJsClient> => {
         const client = (await createLibp2pJsClientOrUseExistingOne({
@@ -277,6 +279,70 @@ describeSkipIfRpc("IPNS push-channel watchdog (issue #330)", () => {
             publisher.getFetchCount(),
             "silence past the watchdog must trip the resolver back to network revalidation"
         ).to.be.greaterThan(fetchesAfterFirstResolve);
+    });
+
+    // The stale-replay guard. `ipnsValidator` checks the signature and EOL but NOT sequence
+    // order, so without a sequence comparison a signature-valid but strictly OLDER (still
+    // unexpired) record gossiped on the topic would count as a heartbeat — a lagging peer
+    // rebroadcasting its stale best record, or an adversarial subscriber replaying an old one,
+    // could then hold the watchdog open indefinitely (up to the replayed record's validity,
+    // hours) and keep the node serving its cache without ever running the revalidation that
+    // would find the newer record. A heartbeat must attest that the channel delivers records at
+    // least as new as the best we hold: a replay of an older sequence must neither advance the
+    // arrival stamp nor extend cache serving past the window the last CURRENT arrival opened.
+    it("a replayed older record does not extend the watchdog window (issue #330 stale-replay guard)", async () => {
+        const TTL_MS = 2_000;
+        const WATCHDOG_MS = 4_000;
+        const identity = await makeIpnsIdentity();
+        const olderRecord = await makeMarshalledRecord(identity, VALUE_CID_SEQ1, 1n, TTL_MS);
+        const currentRecord = await makeMarshalledRecord(identity, VALUE_CID_SEQ2, 2n, TTL_MS);
+        const publisher = await startPublisherNode({
+            routingKey: identity.routingKey,
+            recordToServe: currentRecord,
+            topic: identity.topic
+        });
+        const routerUrl = await startRouterServing(identity.cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+        const pushChannel = (node as ClientWithPushChannel)._ipnsPushChannel;
+        if (pushChannel) pushChannel.watchdogMs = WATCHDOG_MS;
+
+        const firstValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+        expect(firstValue).to.contain(VALUE_CID_SEQ2);
+        await waitForMutualSubscription(node, publisher.client, identity.topic);
+
+        // Join-time activity (the fetch-on-join fast path, the direct fetch's cache write) may
+        // stamp arrivals for a second or so after the mesh forms; let it settle, then anchor on
+        // the ACTUAL last stamp so the window edges below are exact rather than estimated.
+        await sleep(1_500);
+        const anchorMs = pushChannel?.lastValidRecordArrivalMs?.get(identity.topic);
+        expect(anchorMs, "the cold resolve must have stamped a push-channel arrival").to.be.a("number");
+        const fetchesBeforeReplay = publisher.getFetchCount();
+        expect(fetchesBeforeReplay).to.be.greaterThan(0);
+
+        // Replay the OLDER (signature-valid, unexpired) record ~1s before the anchored window
+        // would close.
+        await sleep(anchorMs! + WATCHDOG_MS - 1_000 - Date.now());
+        const { receivedAtMs } = await publishUntilReceived({
+            from: publisher.client,
+            to: node,
+            topic: identity.topic,
+            data: olderRecord
+        });
+
+        // Past the window the last current arrival opened, but still well inside the window the
+        // replay would have opened if it (wrongly) counted as a heartbeat: the resolver must
+        // treat the channel as unhealthy and revalidate over the network. The selector still
+        // protects the cache itself, so the resolved value stays the current record's.
+        await sleep(anchorMs! + WATCHDOG_MS + 600 - Date.now());
+        expect(Date.now() - receivedAtMs, "the post-window resolve must land inside a replay-extended window").to.be.lessThan(
+            WATCHDOG_MS - 1_000
+        );
+        const postReplayValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+        expect(postReplayValue).to.contain(VALUE_CID_SEQ2);
+        expect(
+            publisher.getFetchCount(),
+            "a replayed older record must NOT keep the push channel healthy: the resolver must revalidate once the last CURRENT arrival falls out of the watchdog window (issue #330 stale-replay guard)"
+        ).to.be.greaterThan(fetchesBeforeReplay);
     });
 
     // Fetch-on-join pin: the fix RELIES on @helia/ipns's PubSubIPNSRouting subscription-change

--- a/test/node/helia/ipns-push-channel-watchdog.unit.test.ts
+++ b/test/node/helia/ipns-push-channel-watchdog.unit.test.ts
@@ -25,12 +25,11 @@ import type { PeerId } from "@libp2p/interface";
 // no subscribers, the resolver falls back to the exact per-ttl revalidation behavior of issues
 // #301/#307 (pinned by the fetch-call-count suite's zero-subscriber test).
 //
-// Expected on master (before the fix): the two "(issue #330)" watchdog tests FAIL, because the
-// cache gate serves only within the record ttl and refetches after it regardless of push-channel
-// health. The fetch-on-join pin and the nocache contract test pass before and after.
-//
-// The `_ipnsPushChannel` accesses are through a widening cast so this suite still RUNS (red)
-// against a dist built from master, where the field does not exist yet.
+// Written red-first: before the fix the two watchdog tests failed (the cache gate served only
+// within the record ttl and refetched after it regardless of push-channel health), while the
+// fetch-on-join pin and the nocache contract test passed before and after. The
+// `_ipnsPushChannel` accesses go through a widening cast so the suite also runs (red) against a
+// pre-fix dist where the field does not exist.
 //
 // Like the direct-fetch suite, this stands up a STARTED node-under-test plus real second libp2p
 // nodes that listen on /ws and serve records over the fetch protocol. Client-side libp2p only

--- a/test/node/helia/ipns-push-channel-watchdog.unit.test.ts
+++ b/test/node/helia/ipns-push-channel-watchdog.unit.test.ts
@@ -1,0 +1,360 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { createLibp2pJsClientOrUseExistingOne } from "../../../dist/node/helia/helia-for-pkc.js";
+import { MockHttpRouter } from "../../../dist/node/runtime/node/test/mock-http-router.js";
+import { ipnsNameToIpnsOverPubsubTopic, pubsubTopicToDhtKeyCid } from "../../../dist/node/util.js";
+import { describeSkipIfRpc } from "../../helpers/conditional-tests.js";
+import { generateKeyPair } from "@libp2p/crypto/keys";
+import { peerIdFromPrivateKey } from "@libp2p/peer-id";
+import { createIPNSRecord, marshalIPNSRecord, multihashToIPNSRoutingKey, unmarshalIPNSRecord } from "ipns";
+import { pubSubIPNSRouting } from "@helia/ipns";
+import { CID } from "multiformats/cid";
+import { equals as uint8ArrayEquals } from "uint8arrays/equals";
+import type { Libp2pJsClient } from "../../../dist/node/helia/libp2pjsClient.js";
+import type { IpnsPubsubLocalStore } from "../../../dist/node/helia/util.js";
+import type { PeerId } from "@libp2p/interface";
+
+// Push-channel watchdog suite for issue #330: the ipns-pubsub-router spec's model is
+// fetch-on-join plus gossip (kubo's go-libp2p-pubsub-router rebroadcasts its best record on the
+// topic every 10 minutes and never refetches on a timer), so a subscribed name whose push
+// channel is demonstrably alive must serve resolves from the cached record indefinitely, not
+// revalidate over the network once per record-ttl window. "Demonstrably alive" is the watchdog:
+// the topic has at least one gossipsub subscriber AND a signature-valid record arrived within
+// the watchdog window (default 15 min = 1.5x kubo's rebroadcast interval), where an arrival is
+// a gossiped record (identical rebroadcast bytes included), a record accepted into the local
+// store from any path, or a validated network fetch. When the watchdog trips or the topic has
+// no subscribers, the resolver falls back to the exact per-ttl revalidation behavior of issues
+// #301/#307 (pinned by the fetch-call-count suite's zero-subscriber test).
+//
+// Expected on master (before the fix): the two "(issue #330)" watchdog tests FAIL, because the
+// cache gate serves only within the record ttl and refetches after it regardless of push-channel
+// health. The fetch-on-join pin and the nocache contract test pass before and after.
+//
+// The `_ipnsPushChannel` accesses are through a widening cast so this suite still RUNS (red)
+// against a dist built from master, where the field does not exist yet.
+//
+// Like the direct-fetch suite, this stands up a STARTED node-under-test plus real second libp2p
+// nodes that listen on /ws and serve records over the fetch protocol. Client-side libp2p only
+// and config-independent (never touches Kubo or the PKC RPC server), so it runs once under
+// non-RPC via describeSkipIfRpc.
+describeSkipIfRpc("IPNS push-channel watchdog (issue #330)", () => {
+    const clientsToStop: Libp2pJsClient[] = [];
+    const startedRouters: MockHttpRouter[] = [];
+    let keyCounter = 0;
+
+    afterEach(async () => {
+        while (clientsToStop.length) await clientsToStop.pop()!.heliaWithKuboRpcClientFunctions.stop();
+        while (startedRouters.length) {
+            try {
+                await startedRouters.pop()!.destroy();
+            } catch {
+                // already destroyed
+            }
+        }
+    });
+
+    const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+    type ClientWithPushChannel = Libp2pJsClient & { _ipnsPushChannel?: { watchdogMs: number } };
+
+    const createNode = async (opts: { listen?: boolean; routers?: string[] } = {}): Promise<Libp2pJsClient> => {
+        const client = (await createLibp2pJsClientOrUseExistingOne({
+            key: `push-watchdog-${keyCounter++}`,
+            httpRoutersOptions: opts.routers ?? ["http://localhost:1"],
+            libp2pOptions: {
+                ...(opts.listen ? { addresses: { listen: ["/ip4/127.0.0.1/tcp/0/ws"] } } : {})
+            },
+            heliaOptions: {}
+        })) as Libp2pJsClient;
+        clientsToStop.push(client);
+        return client;
+    };
+
+    // Two distinct valid CIDv1 values so a resolve/cache read identifies WHICH record it came from.
+    const VALUE_CID_SEQ1 = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi";
+    const VALUE_CID_SEQ2 = "bafybeihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku";
+
+    const makeIpnsIdentity = async () => {
+        const privateKey = await generateKeyPair("Ed25519");
+        const ipnsPeerId = peerIdFromPrivateKey(privateKey);
+        const routingKey = multihashToIPNSRoutingKey(ipnsPeerId.toMultihash());
+        const topic = ipnsNameToIpnsOverPubsubTopic(ipnsPeerId.toString());
+        const cid = pubsubTopicToDhtKeyCid(topic).toString();
+        return { privateKey, ipnsPeerId, routingKey, topic, cid };
+    };
+    type IpnsIdentity = Awaited<ReturnType<typeof makeIpnsIdentity>>;
+
+    // `ttlMs` becomes the record's ttl field: the window the pre-#330 cache gate serves within
+    // (jittered to 0.75-1.0x), kept SHORT here so the suite can outlive it in seconds.
+    const makeMarshalledRecord = async (identity: IpnsIdentity, valueCid: string, sequence: bigint, ttlMs: number): Promise<Uint8Array> =>
+        marshalIPNSRecord(
+            await createIPNSRecord(identity.privateKey, CID.parse(valueCid), sequence, 60 * 60 * 1000, {
+                ttlNs: BigInt(ttlMs) * 1_000_000n
+            })
+        );
+
+    // A real libp2p node that listens on /ws, serves `recordToServe` for `routingKey` over the
+    // fetch protocol (counting every lookup it answers for that key), and subscribes to the topic
+    // (via the GossipSub PROTOTYPE method, bypassing helia-for-pkc's instance-level subscribe
+    // monkey-patch so it does not kick off its own warmup) so it can gossip on it and count as a
+    // topic subscriber for the node-under-test's push-channel health check.
+    const startPublisherNode = async (args: { routingKey: Uint8Array; recordToServe: Uint8Array; topic: string }) => {
+        const client = await createNode({ listen: true });
+        let fetchCount = 0;
+        const fetchService = client._helia.libp2p.services.fetch;
+        fetchService.unregisterLookupFunction("/ipns/");
+        fetchService.registerLookupFunction("/ipns/", async (key: Uint8Array) => {
+            if (!uint8ArrayEquals(key, args.routingKey)) return undefined;
+            fetchCount++;
+            return args.recordToServe;
+        });
+        const pubsub = client._helia.libp2p.services.pubsub;
+        Object.getPrototypeOf(pubsub).subscribe.call(pubsub, args.topic);
+
+        const wsAddrs = client._helia.libp2p
+            .getMultiaddrs()
+            .map((m) => m.toString())
+            .filter((a) => a.includes("/ws"))
+            .map((a) => a.replace(/\/p2p\/[^/]+$/, ""));
+        expect(wsAddrs.length, "publisher must expose at least one ws multiaddr").to.be.greaterThan(0);
+        return {
+            client,
+            ID: client._helia.libp2p.peerId.toString(),
+            Addrs: wsAddrs,
+            getFetchCount: () => fetchCount
+        };
+    };
+
+    const startRouterServing = async (cid: string, provider: { ID: string; Addrs: string[] }): Promise<string> => {
+        const router = new MockHttpRouter();
+        await router.start();
+        startedRouters.push(router);
+        router.addProviderForTesting(cid, provider);
+        return router.url;
+    };
+
+    // Drain name.resolve's async generator and return the final yielded value (an /ipfs/ path).
+    const resolveOnce = async (node: Libp2pJsClient, ipnsName: string, options?: { nocache?: boolean }): Promise<string> => {
+        const values: string[] = [];
+        for await (const value of node.heliaWithKuboRpcClientFunctions.name.resolve(ipnsName, options)) values.push(value);
+        expect(values.length, "name.resolve must yield at least one value").to.be.greaterThan(0);
+        return values[values.length - 1];
+    };
+
+    // Wait until both nodes report each other as subscribers of `topic` — the health check's
+    // "topic has subscribers" half, and the precondition for gossip delivery.
+    const waitForMutualSubscription = async (a: Libp2pJsClient, b: Libp2pJsClient, topic: string): Promise<void> => {
+        const seenBy = (viewer: Libp2pJsClient, target: Libp2pJsClient) =>
+            viewer._helia.libp2p.services.pubsub.getSubscribers(topic).some((p) => p.toString() === target._helia.libp2p.peerId.toString());
+        const deadline = Date.now() + 15_000;
+        while (Date.now() < deadline && !(seenBy(a, b) && seenBy(b, a))) await sleep(200);
+        expect(seenBy(a, b) && seenBy(b, a), "both nodes must see each other as topic subscribers").to.equal(true);
+    };
+
+    // Publish `data` on `topic` from `from` until `to`'s pubsub layer actually RECEIVES a message
+    // on that topic, and return the receive time. Guards the rebroadcast tests against failing
+    // for the wrong reason: after this returns the record demonstrably arrived at the node.
+    const publishUntilReceived = async (args: {
+        from: Libp2pJsClient;
+        to: Libp2pJsClient;
+        topic: string;
+        data: Uint8Array;
+    }): Promise<{ receivedAtMs: number }> => {
+        let receivedAtMs: number | undefined;
+        const onMessage = (evt: CustomEvent<{ topic: string }>) => {
+            if (evt.detail.topic === args.topic && receivedAtMs === undefined) receivedAtMs = Date.now();
+        };
+        args.to._helia.libp2p.services.pubsub.addEventListener("message", onMessage);
+        try {
+            const deadline = Date.now() + 20_000;
+            while (receivedAtMs === undefined && Date.now() < deadline) {
+                try {
+                    await args.from._helia.libp2p.services.pubsub.publish(args.topic, args.data);
+                } catch {
+                    // gossipsub throws NoPeersSubscribedToTopic until the mesh forms; keep retrying
+                }
+                await sleep(300);
+            }
+            expect(receivedAtMs, "the gossiped record must arrive at the node's pubsub layer").to.not.equal(undefined);
+            return { receivedAtMs: receivedAtMs! };
+        } finally {
+            args.to._helia.libp2p.services.pubsub.removeEventListener("message", onMessage);
+        }
+    };
+
+    // Read the record cached at the node's pubsub routing layer (same structural-access pattern
+    // src uses: a fresh PubSubIPNSRouting wraps the SAME helia datastore).
+    const readCachedRecordSequence = async (node: Libp2pJsClient, routingKey: Uint8Array): Promise<bigint | undefined> => {
+        const localStore = (pubSubIPNSRouting(node._helia) as unknown as { localStore: IpnsPubsubLocalStore }).localStore;
+        if (!(await localStore.has(routingKey))) return undefined;
+        const { record } = await localStore.get(routingKey);
+        return unmarshalIPNSRecord(record).sequence;
+    };
+
+    // The core issue #330 pin. A name whose topic HAS a live subscriber and whose record was
+    // network-confirmed moments ago (the cold resolve's own fetch opens the trust window) must
+    // keep serving resolves from cache PAST the record's ttl with zero further fetch calls.
+    // Before the fix the cache gate refetches on the first resolve after ttl expiry no matter
+    // what, which at N communities is the once-per-name-per-minute churn measured in the PR #331
+    // baseline (138 calls per 5 minutes at 32 names).
+    it("serves resolves past the record ttl with zero fetch calls while the push channel is healthy (issue #330)", async () => {
+        const TTL_MS = 3_000;
+        const identity = await makeIpnsIdentity();
+        const record = await makeMarshalledRecord(identity, VALUE_CID_SEQ1, 1n, TTL_MS);
+        const publisher = await startPublisherNode({ routingKey: identity.routingKey, recordToServe: record, topic: identity.topic });
+        const routerUrl = await startRouterServing(identity.cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+
+        const firstValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+        expect(firstValue).to.contain(VALUE_CID_SEQ1);
+        const ttlExpiredAt = Date.now() + TTL_MS;
+        await waitForMutualSubscription(node, publisher.client, identity.topic);
+        const fetchesAfterFirstResolve = publisher.getFetchCount();
+        expect(fetchesAfterFirstResolve, "the cold resolve must fetch over the network").to.be.greaterThan(0);
+
+        // Well past the FULL (unjittered) ttl: expired for every jitter factor.
+        await sleep(ttlExpiredAt + 600 - Date.now());
+        for (let i = 0; i < 2; i++) {
+            const value = await resolveOnce(node, identity.ipnsPeerId.toString());
+            expect(value).to.contain(VALUE_CID_SEQ1);
+        }
+        expect(
+            publisher.getFetchCount(),
+            "a resolve past the record ttl must NOT refetch while the topic has a subscriber and a record was confirmed within the watchdog window (issue #330)"
+        ).to.equal(fetchesAfterFirstResolve);
+    });
+
+    // The watchdog's two edges, with the window shrunk to seconds via the test hook. An
+    // identical-bytes rebroadcast (what kubo's go-libp2p-pubsub-router emits every 10 minutes
+    // when nothing changes) must EXTEND the serve window: the router's #handleRecord returns
+    // before localStore.put on identical bytes, so this pins that arrivals are stamped from the
+    // raw (validated) gossip message, not only from accepted-newer cache writes. And once the
+    // channel then stays silent past the watchdog, the resolver must fall back to network
+    // revalidation instead of serving a possibly-stale record forever.
+    it("an identical-bytes rebroadcast keeps serving from cache past the watchdog, and silence past it revalidates (issue #330)", async () => {
+        const TTL_MS = 2_000;
+        const WATCHDOG_MS = 4_000;
+        const identity = await makeIpnsIdentity();
+        const record = await makeMarshalledRecord(identity, VALUE_CID_SEQ1, 1n, TTL_MS);
+        const publisher = await startPublisherNode({ routingKey: identity.routingKey, recordToServe: record, topic: identity.topic });
+        const routerUrl = await startRouterServing(identity.cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+        const pushChannel = (node as ClientWithPushChannel)._ipnsPushChannel;
+        if (pushChannel) pushChannel.watchdogMs = WATCHDOG_MS;
+
+        const firstValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+        expect(firstValue).to.contain(VALUE_CID_SEQ1);
+        const networkConfirmedAtMs = Date.now();
+        await waitForMutualSubscription(node, publisher.client, identity.topic);
+        const fetchesAfterFirstResolve = publisher.getFetchCount();
+
+        // Rebroadcast the SAME bytes ~1s before the fetch-opened watchdog window would close.
+        await sleep(networkConfirmedAtMs + WATCHDOG_MS - 1_000 - Date.now());
+        const { receivedAtMs } = await publishUntilReceived({
+            from: publisher.client,
+            to: node,
+            topic: identity.topic,
+            data: record
+        });
+
+        // Past the watchdog as measured from the cold resolve's fetch, past the ttl many times
+        // over, but within the watchdog as measured from the rebroadcast: must still be served
+        // from cache. (The margin keeps this point at least 1s clear of the rebroadcast-opened
+        // window's close even on a slow runner.)
+        await sleep(networkConfirmedAtMs + WATCHDOG_MS + 1_000 - Date.now());
+        expect(Date.now() - receivedAtMs).to.be.lessThan(WATCHDOG_MS - 1_000);
+        const rebroadcastValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+        expect(rebroadcastValue).to.contain(VALUE_CID_SEQ1);
+        expect(
+            publisher.getFetchCount(),
+            "an identical-bytes rebroadcast must keep the push channel healthy: no refetch while the last arrival is inside the watchdog window (issue #330)"
+        ).to.equal(fetchesAfterFirstResolve);
+
+        // Now let the channel go silent past the watchdog: the resolver must revalidate over the
+        // network again (and only then), restoring the pre-#330 ttl behavior as the fallback.
+        await sleep(receivedAtMs + WATCHDOG_MS + 600 - Date.now());
+        const postSilenceValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+        expect(postSilenceValue).to.contain(VALUE_CID_SEQ1);
+        expect(
+            publisher.getFetchCount(),
+            "silence past the watchdog must trip the resolver back to network revalidation"
+        ).to.be.greaterThan(fetchesAfterFirstResolve);
+    });
+
+    // Fetch-on-join pin: the fix RELIES on @helia/ipns's PubSubIPNSRouting subscription-change
+    // fast path (started since the helia 7 migration) to sync state on topology change, per the
+    // ipns-pubsub-router spec ("whenever A notices any node that has connected to it and
+    // subscribed to t it should run the Fetch protocol"). A peer that joins the topic holding a
+    // NEWER record must have that record fetched from it and cached WITHOUT any resolve call. If
+    // an @helia/ipns upgrade breaks this path, serving from cache while the mesh looks alive
+    // would ride topology changes blind, so this must go red.
+    it("a newer record held by a peer that joins the topic is fetched and cached without a resolve (issue #330)", async () => {
+        const TTL_MS = 60_000;
+        const identity = await makeIpnsIdentity();
+        const seq1 = await makeMarshalledRecord(identity, VALUE_CID_SEQ1, 1n, TTL_MS);
+        const publisher = await startPublisherNode({ routingKey: identity.routingKey, recordToServe: seq1, topic: identity.topic });
+        const routerUrl = await startRouterServing(identity.cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+
+        const firstValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+        expect(firstValue).to.contain(VALUE_CID_SEQ1);
+        expect(await readCachedRecordSequence(node, identity.routingKey), "the cold resolve must cache seq 1").to.equal(1n);
+
+        // The joiner: a fresh node whose OWN pubsub-router localStore (the default "/ipns/" fetch
+        // lookup registered inside helia-for-pkc serves from it) is seeded with the seq 2 record.
+        const joiner = await createNode({ listen: true });
+        const joinerLocalStore = (pubSubIPNSRouting(joiner._helia) as unknown as { localStore: IpnsPubsubLocalStore }).localStore;
+        const seq2 = await makeMarshalledRecord(identity, VALUE_CID_SEQ2, 2n, TTL_MS);
+        await joinerLocalStore.put(identity.routingKey, seq2);
+
+        // Connect first and wait until the node's pubsub router has the joiner in its fetch
+        // topology (fetchPeers fills on identify discovering the fetch protocol) — the
+        // subscription-change handler ignores peers it cannot fetch from, so subscribing before
+        // this point would race identify and flake.
+        await node._helia.libp2p.dial(joiner._helia.libp2p.getMultiaddrs());
+        const nodePubsubRouter = node._heliaIpnsRouter.routers.find((r) => String(r) === "PubSubRouting()") as unknown as
+            | { fetchPeers: { has(peerId: PeerId): boolean } }
+            | undefined;
+        expect(nodePubsubRouter, "the node's IPNS facade must carry the pubsub router").to.not.equal(undefined);
+        const joinerPeerId = joiner._helia.libp2p.peerId;
+        const topologyDeadline = Date.now() + 10_000;
+        while (Date.now() < topologyDeadline && !nodePubsubRouter!.fetchPeers.has(joinerPeerId)) await sleep(100);
+        expect(nodePubsubRouter!.fetchPeers.has(joinerPeerId), "the joiner must enter the fetch topology").to.equal(true);
+
+        // NOW the joiner subscribes: the node's router must react to the subscription-change by
+        // fetching the record from it and caching the newer seq 2 — no resolve call involved.
+        const joinerPubsub = joiner._helia.libp2p.services.pubsub;
+        Object.getPrototypeOf(joinerPubsub).subscribe.call(joinerPubsub, identity.topic);
+
+        const cacheDeadline = Date.now() + 10_000;
+        let cachedSequence = await readCachedRecordSequence(node, identity.routingKey);
+        while (Date.now() < cacheDeadline && cachedSequence !== 2n) {
+            await sleep(200);
+            cachedSequence = await readCachedRecordSequence(node, identity.routingKey);
+        }
+        expect(cachedSequence, "the record held by the joining peer must be fetched and cached (fetch-on-join)").to.equal(2n);
+    });
+
+    // Contract pin, green before and after the fix: nocache: true must bypass cache serving even
+    // while the push channel is healthy, mirroring kubo semantics — explicit refresh always hits
+    // the network.
+    it("nocache: true still fetches over the network while the push channel is healthy", async () => {
+        const TTL_MS = 60_000;
+        const identity = await makeIpnsIdentity();
+        const record = await makeMarshalledRecord(identity, VALUE_CID_SEQ1, 1n, TTL_MS);
+        const publisher = await startPublisherNode({ routingKey: identity.routingKey, recordToServe: record, topic: identity.topic });
+        const routerUrl = await startRouterServing(identity.cid, publisher);
+        const node = await createNode({ routers: [routerUrl] });
+
+        const firstValue = await resolveOnce(node, identity.ipnsPeerId.toString());
+        expect(firstValue).to.contain(VALUE_CID_SEQ1);
+        await waitForMutualSubscription(node, publisher.client, identity.topic);
+        const fetchesAfterFirstResolve = publisher.getFetchCount();
+
+        const nocacheValue = await resolveOnce(node, identity.ipnsPeerId.toString(), { nocache: true });
+        expect(nocacheValue).to.contain(VALUE_CID_SEQ1);
+        expect(
+            publisher.getFetchCount(),
+            "nocache: true must bypass the healthy-channel cache serving and fetch over the network"
+        ).to.be.greaterThan(fetchesAfterFirstResolve);
+    });
+});


### PR DESCRIPTION
Closes #330.

## What

Aligns libp2p-js IPNS resolution with the [ipns-pubsub-router spec](https://specs.ipfs.tech/ipns/ipns-pubsub-router/): a subscribed name whose push channel is demonstrably alive is kept current by gossip pushes, kubo's 10-minute rebroadcast, and fetch-on-join, so the client stops revalidating it over the network on a timer. Steady-state fetch-protocol volume at 32 updating communities drops from **138 calls per 5 minutes to 0**, with push delivery latency unchanged.

## The watchdog

A topic's push channel is **healthy** while it has at least one gossipsub subscriber AND a signature-valid, sequence-current record for it arrived within the watchdog window (`IPNS_PUSH_CHANNEL_WATCHDOG_MS` = 15 min, 1.5x kubo's go-libp2p-pubsub-router rebroadcast interval, so one missed rebroadcast is tolerated). Arrivals are stamped from three sources:

- raw gossip messages validated against the topic's routing key, **including identical-bytes rebroadcasts** (the router's `#handleRecord` returns before `localStore.put` on identical bytes, so the kubo heartbeat that proves liveness is invisible to the put wrap);
- accepted-newer `localStore.put` writes from any path;
- validated network fetches (direct fast path and fallback `router.get()`), so a fresh confirmation of any kind opens the trust window.

Every heartbeat goes through one sequence-guarded stamping path (CodeRabbit's review caught this): `ipnsValidator` checks signature and EOL but not sequence order, so without the guard a signature-valid but strictly older (unexpired) record replayed on the topic would hold the watchdog open indefinitely, up to the replayed record's validity instead of the 15-minute worst case below. An arrival with a sequence below the highest seen from any validated source is ignored; identical rebroadcasts (equal sequence) still extend the window.

Two halves consume it:

1. **Resolver** (`name.resolve` cache gate, `readFreshCachedIpnsRecordFromPubsubLocalStore`): while healthy, the cached record serves past its ttl (signature/EOL still checked on every read). While unhealthy, the exact per-ttl revalidation of #301/#307 applies unchanged, and the network path re-warms the mesh.
2. **Update loop** (`community-client-manager`): the #308/#311 safety-net tick forced `nocache: true` (bounded by the 30s floor) because "the cache gate cannot observe a push that never arrived" — but the watchdog observes exactly that condition, so an armed tick now consults the anchor topic's health (new `isIpnsPushChannelHealthy` probe) and rides the cache while healthy. A skipped tick does not reset the floor, so the first armed tick after a channel degrades forces the network again. Without this half the resolver-side change measured **no improvement at all** (139 vs 138 calls per 5 min): every forced tick bypassed the gate.

Fetch-on-join needed no new code: @helia/ipns's `PubSubIPNSRouting` subscription-change fast path (live since the helia 7 migration) fetches from every fetch-capable peer joining a registered topic; it is now pinned by a test since the design leans on it.

**Staleness trade, stated explicitly:** a mesh that looks alive (subscribers present) but silently delivers nothing moves from ~one record ttl (60s) to the watchdog window (15 min) worst-case; in practice kubo's own 10-minute rebroadcast heals it earlier, a visibly-empty mesh falls back to ttl semantics immediately, and `nocache: true` still always fetches. Kubo-RPC and gateway resolvers are untouched.

## Benchmark (32 communities, 5-minute window, 60s record ttl)

| metric | before | after |
|---|---|---|
| IPNS fetch-protocol calls | **138** (all to the one serving peer, ~1 per name per minute) | **0** |
| newer-record delivery latency | 22ms | 22ms |
| pubsub messages received | 161 | 161 |
| client CPU (% of window) | 0.65-0.76% | 0.41% |

`node test/run-test-config.js --pkc-config remote-libp2pjs test/benchmarks/update-loop-bench.test.ts` (window now defaults to 5 minutes; the bench also gained per-peer, completed-vs-aborted, and duplicate-concurrent-call metrics for #329/#330).

## Tests (all red-first where behavior changed)

- `test/node/helia/ipns-push-channel-watchdog.unit.test.ts` — healthy channel serves past ttl with zero fetch calls; an identical-bytes rebroadcast extends the window past the watchdog while silence past it revalidates; fetch-on-join delivers a newer record with no resolve involved; nocache still bypasses. The two watchdog tests were observed red on unmodified src. A stale-replay guard test (a replayed older record must not extend the watchdog window) pins the sequence guard, also observed red before that guard existed.
- `test/node-and-browser/community/update-loop-fetch-quiescence.test.ts` — an updating community makes zero fetch calls across a 35s window spanning the 30s forced-revalidation floor, then still consumes a pushed newer record inside the 25s delivery budget. Observed red (exactly 1 forced fetch) with only the resolver half in place.
- `test/node/helia/ipns-fetch-call-count.unit.test.ts` — per-race call-count pins: one call per distinct peer; at most two for a dual subscriber+provider peer (the #329 duplicate, deterministically two today, its fix tightens to one); the zero-subscriber degraded mode keeps exactly one fetch round per name per ttl window.
- `test/node-and-browser/community/update-loop-event-driven.test.ts` — the two #311 safety-net pins asserted that timer-fired ticks ALWAYS force nocache (the first CI run failed on exactly that, correctly). They now zero the shared client's watchdog window for their duration, pinning the forcing contract as the unhealthy-channel degraded mode where it still applies unchanged.
- Regression-ran green: all 14 `test/node/helia` suites (111 tests), `helia-ipns-resolve-equivalence`, `update-freshness` on both transports (push latency bound intact), the full event-driven loop suite (15 tests), and the libp2pjs clients-state suite.

## Related

- #330 (the spec discrepancy this fixes; kubo behavior verified in its comments)
- #329 (duplicate subscriber+provider fetch per race, still open, orthogonal to this change)
- #301/#307/#308/#311 (the cache gate and event-driven loop this builds on)

