### PR TITLE
fix(publication): drop duplicate challenge deliveries and reject a second challenge answer (#349)

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -160,6 +160,7 @@ export enum messages {
     ERR_INVALID_COMMUNITY_EDIT_CHALLENGE_REQUEST_TO_ENCRYPT_SCHEMA = "RPC client sent an invalid schema for challenge request with communityEdit",
     ERR_COMMUNITY_EDIT_OPTIONS_SCHEMA = "User sent a community edit options with invalid schema",
     ERR_INVALID_CHALLENGE_ANSWERS = "User sent challenge answers with invalid schema",
+    ERR_CHALLENGE_ANSWER_ALREADY_PUBLISHED = "publishChallengeAnswers was called again for a challenge exchange whose answer has already been published or is being published. Each challenge is answered once",
     ERR_INVALID_CREATE_PKC_WS_SERVER_OPTIONS_SCHEMA = "Invalid create arguments for PKC WS RPC server",
     ERR_INVALID_CREATE_PKC_ARGS_SCHEMA = "User sent arguments with invalid schema in an attempt to create a PKC instance",
     ERR_INVALID_CREATE_COMMUNITY_WITH_RPC_ARGS_SCHEMA = "User provided invalid schema of arguments for pkc.createCommunity while connected to RPC",

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -133,6 +133,10 @@ class Publication extends TypedEmitter<PublicationEvents> {
             challengeVerification?: DecryptedChallengeVerificationMessageType;
             challengeRequestPublishTimestamp?: number; // in seconds
             challengeAnswerPublishTimestamp?: number; // in seconds
+            // Set synchronously when publishChallengeAnswers claims this exchange, before the answer is
+            // encrypted, signed and published; cleared if that publish fails so the user can retry.
+            // Together with challengeAnswer it makes a second publishChallengeAnswers call reject (#349).
+            challengeAnswerPublishInFlight?: boolean;
             signer?: Signer; // could be undefined if we're publishing over an RPC
             challengeRequestPublishError?: Error;
             challengeAnswerPublishError?: Error;
@@ -389,6 +393,14 @@ class Publication extends TypedEmitter<PublicationEvents> {
             ...msg,
             ...decryptedChallenge
         };
+        // The guard at the top of this method ran before the awaits above. A copy of the same CHALLENGE
+        // delivered through another pubsub provider can have passed it in the meantime and be the one
+        // that recorded the challenge. Nothing can interleave between here and the write below, so
+        // re-checking now is enough to drop the copy before it touches the state or emits (#349).
+        if (Object.values(this._challengeExchanges).some((exchange) => exchange.challenge)) {
+            log.trace("Received a copy of a challenge that was already handled, ignoring it");
+            return;
+        }
         this._challengeExchanges[msg.challengeRequestId.toString()].challenge = decryptedChallengeMsg;
 
         this._updatePublishingStateWithEmission("waiting-challenge-answers");
@@ -485,6 +497,14 @@ class Publication extends TypedEmitter<PublicationEvents> {
 
         const challengeVerificationMsg = { ...msg, ...decryptedChallengeVerification };
 
+        // Same re-check as in _handleIncomingChallengePubsubMessage: the guard at the top ran before the
+        // awaits, and a copy of this CHALLENGEVERIFICATION from another provider may have recorded the
+        // verdict since. Dropping the copy here keeps "challengeverification" and the post-publish
+        // cleanup to one run per exchange (#349).
+        if (this._challengeExchanges[msg.challengeRequestId.toString()].challengeVerification) {
+            log.trace("Received a copy of a challenge verification that was already handled, ignoring it");
+            return;
+        }
         this._challengeExchanges[msg.challengeRequestId.toString()].challengeVerification = challengeVerificationMsg;
 
         Object.values(this._challengeExchanges).forEach((exchange) => this._updatePubsubState("stopped", exchange.providerUrl));
@@ -582,29 +602,48 @@ class Publication extends TypedEmitter<PublicationEvents> {
         if (challengeExchangesWithChallenge.length > 1) throw Error("We should only have one challenge exchange with challenge");
 
         const challengeExchange = challengeExchangesWithChallenge[0];
+        const challengeRequestIdString = challengeExchange.challengeRequest.challengeRequestId.toString();
+
+        // Each challenge is answered once. A second call, whether after the first answer was published or
+        // while it is still being encrypted and signed, would put a second CHALLENGEANSWER on the topic;
+        // the community rejects or errors on it, and for a locally hosted community that error would
+        // propagate back here and mark a publication the community accepts as failed (#349). The claim
+        // is made before the first await so two calls in the same tick cannot both pass.
+        if (challengeExchange.challengeAnswer || challengeExchange.challengeAnswerPublishInFlight)
+            throw new PKCError("ERR_CHALLENGE_ANSWER_ALREADY_PUBLISHED", {
+                challengeRequestId: challengeRequestIdString,
+                publishingState: this.publishingState
+            });
+        challengeExchange.challengeAnswerPublishInFlight = true;
 
         assert(this._community, "Local pkc-js needs publication._community to be defined to publish challenge answer");
 
         if (!challengeExchange.signer) throw Error("Signer is undefined for this challenge exchange");
-        const encryptedChallengeAnswers = await encryptEd25519AesGcm(
-            JSON.stringify(toEncryptAnswers),
-            challengeExchange.signer.privateKey,
-            this._community.encryption.publicKey
-        );
+        let answerMsgToPublish: ChallengeAnswerMessageType;
+        try {
+            const encryptedChallengeAnswers = await encryptEd25519AesGcm(
+                JSON.stringify(toEncryptAnswers),
+                challengeExchange.signer.privateKey,
+                this._community.encryption.publicKey
+            );
 
-        const toSignAnswer: Omit<ChallengeAnswerMessageType, "signature"> = cleanUpBeforePublishing({
-            type: "CHALLENGEANSWER",
-            challengeRequestId: challengeExchange.challengeRequest.challengeRequestId,
-            encrypted: encryptedChallengeAnswers,
-            userAgent: this._pkc.userAgent,
-            protocolVersion: env.PROTOCOL_VERSION,
-            timestamp: timestamp()
-        });
+            const toSignAnswer: Omit<ChallengeAnswerMessageType, "signature"> = cleanUpBeforePublishing({
+                type: "CHALLENGEANSWER",
+                challengeRequestId: challengeExchange.challengeRequest.challengeRequestId,
+                encrypted: encryptedChallengeAnswers,
+                userAgent: this._pkc.userAgent,
+                protocolVersion: env.PROTOCOL_VERSION,
+                timestamp: timestamp()
+            });
 
-        const answerMsgToPublish = <ChallengeAnswerMessageType>{
-            ...toSignAnswer,
-            signature: await signChallengeAnswer({ challengeAnswer: toSignAnswer, signer: challengeExchange.signer })
-        };
+            answerMsgToPublish = <ChallengeAnswerMessageType>{
+                ...toSignAnswer,
+                signature: await signChallengeAnswer({ challengeAnswer: toSignAnswer, signer: challengeExchange.signer })
+            };
+        } catch (e) {
+            challengeExchange.challengeAnswerPublishInFlight = false;
+            throw e;
+        }
 
         // TODO should be handling multiple providers with publishing challenge answer?
         // For now, let's just publish to the provider that got us the challenge and its request
@@ -617,6 +656,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
             } catch (e) {
                 this._challengeExchanges[challengeExchange.challengeRequest.challengeRequestId.toString()].challengeAnswerPublishError =
                     e as Error | PKCError;
+                challengeExchange.challengeAnswerPublishInFlight = false;
                 this._updatePublishingStateWithEmission("failed");
                 this._updatePubsubState("stopped", challengeExchange.providerUrl);
                 throw e;
@@ -631,6 +671,7 @@ class Publication extends TypedEmitter<PublicationEvents> {
             } catch (e) {
                 this._challengeExchanges[challengeExchange.challengeRequest.challengeRequestId.toString()].challengeAnswerPublishError =
                     e as Error | PKCError;
+                challengeExchange.challengeAnswerPublishInFlight = false;
                 this._updatePublishingStateWithEmission("failed");
                 this._updatePubsubState("stopped", challengeExchange.providerUrl);
                 throw e;

--- a/src/publications/publication.ts
+++ b/src/publications/publication.ts
@@ -476,11 +476,6 @@ class Publication extends TypedEmitter<PublicationEvents> {
                     this.emit("error", <PKCError>e);
                     return;
                 }
-
-                if (decryptedChallengeVerification.comment) {
-                    await this._verifyDecryptedChallengeVerificationAndUpdateCommentProps(decryptedChallengeVerification);
-                    log("Updated the props of this instance with challengeverification.encrypted");
-                }
             }
         } else {
             newPublishingState = "failed";
@@ -499,13 +494,20 @@ class Publication extends TypedEmitter<PublicationEvents> {
 
         // Same re-check as in _handleIncomingChallengePubsubMessage: the guard at the top ran before the
         // awaits, and a copy of this CHALLENGEVERIFICATION from another provider may have recorded the
-        // verdict since. Dropping the copy here keeps "challengeverification" and the post-publish
-        // cleanup to one run per exchange (#349).
+        // verdict since. The verdict is recorded here, synchronously after the last await above and
+        // before the comment props are updated from it, so a copy is dropped before it re-verifies the
+        // comment or emits "update" with nothing changed; "challengeverification" and the post-publish
+        // cleanup run once per exchange as well (#349).
         if (this._challengeExchanges[msg.challengeRequestId.toString()].challengeVerification) {
             log.trace("Received a copy of a challenge verification that was already handled, ignoring it");
             return;
         }
         this._challengeExchanges[msg.challengeRequestId.toString()].challengeVerification = challengeVerificationMsg;
+
+        if (decryptedChallengeVerification?.comment) {
+            await this._verifyDecryptedChallengeVerificationAndUpdateCommentProps(decryptedChallengeVerification);
+            log("Updated the props of this instance with challengeverification.encrypted");
+        }
 
         Object.values(this._challengeExchanges).forEach((exchange) => this._updatePubsubState("stopped", exchange.providerUrl));
 

--- a/src/test/mock-ipfs-client.ts
+++ b/src/test/mock-ipfs-client.ts
@@ -98,6 +98,12 @@ class MockPubsubHttpClient {
             },
             subscribe: async (topic: string, rawCallback: PubsubSubscriptionHandler) => {
                 await ensurePubsubActive(this._connectionState);
+                // kubo-rpc-client's SubscriptionTracker rejects a second subscribe with the same handler
+                // on a topic, and the client manager treats that rejection as "already subscribed". Do
+                // the same instead of registering the handler twice, which made every message reach it
+                // twice when a publication retried its request on the same provider (#349).
+                if (this._subscriptions.some((sub) => sub.topic === topic && sub.rawCallback === rawCallback))
+                    throw new Error(`Already subscribed to ${topic} with this handler`);
                 this._ensureTopicListener(topic);
                 const uniqueSubId = uuidV4();
                 this._subscriptions.push({ topic, rawCallback, subscriptionId: uniqueSubId });

--- a/test/node/publications/comment/duplicate-challenge-answer.publish.test.ts
+++ b/test/node/publications/comment/duplicate-challenge-answer.publish.test.ts
@@ -1,0 +1,202 @@
+// Regression for issue #349: publishChallengeAnswers accepts a second call for a challenge that was
+// already answered.
+//
+// A UI that received the same challenge twice (see duplicate-challenge-delivery.publish.test.ts)
+// answers twice. Without a guard the publisher signs and publishes a second CHALLENGEANSWER. The
+// community consumed the first answer already, so the second one finds no resolve handle and the
+// community's answer handler throws. Over pubsub that throw is only logged. For a community hosted in
+// the same PKC instance the publisher awaits the community handler directly, so the throw propagates
+// back into publishChallengeAnswers, which records it, moves the publishing state to "failed" and
+// rethrows, while the community goes on to verify the first answer and store the publication.
+//
+// Expected: the second call rejects with ERR_CHALLENGE_ANSWER_ALREADY_PUBLISHED before doing any
+// work, the community sees exactly one answer, the publishing state is never "failed", and the
+// publication succeeds on the first answer. Two calls issued in the same tick must behave the same
+// way, so the claim on the exchange has to be made before the first await.
+//
+// The community's verify() is held behind a gate so the second answer always lands while the first
+// is still being verified, the ordering that makes the community handler throw.
+
+import { mockPKC, mockGatewayPKC, generateMockPost, resolveWhenConditionIsTrue } from "../../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
+import { it, beforeAll, beforeEach, afterAll, expect } from "vitest";
+import type { PKC as PKCType } from "../../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+import type { Comment } from "../../../../dist/node/publications/comment/comment.js";
+import type { PKCError } from "../../../../dist/node/pkc-error.js";
+import type { ChallengeFileInput, CommunityChallengeSetting } from "../../../../dist/node/community/types.js";
+import type {
+    DecryptedChallengeAnswerMessageType,
+    DecryptedChallengeMessageType,
+    DecryptedChallengeVerificationMessageType
+} from "../../../../dist/node/pubsub-messages/types.js";
+
+const PUBSUB_PROVIDER = "http://localhost:15002/api/v0";
+
+type Gate = { waitForRelease: Promise<void>; release: () => void };
+const makeGate = (): Gate => {
+    let release!: () => void;
+    const waitForRelease = new Promise<void>((resolve) => (release = resolve));
+    return { waitForRelease, release };
+};
+
+// Publication state changes synchronously inside the pubsub handlers; poll instead of listening.
+const waitFor = async (predicate: () => boolean): Promise<void> => {
+    while (!predicate()) await new Promise((resolve) => setTimeout(resolve, 20));
+};
+
+// Long enough for a second answer that did get published to reach the community and be processed.
+const SETTLE_MS = 1500;
+const settle = () => new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
+
+// Skipped under RPC: registers an in-process challenge factory via pkc.settings.challenges, and the
+// same-process scenario needs the publisher and the community in one PKC instance (an RPC client
+// delegates the whole exchange to the server).
+describeSkipIfRpc("a second publishChallengeAnswers call for the same challenge (#349)", () => {
+    let pkc: PKCType;
+    let publisherPKC: PKCType;
+    let community: LocalCommunity;
+
+    // Released by the test to let the community publish its verdict.
+    let verifyGate: Gate;
+
+    const gatedVerifyChallenge = (_: { challengeSettings: CommunityChallengeSetting }): ChallengeFileInput => ({
+        type: "text/plain",
+        description: "Sends its challenge immediately and verifies the answer when the test says so",
+        getChallenge: async () => ({
+            challenge: "say anything",
+            type: "text/plain",
+            verify: async () => {
+                await verifyGate.waitForRelease;
+                return { success: true };
+            }
+        })
+    });
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        pkc.settings.challenges = { "gated-verify": gatedVerifyChallenge };
+        community = (await pkc.createCommunity()) as LocalCommunity;
+        community.setMaxListeners(100);
+        await community.edit({ settings: { challenges: [{ name: "gated-verify" }] } });
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+        publisherPKC = await mockGatewayPKC({
+            forceMockPubsub: true,
+            pkcOptions: { pubsubKuboRpcClientsOptions: [PUBSUB_PROVIDER] }
+        });
+    });
+
+    beforeEach(() => {
+        verifyGate = makeGate();
+    });
+
+    afterAll(async () => {
+        verifyGate?.release();
+        await publisherPKC.destroy();
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    type Observed = {
+        post: Comment;
+        errors: PKCError[];
+        publishingStates: string[];
+        challenges: DecryptedChallengeMessageType[];
+        verifications: DecryptedChallengeVerificationMessageType[];
+        answersSeenByCommunity: DecryptedChallengeAnswerMessageType[];
+        detach: () => void;
+    };
+
+    const publishAndWaitForChallenge = async (publisher: PKCType): Promise<Observed> => {
+        const post: Comment = await generateMockPost({ communityAddress: community.address, pkc: publisher });
+        const errors: PKCError[] = [];
+        const publishingStates: string[] = [];
+        const challenges: DecryptedChallengeMessageType[] = [];
+        const verifications: DecryptedChallengeVerificationMessageType[] = [];
+        const answersSeenByCommunity: DecryptedChallengeAnswerMessageType[] = [];
+        post.on("error", (error) => errors.push(error as PKCError));
+        post.on("publishingstatechange", (state) => publishingStates.push(state));
+        post.on("challenge", (challenge) => challenges.push(challenge));
+        post.on("challengeverification", (verification) => verifications.push(verification));
+        const countAnswers = (answer: DecryptedChallengeAnswerMessageType) => {
+            if (challenges.some((challenge) => challenge.challengeRequestId.toString() === answer.challengeRequestId.toString()))
+                answersSeenByCommunity.push(answer);
+        };
+        community.on("challengeanswer", countAnswers);
+
+        await post.publish();
+        await waitFor(() => challenges.length >= 1);
+        expect(post.publishingState).to.equal("waiting-challenge-answers");
+
+        return {
+            post,
+            errors,
+            publishingStates,
+            challenges,
+            verifications,
+            answersSeenByCommunity,
+            detach: () => community.removeListener("challengeanswer", countAnswers)
+        };
+    };
+
+    const expectAlreadyPublishedRejection = (result: PromiseSettledResult<unknown>) => {
+        expect(result.status, "the second publishChallengeAnswers call must reject").to.equal("rejected");
+        if (result.status !== "rejected") return;
+        expect((result.reason as PKCError).code).to.equal("ERR_CHALLENGE_ANSWER_ALREADY_PUBLISHED");
+    };
+
+    const expectPublishedOnceAndSucceeded = async (observed: Observed) => {
+        await settle();
+        expect(observed.answersSeenByCommunity.length, "the community must see exactly one answer").to.equal(1);
+        expect(observed.post.publishingState).to.equal("waiting-challenge-verification");
+        expect(observed.publishingStates.filter((state) => state === "failed")).to.deep.equal([]);
+        expect(observed.errors.map((error) => error.code)).to.deep.equal([]);
+
+        verifyGate.release();
+        await waitFor(() => observed.verifications.length >= 1);
+        expect(observed.verifications[0].challengeSuccess).to.be.true;
+        expect(observed.post.cid).to.be.a("string");
+        expect(observed.post.publishingState).to.equal("succeeded");
+        expect(observed.post.state).to.equal("stopped");
+        expect(observed.publishingStates.filter((state) => state === "failed")).to.deep.equal([]);
+        expect(observed.errors).to.deep.equal([]);
+        expect(community._dbHandler.queryComment(observed.post.cid!)).to.exist;
+    };
+
+    it("rejects the second call and does not fail a publication to a community hosted in the same PKC instance", async () => {
+        const observed = await publishAndWaitForChallenge(pkc);
+        try {
+            await observed.post.publishChallengeAnswers({ challengeAnswers: ["anything"] });
+            expect(observed.post.publishingState).to.equal("waiting-challenge-verification");
+
+            const [second] = await Promise.allSettled([observed.post.publishChallengeAnswers({ challengeAnswers: ["anything"] })]);
+            expectAlreadyPublishedRejection(second);
+            expect(observed.post.publishingState).to.equal("waiting-challenge-verification");
+
+            await expectPublishedOnceAndSucceeded(observed);
+        } finally {
+            observed.detach();
+            verifyGate.release();
+            await observed.post.stop();
+        }
+    });
+
+    it("rejects the second of two calls issued in the same tick over pubsub and publishes one answer", async () => {
+        const observed = await publishAndWaitForChallenge(publisherPKC);
+        try {
+            const results = await Promise.allSettled([
+                observed.post.publishChallengeAnswers({ challengeAnswers: ["anything"] }),
+                observed.post.publishChallengeAnswers({ challengeAnswers: ["anything"] })
+            ]);
+            expect(results[0].status, "the first call must publish the answer").to.equal("fulfilled");
+            expectAlreadyPublishedRejection(results[1]);
+
+            await expectPublishedOnceAndSucceeded(observed);
+        } finally {
+            observed.detach();
+            verifyGate.release();
+            await observed.post.stop();
+        }
+    });
+});

--- a/test/node/publications/comment/duplicate-challenge-delivery.publish.test.ts
+++ b/test/node/publications/comment/duplicate-challenge-delivery.publish.test.ts
@@ -1,0 +1,172 @@
+// Regression: the same CHALLENGE (and CHALLENGEVERIFICATION) pubsub message delivered twice to a
+// publisher is processed twice.
+//
+// A publisher subscribed to the challenge topic through more than one pubsub provider receives every
+// community message once per provider. _handleIncomingChallengePubsubMessage guards against a second
+// challenge with "if any exchange already holds a challenge, return", but the exchange's challenge
+// is only recorded after the signature verification and the decryption have been awaited. Two copies
+// dispatched close together both pass the guard, so the publisher decrypts the challenge twice and
+// emits "challenge" twice (a UI would prompt twice and answer twice). When the second copy finishes
+// after the user already answered the first one, it also drags the publishing state back from
+// "waiting-challenge-verification" to "waiting-challenge-answers"; that ordering depends on how fast
+// the answer is signed and published, and is what CI hit on the #340 watchdog test, where the single
+// provider listed twice made the mock pubsub client deliver each message twice. The verification
+// handler records its guard late in the same way, so a duplicated CHALLENGEVERIFICATION emits
+// "challengeverification" twice as well. The two event-count assertions fail deterministically; the
+// state assertion after the answer documents the regression CI saw and holds once the duplicates
+// are dropped.
+//
+// The duplicate is produced deterministically: the test taps the publisher's mock pubsub client with
+// a second subscription on the same topic and hands every community message to the publication's
+// pubsub handler a second time. The mock client dispatches to its subscriptions in one synchronous
+// loop, so the copy always reaches the handler in the same tick as the original, exactly like a
+// second provider that delivers the same message. The community's challenge and verification are
+// held behind gates so each phase of the exchange can be observed at rest.
+
+import { mockPKC, mockGatewayPKC, generateMockPost, resolveWhenConditionIsTrue } from "../../../../dist/node/test/test-util.js";
+import { describeSkipIfRpc } from "../../../helpers/conditional-tests.js";
+import { it, beforeAll, afterAll, expect } from "vitest";
+import type { PKC as PKCType } from "../../../../dist/node/pkc/pkc.js";
+import type { LocalCommunity } from "../../../../dist/node/runtime/node/community/local-community.js";
+import type { Comment } from "../../../../dist/node/publications/comment/comment.js";
+import type { PKCError } from "../../../../dist/node/pkc-error.js";
+import type { ChallengeFileInput, CommunityChallengeSetting } from "../../../../dist/node/community/types.js";
+import type { IpfsHttpClientPubsubMessage } from "../../../../dist/node/types.js";
+import type {
+    DecryptedChallengeMessageType,
+    DecryptedChallengeVerificationMessageType
+} from "../../../../dist/node/pubsub-messages/types.js";
+
+const PUBSUB_PROVIDER = "http://localhost:15002/api/v0";
+
+type Gate = { waitForRelease: Promise<void>; release: () => void };
+const makeGate = (): Gate => {
+    let release!: () => void;
+    const waitForRelease = new Promise<void>((resolve) => (release = resolve));
+    return { waitForRelease, release };
+};
+
+// Publication state changes synchronously inside the pubsub handlers; poll instead of listening.
+const waitFor = async (predicate: () => boolean): Promise<void> => {
+    while (!predicate()) await new Promise((resolve) => setTimeout(resolve, 20));
+};
+
+// The duplicate copy finishes its verification and decryption within milliseconds of the original.
+// Give it ample time so a duplicate that slipped through is observed rather than missed.
+const SETTLE_MS = 1500;
+const settle = () => new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
+
+// The pubsub handler is private on Publication; reach it the same way pubsub.test.ts reaches the
+// private thresholds.
+type PublicationWithPubsubHandler = { _handleChallengeExchange: (msg: IpfsHttpClientPubsubMessage) => Promise<void> };
+
+// Skipped under RPC: registers an in-process challenge factory via pkc.settings.challenges and taps
+// a non-RPC publisher's pubsub client (an RPC client delegates the whole exchange to the server).
+describeSkipIfRpc("a CHALLENGE delivered twice to the publisher", () => {
+    let pkc: PKCType;
+    let publisherPKC: PKCType;
+    let community: LocalCommunity;
+
+    const challengeGate = makeGate();
+    const verifyGate = makeGate();
+
+    const gatedChallenge = (_: { challengeSettings: CommunityChallengeSetting }): ChallengeFileInput => ({
+        type: "text/plain",
+        description: "Sends its challenge and verifies the answer when the test says so",
+        getChallenge: async () => {
+            await challengeGate.waitForRelease;
+            return {
+                challenge: "say anything",
+                type: "text/plain",
+                verify: async () => {
+                    await verifyGate.waitForRelease;
+                    return { success: true };
+                }
+            };
+        }
+    });
+
+    beforeAll(async () => {
+        pkc = await mockPKC();
+        pkc.settings.challenges = { gated: gatedChallenge };
+        community = (await pkc.createCommunity()) as LocalCommunity;
+        await community.edit({ settings: { challenges: [{ name: "gated" }] } });
+        await community.start();
+        await resolveWhenConditionIsTrue({ toUpdate: community, predicate: async () => typeof community.updatedAt === "number" });
+        publisherPKC = await mockGatewayPKC({
+            forceMockPubsub: true,
+            pkcOptions: { pubsubKuboRpcClientsOptions: [PUBSUB_PROVIDER] }
+        });
+    });
+
+    afterAll(async () => {
+        challengeGate.release();
+        verifyGate.release();
+        await publisherPKC.destroy();
+        await community.delete();
+        await pkc.destroy();
+    });
+
+    it("emits one challenge and one verification and never leaves waiting-challenge-verification", async () => {
+        const post: Comment = await generateMockPost({ communityAddress: community.address, pkc: publisherPKC });
+
+        const errors: PKCError[] = [];
+        const publishingStates: string[] = [];
+        const challenges: DecryptedChallengeMessageType[] = [];
+        const verifications: DecryptedChallengeVerificationMessageType[] = [];
+        post.on("error", (error) => errors.push(error as PKCError));
+        post.on("publishingstatechange", (state) => publishingStates.push(state));
+        post.on("challenge", (challenge) => challenges.push(challenge));
+        post.on("challengeverification", (verification) => verifications.push(verification));
+
+        const pubsubClient = publisherPKC.clients.pubsubKuboRpcClients[PUBSUB_PROVIDER]._client;
+        const redeliverToPublication = (msg: IpfsHttpClientPubsubMessage) => {
+            // Same tick as the mock client's own dispatch to the publication, like a second provider.
+            void (post as unknown as PublicationWithPubsubHandler)._handleChallengeExchange(msg);
+        };
+
+        try {
+            // publish() resolves once the request is out and the publication is subscribed. The
+            // community holds its challenge until the gate opens, so the tap is in place before any
+            // community message reaches the publisher.
+            await post.publish();
+            expect(post.publishingState).to.equal("waiting-challenge");
+            await pubsubClient.pubsub.subscribe(community.pubsubTopic, redeliverToPublication);
+
+            challengeGate.release();
+            await waitFor(() => challenges.length >= 1);
+            await settle();
+
+            expect(errors.map((error) => error.code)).to.deep.equal([]);
+            expect(challenges.length, "one CHALLENGE message must produce one challenge event").to.equal(1);
+            expect(post.publishingState).to.equal("waiting-challenge-answers");
+
+            await post.publishChallengeAnswers({ challengeAnswers: ["anything"] });
+            await waitFor(() => post.publishingState === "waiting-challenge-verification");
+            await settle();
+            expect(
+                post.publishingState,
+                "a late duplicate of the CHALLENGE must not move an answered exchange back to waiting-challenge-answers"
+            ).to.equal("waiting-challenge-verification");
+            expect(challenges.length).to.equal(1);
+
+            verifyGate.release();
+            await waitFor(() => verifications.length >= 1);
+            await settle();
+
+            expect(errors.map((error) => error.code)).to.deep.equal([]);
+            expect(verifications.length, "one CHALLENGEVERIFICATION message must produce one challengeverification event").to.equal(1);
+            expect(verifications[0].challengeSuccess).to.be.true;
+            expect(post.cid).to.be.a("string");
+            expect(post.publishingState).to.equal("succeeded");
+            expect(post.state).to.equal("stopped");
+            expect(publishingStates.filter((state) => state === "succeeded").length).to.equal(1);
+            expect(community._dbHandler.queryComment(post.cid!)).to.exist;
+        } finally {
+            await pubsubClient.pubsub.unsubscribe(community.pubsubTopic, redeliverToPublication);
+            challengeGate.release();
+            verifyGate.release();
+            await post.stop();
+        }
+    });
+});

--- a/test/node/publications/comment/duplicate-challenge-delivery.publish.test.ts
+++ b/test/node/publications/comment/duplicate-challenge-delivery.publish.test.ts
@@ -12,9 +12,13 @@
 // the answer is signed and published, and is what CI hit on the #340 watchdog test, where the single
 // provider listed twice made the mock pubsub client deliver each message twice. The verification
 // handler records its guard late in the same way, so a duplicated CHALLENGEVERIFICATION emits
-// "challengeverification" twice as well. The two event-count assertions fail deterministically; the
-// state assertion after the answer documents the regression CI saw and holds once the duplicates
-// are dropped.
+// "challengeverification" twice as well, and because its guard is re-checked only after the comment
+// props were updated from the decrypted verification, the second copy also re-verifies the comment
+// and emits "update" a second time with nothing changed on the instance (the copy carries the same
+// cid, CommentIpfs and CommentUpdate). "update" is emitted only when a prop actually changed
+// everywhere else on Comment. The three event-count assertions fail deterministically; the state
+// assertion after the answer documents the regression CI saw and holds once the duplicates are
+// dropped.
 //
 // The duplicate is produced deterministically: the test taps the publisher's mock pubsub client with
 // a second subscription on the same topic and hands every community message to the publication's
@@ -118,6 +122,8 @@ describeSkipIfRpc("a CHALLENGE delivered twice to the publisher", () => {
         post.on("publishingstatechange", (state) => publishingStates.push(state));
         post.on("challenge", (challenge) => challenges.push(challenge));
         post.on("challengeverification", (verification) => verifications.push(verification));
+        let updates = 0;
+        post.on("update", () => updates++);
 
         const pubsubClient = publisherPKC.clients.pubsubKuboRpcClients[PUBSUB_PROVIDER]._client;
         const redeliverToPublication = (msg: IpfsHttpClientPubsubMessage) => {
@@ -158,6 +164,10 @@ describeSkipIfRpc("a CHALLENGE delivered twice to the publisher", () => {
             expect(verifications.length, "one CHALLENGEVERIFICATION message must produce one challengeverification event").to.equal(1);
             expect(verifications[0].challengeSuccess).to.be.true;
             expect(post.cid).to.be.a("string");
+            expect(
+                updates,
+                "the first copy sets cid and the comment props, the second copy changes nothing, so update is emitted once"
+            ).to.equal(1);
             expect(post.publishingState).to.equal("succeeded");
             expect(post.state).to.equal("stopped");
             expect(publishingStates.filter((state) => state === "succeeded").length).to.equal(1);


### PR DESCRIPTION
Closes #349.

## Problem

A publisher subscribed to the challenge topic through more than one pubsub provider receives every community message once per provider. Both publisher-side handlers in `src/publications/publication.ts` guard against a repeat, but each records what the guard reads only after awaiting signature verification and decryption, so two copies of one message both pass the guard:

- Two copies of a CHALLENGE make the publisher decrypt twice and emit `challenge` twice. When the second copy finishes after the user already answered the first, it drags the publishing state back from `waiting-challenge-verification` to `waiting-challenge-answers`. This is what CI hit on the #340 watchdog test (the single provider listed twice made the mock pubsub client deliver each message twice; the per-test log showed the first copy handled, the answer published, and the second copy handled 2ms later).
- Two copies of a CHALLENGEVERIFICATION emit `challengeverification` twice and run the post-publish cleanup twice.

A UI that receives two `challenge` events answers twice, and `publishChallengeAnswers` had no "already answered" guard. On the community a second answer that lands while the first is still being verified hits a deleted resolve handle and throws. Over pubsub that is only logged, but for a community hosted in the same PKC instance the publisher awaits the community handler directly, so the throw propagated back, the publishing state was set to `failed` and the error rethrown while the community went on to store the publication.

## Fix

- Both handlers re-check their existing guard immediately after their last await. Everything from there to the write is synchronous, so the re-check is race-free and a duplicate copy is dropped before it touches state or emits. In the verification handler the verdict is recorded before the comment props are updated from it, so a duplicate never re-verifies the comment or emits `update` with nothing changed on the instance (`update` is only emitted on an actual prop change everywhere else on Comment). The guard stays per publication, not per request id, so a challenge for a retried request is still collapsed to one.
- `publishChallengeAnswers` rejects a second call with a new `ERR_CHALLENGE_ANSWER_ALREADY_PUBLISHED` error. The exchange is claimed before the first await so two calls in the same tick cannot both pass; the claim is released if encrypting, signing or publishing the answer throws, so a retry after a failed publish still works.
- The mock pubsub client now rejects a repeated subscribe with the same handler with the same `Already subscribed to` error kubo-rpc-client throws, which the client manager already handles, instead of registering the handler twice. This is what made the #340 test flaky; the new regression tests do not depend on it.

## Tests

- `test/node/publications/comment/duplicate-challenge-delivery.publish.test.ts`: taps the publisher's mock pubsub client and redelivers every community message to the publication in the same tick, like a second provider. Expects one `challenge` event, one `challengeverification` event, one `update` event, no state regression after the answer, and a stored comment. Red on master (2 challenge events, 2 verification events, 2 update events).
- `test/node/publications/comment/duplicate-challenge-answer.publish.test.ts`: a second `publishChallengeAnswers` call, once same-process after the first resolved and once over pubsub with both calls in the same tick. Expects the rejection with the new code, exactly one answer seen by the community, no `failed` state, and a succeeded publication. Red on master (the same-process second call rejected with the community's plain "critical error" and failed the publication).

Run locally against the fix: both new suites, the #340 watchdog suite, `test/node/pubsub/mock.pubsub.server.test.ts`, and every node and node-and-browser suite that calls `publishChallengeAnswers` outside RPC (in-flight duplicate requests, path challenge, pseudonymity exclusion, disable-pubsub exchange, misc, modqueue, pubsub-msgs properties, publish/pubsub, publishingstate, pubsub-msgs challenge, signatures pubsub.messages). All pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate challenge answers from being published or processed concurrently.
  * Duplicate challenge and verification messages are now ignored, preventing incorrect publication state changes.
  * Repeated answer submissions now return a clear error without interrupting publication.

* **Tests**
  * Added coverage for duplicate submissions and repeated challenge message delivery, including simultaneous requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
