### PR TITLE
fix(community): flush the pre-purge update cid even when the purge lands mid-publish-cycle (#336)

### DIFF
--- a/src/runtime/node/community/local-community/cleanup.ts
+++ b/src/runtime/node/community/local-community/cleanup.ts
@@ -95,13 +95,26 @@ export const UNPIN_GRACE_PERIOD_MS = 30 * 60 * 1000;
 // direction. WeakMap so a stopped community's tracking dies with it.
 const cidsToUnpinFirstSeenAtMsByCommunity = new WeakMap<LocalCommunity, Map<string, number>>();
 
-// Communities with a purge whose unpin flush has not completed yet. A purge can land mid-sync, after
-// that cycle's unpinStaleCids already ran and before its block.rm drains _blocksToRm, so "is
-// _blocksToRm non-empty right now" alone can miss the flush; this survives until a flush pass
-// actually drains the unpin queue.
-const communitiesWithPendingPurgeFlush = new WeakSet<LocalCommunity>();
+// Communities with a purge whose unpin flush has not completed yet, mapped to when the purge
+// landed. A purge can land mid-sync, after that cycle's unpinStaleCids already ran and before its
+// block.rm drains _blocksToRm, so "is _blocksToRm non-empty right now" alone can miss the flush;
+// this survives until a flush pass drains the unpin queue in a cycle whose record was generated
+// AFTER the purge landed. The timestamp matters (issue #336): a purge landing while a publish
+// cycle is in flight can reference the record that cycle is publishing, whose cid only enters
+// _cidsToUnPin when the NEXT cycle supersedes it — so a flush in the in-flight cycle must not
+// disarm the flag, or that record sits pinned under the issue #305 grace with nothing left to
+// flush it.
+const communitiesWithPendingPurgeFlush = new WeakMap<LocalCommunity, number>();
 
-export async function unpinStaleCids(community: LocalCommunity, options: { bypassGracePeriod?: boolean } = {}) {
+export async function unpinStaleCids(
+    community: LocalCommunity,
+    // cycleStartedAtMs: when the calling publish cycle snapshotted the DB for the record it
+    // published. Used to decide whether a completed purge flush may disarm the pending-purge
+    // flag: only a cycle whose record was generated after the purge landed can have every
+    // pre-purge cid in its queue (issue #336). Callers outside the publish cycle leave it unset,
+    // which conservatively keeps the flag armed for the next publish cycle.
+    options: { bypassGracePeriod?: boolean; cycleStartedAtMs?: number } = {}
+) {
     const log = Logger("pkc-js:local-community:sync:unpinStaleCids");
 
     if (community._cidsToUnPin.size > 0) {
@@ -122,7 +135,8 @@ export async function unpinStaleCids(community: LocalCommunity, options: { bypas
         // outranks the reader grace of issue #305. The purged cids also could not wait anyway: their
         // blocks get force-removed right after this function in updateCommunityIpnsIfNeeded, and kubo
         // refuses to rm a pinned block.
-        const flushGraceForPendingPurge = communitiesWithPendingPurgeFlush.has(community) || community._blocksToRm.length > 0;
+        const purgeFlushArmedAtMs = communitiesWithPendingPurgeFlush.get(community);
+        const flushGraceForPendingPurge = purgeFlushArmedAtMs !== undefined || community._blocksToRm.length > 0;
         const cidsToUnpinNow = Array.from(community._cidsToUnPin.values()).filter(
             (cid) =>
                 options.bypassGracePeriod || flushGraceForPendingPurge || now - (firstSeenAtMs.get(cid) ?? now) >= UNPIN_GRACE_PERIOD_MS
@@ -160,8 +174,17 @@ export async function unpinStaleCids(community: LocalCommunity, options: { bypas
         );
 
         // In flush mode every queued cid was eligible, so an empty queue means the flush completed; a
-        // non-empty one means some pin.rm failed and the flag must survive for the next pass.
-        if (flushGraceForPendingPurge && community._cidsToUnPin.size === 0) communitiesWithPendingPurgeFlush.delete(community);
+        // non-empty one means some pin.rm failed and the flag must survive for the next pass. A
+        // completed flush disarms the flag only when this cycle's record was generated after the
+        // purge landed: a purge landing mid-cycle can reference the record the in-flight cycle
+        // published, which enters the queue only when the next cycle supersedes it, so that next
+        // cycle must still flush (issue #336).
+        if (flushGraceForPendingPurge && community._cidsToUnPin.size === 0) {
+            const cycleObservedPurge =
+                purgeFlushArmedAtMs === undefined ||
+                (options.cycleStartedAtMs !== undefined && options.cycleStartedAtMs > purgeFlushArmedAtMs);
+            if (cycleObservedPurge) communitiesWithPendingPurgeFlush.delete(community);
+        }
 
         log.trace(`unpinned ${sizeBefore - community._cidsToUnPin.size} stale cids from ipfs node for community (${community.address})`);
     }
@@ -359,7 +382,9 @@ export async function addAllCidsUnderPurgedCommentToBeRemoved(
 ) {
     // Every purge flow funnels through here, and the flag makes the next unpinStaleCids pass flush
     // the grace period for the whole queue even when the purge lands mid-sync (see unpinStaleCids).
-    communitiesWithPendingPurgeFlush.add(community);
+    // The timestamp lets the flush tell whether the cycle it ran in generated its record before or
+    // after this purge landed (issue #336).
+    communitiesWithPendingPurgeFlush.set(community, Date.now());
     community._cidsToUnPin.add(purgedCommentAndCommentUpdate.commentTableRow.cid);
     community._blocksToRm.push(purgedCommentAndCommentUpdate.commentTableRow.cid);
     if (typeof purgedCommentAndCommentUpdate.commentUpdateTableRow?.postUpdatesBucket === "number") {

--- a/src/runtime/node/community/local-community/ipns-publishing.ts
+++ b/src/runtime/node/community/local-community/ipns-publishing.ts
@@ -274,7 +274,8 @@ async function validateAndSignCommunityRecord(community: LocalCommunity, build: 
 async function publishCommunityRecordToIpns(
     community: LocalCommunity,
     build: CommunityRecordBuild,
-    newCommunityRecord: CommunityIpfsType
+    newCommunityRecord: CommunityIpfsType,
+    cycleStartedAtMs: number
 ): Promise<void> {
     const { log, newIpns, newModQueue, editIdsToIncludeInNextUpdate } = build;
     const kuboRpcClient = community._clientsManager.getDefaultKuboRpcClient();
@@ -322,7 +323,13 @@ async function publishCommunityRecordToIpns(
     addOldPageCidsToCidsToUnpin(community, community.raw.communityIpfs?.modQueue, newIpns.modQueue).catch((err) =>
         log.error("Failed to add old page cids of community.modQueue to _cidsToUnpin", err)
     );
-    await unpinStaleCids(community);
+    // Queue the record this publish just superseded BEFORE the flush below (issue #336): it was
+    // generated while any comment a pending purge just deleted was still in the DB, so the purge
+    // guarantee extends to it, and queueing it after unpinStaleCids would leave it to sit out the
+    // issue #305 grace period pinned. The new record is already added, pinned and IPNS-published
+    // at this point, so the old cid is safely superseded.
+    if (community.updateCid && community.updateCid !== file.path) community._cidsToUnPin.add(community.updateCid);
+    await unpinStaleCids(community, { cycleStartedAtMs });
     if (community._blocksToRm.length > 0) {
         const removedBlocks = await removeBlocksFromKuboNode({
             ipfsClient: community._clientsManager.getDefaultKuboRpcClient()._client,
@@ -333,7 +340,6 @@ async function publishCommunityRecordToIpns(
         log("Removed blocks", removedBlocks, "from kubo node");
         community._blocksToRm = community._blocksToRm.filter((blockCid) => !removedBlocks.includes(blockCid));
     }
-    if (community.updateCid) community._cidsToUnPin.add(community.updateCid); // add old cid of community to be unpinned
     const configuredPubsubTopic = community.pubsubTopic;
     // A pubsubTopic edit is applied to the instance through the published record, so while the exchange
     // is disabled it would be swallowed: the record omits the topic by design. Land it on the configured
@@ -402,9 +408,13 @@ export async function updateCommunityIpnsIfNeeded(
 
     if (!community._communityUpdateTrigger) return; // No reason to update
 
+    // Stamped before the record's DB snapshot below: a purge that lands after this point may
+    // reference the record this cycle publishes, and unpinStaleCids uses the stamp to keep the
+    // pending-purge flush armed for the next cycle in that case (issue #336).
+    const cycleStartedAtMs = Date.now();
     const build = await calculateNextCommunityRecord(community, commentUpdateRowsToPublishToIpfs, log);
     const newCommunityRecord = await validateAndSignCommunityRecord(community, build);
-    await publishCommunityRecordToIpns(community, build, newCommunityRecord);
+    await publishCommunityRecordToIpns(community, build, newCommunityRecord, cycleStartedAtMs);
 }
 
 export async function syncIpnsWithDb(community: LocalCommunity) {

--- a/test/node/publications/comment-moderation/purge-unpins-pre-purge-update-cid.test.ts
+++ b/test/node/publications/comment-moderation/purge-unpins-pre-purge-update-cid.test.ts
@@ -1,0 +1,165 @@
+import {
+    publishRandomPost,
+    publishWithExpectedResult,
+    resolveWhenConditionIsTrue,
+    createSubWithNoChallenge,
+    mockPKC
+} from "../../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
+import { it, beforeAll, afterAll, expect } from "vitest";
+import type { PKC } from "../../../../dist/node/pkc/pkc.js";
+import type { Comment } from "../../../../dist/node/publications/comment/comment.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+import type { SignerWithPublicKeyAddress } from "../../../../dist/node/signer/index.js";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Deterministic repro of issue #336: a purge that lands while a publish cycle is in flight (after
+// the cycle's name.publish, before it reassigns community.updateCid) reads a STALE
+// community.updateCid in storeCommentModeration, so the cid it queues for the purge flush is the
+// already-superseded record, not the just-published record that still embeds the purged comment.
+// That record's cid only enters _cidsToUnPin at the tail of the NEXT cycle, after that cycle's
+// unpinStaleCids already consumed the pending-purge flag, so on buggy code it sits pinned under
+// the 30-minute unpin grace of issue #305 with nothing left to flush it: the purged content stays
+// pinned on the community's kubo node. This is the exact interleaving behind the purged.test.ts
+// CI failures on run 33748582879.
+//
+// Skipped under RPC: the test wraps the community-side kubo name.publish and reads
+// LocalCommunity internals (_dbHandler, _clientsManager), which is impossible when the community
+// lives in a separate RPC server process.
+describeSkipIfRpc("Purge flush unpins the pre-purge community update cid (issue #336)", () => {
+    let pkc: PKC;
+    let community: LocalCommunity;
+    let moderatorSigner: SignerWithPublicKeyAddress;
+    let post: Comment;
+    let restorePublish: (() => void) | undefined;
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        community = (await createSubWithNoChallenge({}, pkc)) as LocalCommunity;
+        await community.start();
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => typeof community.updatedAt === "number"
+        });
+
+        moderatorSigner = await pkc.createSigner();
+        await community.edit({ roles: { [moderatorSigner.address]: { role: "moderator" } } });
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => community.roles?.[moderatorSigner.address]?.role === "moderator"
+        });
+
+        post = await publishRandomPost({ communityAddress: community.address, pkc });
+        if (!post.cid) throw Error("Published post has no cid");
+
+        // Wait until the live community record embeds the post, so every record published from
+        // here until the purge deletes it references the soon-to-be-purged comment
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () => community.lastPostCid === post.cid
+        });
+    });
+
+    afterAll(async () => {
+        restorePublish?.();
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("A record published moments before the purge is unpinned by the purge flush", async () => {
+        const kuboClient = community._clientsManager.getDefaultKuboRpcClient()._client;
+        const isPinned = async (cid: string): Promise<boolean> => {
+            for await (const pin of kuboClient.pin.ls()) if (pin.cid.toString() === cid) return true;
+            return false;
+        };
+
+        const purgeWhilePublishCycleIsInFlight = async () => {
+            const purgeMod = await pkc.createCommentModeration({
+                communityAddress: community.address,
+                commentCid: post.cid,
+                commentModeration: { reason: "Purge landing mid-publish-cycle (issue #336)", purged: true },
+                signer: moderatorSigner
+            });
+            await publishWithExpectedResult({ publication: purgeMod, expectedChallengeSuccess: true });
+
+            // The purge must have run its storeCommentModeration (DB delete + unpin queueing,
+            // which reads the stale community.updateCid) before the held cycle proceeds to its
+            // unpinStaleCids, otherwise the interleaving under test is not reproduced
+            const deadline = Date.now() + 60_000;
+            while (community._dbHandler.commentExistsInDb(post.cid!)) {
+                if (Date.now() > deadline) throw Error("Timed out waiting for the purge to delete the post from the DB");
+                await sleep(100);
+            }
+        };
+
+        const namesysApi = kuboClient.name;
+        const originalPublish = namesysApi.publish.bind(namesysApi);
+        restorePublish = () => {
+            namesysApi.publish = originalPublish;
+        };
+
+        let raceExercised = false;
+        let recordCidLiveDuringPurge: string | undefined;
+        let purgeDuringHeldCycle: Promise<void> | undefined;
+        const interceptedPublish = async (...args: Parameters<typeof originalPublish>): ReturnType<typeof originalPublish> => {
+            const res = await originalPublish(...args);
+            if (!raceExercised) {
+                raceExercised = true;
+                // The record just published under args[0] was generated while the post was still
+                // in the DB, so it embeds the comment about to be purged. Hold the cycle here
+                // (before its unpinStaleCids and its community.updateCid reassignment) until the
+                // purge has fully landed, mirroring the CI interleaving.
+                recordCidLiveDuringPurge = String(args[0]).replace("/ipfs/", "");
+                purgeDuringHeldCycle = purgeWhilePublishCycleIsInFlight();
+                await purgeDuringHeldCycle;
+            }
+            return res;
+        };
+        namesysApi.publish = interceptedPublish as typeof namesysApi.publish;
+
+        // Make the next sync cycle regenerate the post's CommentUpdate and publish a new record
+        // embedding the post, so the interceptor gets to hold that exact cycle while the purge
+        // runs to completion
+        community._dbHandler.forceUpdateOnAllCommentsWithCid([post.cid!]);
+
+        const raceDeadline = Date.now() + 60_000;
+        while (!raceExercised) {
+            if (Date.now() > raceDeadline) throw Error("Timed out waiting for the sync loop to publish a record with the post");
+            await sleep(100);
+        }
+        await purgeDuringHeldCycle;
+        restorePublish();
+        restorePublish = undefined;
+        if (!recordCidLiveDuringPurge) throw Error("Interceptor did not capture the published record cid");
+
+        expect(
+            await isPinned(recordCidLiveDuringPurge),
+            "the record published right before the purge should be pinned while it is the live record"
+        ).to.be.true;
+
+        // Wait for the record published during the purge to be superseded by a post-purge record:
+        // its superseding cycle is the last one that can flush it
+        await resolveWhenConditionIsTrue({
+            toUpdate: community,
+            predicate: async () =>
+                typeof community.updateCid === "string" &&
+                community.updateCid !== recordCidLiveDuringPurge &&
+                !community._dbHandler.commentExistsInDb(post.cid!)
+        });
+
+        // Fixed code queues the superseded record before the flush and keeps the purge flush
+        // armed across the cycle the purge landed in, so the record is unpinned within a cycle
+        // or two; the bounded retry only absorbs kubo latency. On buggy code the record enters
+        // the queue after the flush already consumed the pending-purge flag and sits under the
+        // 30-minute unpin grace, and nothing else flushes it in this test
+        const unpinDeadline = Date.now() + 30_000;
+        while (await isPinned(recordCidLiveDuringPurge)) {
+            if (Date.now() > unpinDeadline)
+                expect.fail(
+                    `community update cid ${recordCidLiveDuringPurge} embedding the purged comment is still pinned 30s after being superseded post-purge - the purge flush missed it and the unpin grace period is holding the purged content pinned`
+                );
+            await sleep(500);
+        }
+    });
+});


### PR DESCRIPTION
Closes #336.

## Problem

A purge that lands while a publish cycle is in flight (after `name.publish`, before `community.updateCid` is reassigned) reads a stale `community.updateCid` in `storeCommentModeration`, so the cid it queues for the purge flush is the already-superseded record, not the just-published record that still embeds the purged comment. That record's cid only entered `_cidsToUnPin` at the tail of the next cycle, after that cycle's `unpinStaleCids` had already consumed the pending-purge flag, so it sat pinned under the 30-minute unpin grace (#305/#306) with nothing left to flush it: purged content stayed pinned on the community's kubo node.

This is exactly what failed `purged.test.ts` (depth 1 and 2) on the chrome-remote-kubo-rpc job of CI run 33748582879: the purges landed inside the window a slow `block.rm` held open, their target record missed the purge flush, and only an unrelated later purge from a sibling depth suite unpinned it 16 seconds after the assertion. The test has been passing on that cross-suite rescue since the grace period landed.

## Fix

- `publishCommunityRecordToIpns` queues the superseded `updateCid` **before** `unpinStaleCids`, so a pending purge flush covers the last pre-purge record in the cycle that supersedes it. The new record is already added, pinned, and IPNS-published at that point, so the old cid is safely superseded; in non-purge cycles the cid just enters the grace queue one cycle earlier.
- `communitiesWithPendingPurgeFlush` is now a `WeakMap` recording when the purge landed, and a completed flush disarms it only when the cycle's record snapshot postdates the purge (`cycleStartedAtMs`, stamped before `calculateNextCommunityRecord`). A purge landing mid-cycle therefore keeps the flush armed for the next cycle, the first one whose queue can contain every pre-purge record.

## Test

`test/node/publications/comment-moderation/purge-unpins-pre-purge-update-cid.test.ts` reproduces the interleaving deterministically by wrapping the community-side kubo `name.publish` and running the purge to completion while the cycle is held there (same idiom as the #304 repro). Red on the previous code (the record embedding the purged comment is still pinned 30s after being superseded), green with the fix (unpinned within the superseding cycle, ~2s).

Also ran the neighbouring purge/GC suites (`test/node/publications/comment-moderation`, `garbage.collection.community.test.ts`): all pass.